### PR TITLE
feat: improve audiobook search to include author matching

### DIFF
--- a/templates/batch_match.html
+++ b/templates/batch_match.html
@@ -506,7 +506,7 @@
             <!-- Selection Area -->
             <div class="selection-area">
                 <form method="GET" action="/batch-match">
-                    <input type="text" name="search" placeholder="🔍 Filter by title..." class="search-box" value="{{ search }}" autofocus>
+                    <input type="text" name="search" placeholder="🔍 Filter by title or author..." class="search-box" value="{{ search }}" autofocus>
                     <button type="submit" class="btn btn-primary">Search</button>
                 </form>
                 

--- a/templates/match.html
+++ b/templates/match.html
@@ -361,7 +361,7 @@
                 <input 
                     type="text" 
                     name="search" 
-                    placeholder="🔍 Filter by title..." 
+                    placeholder="🔍 Filter by title or author..." 
                     class="search-box" 
                     value="{{ search }}"
                     autofocus


### PR DESCRIPTION
## Summary
- Audiobook search in match and batch-match routes now searches both title AND author fields
- Added `get_abs_author()` helper to extract author from ABS metadata
- Added `audiobook_matches_search()` helper for unified search logic
- Updated search box placeholder text to indicate author search is supported

Fixes #4 

## Test plan
- [ ] Search for an audiobook by author name in the match page
- [ ] Search for an audiobook by author name in the batch-match page
- [ ] Verify title search still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)