### PR TITLE
Add GitHub Actions workflow for Docker publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,39 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}


### PR DESCRIPTION
Automatically publish to ghcr.io to be able to download at 

ghcr.io/cporcellijr/abs-kosync-bridge:latest

in portainer

example:

abs-kosync-enhanced:
    image: ghcr.io/cporcellijr/abs-kosync-bridge:latest
    container_name: abs-kosync-enhanced
    restart: unless-stopped
    environment:
      - TZ=America/New_York
      - LOG_LEVEL=INFO
      - ABS_SERVER=***
      - ABS_KEY=***
      - ABS_LIBRARY_ID=***
      - ABS_COLLECTION_NAME=***
      - KOSYNC_SERVER=***
      - KOSYNC_USER=***
      - KOSYNC_KEY=***
      - KOSYNC_HASH_METHOD=***
      - HARDCOVER_TOKEN=***
      - SYNC_PERIOD_MINS=5 # How often to check for progress changes (minutes)
      - SYNC_DELTA_ABS_SECONDS=60 # Minimum audiobook progress change to trigger sync (seconds)
      - SYNC_DELTA_KOSYNC_PERCENT=0.5 # Minimum ebook progress change to trigger sync (percentage, 0-100)
      - SYNC_DELTA_KOSYNC_WORDS=400 # Minimum word count change to trigger sync
      - FUZZY_MATCH_THRESHOLD=88 # Fuzzy text matching threshold (0-100, higher = stricter)
    volumes:
      - ***:/data # App data (database, transcripts, state)      
      - ***:/books # Main ebook library (for sync matching)
      - ***:/audiobooks # Book Linker volume audiobooks
    ports:
      - "7201:5757"