### PR TITLE
fix time listened calculation 

### DIFF
--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -99,7 +99,7 @@ class ABSSyncClient(SyncClient):
                     'pct': self._abs_to_percentage(abs_ts, book.transcript_file) or 0
                 })
 
-            result, final_ts = self._update_abs_progress_with_offset(book.abs_id, ts_for_text, request.previous_location)
+            result, final_ts = self._update_abs_progress_with_offset(book.abs_id, ts_for_text, abs_ts if abs_ts is not None else 0.0)
             # Calculate percentage from timestamp for state
             pct = self._abs_to_percentage(final_ts, book.transcript_file)
             updated_state = {


### PR DESCRIPTION
The _update_abs_progress_with_offset function expects a timestamp in seconds for calculating time_listened delta. The code was incorrectly passing request.previous_location (a percentage like 0.45) instead of the current ABS timestamp (abs_ts). This caused massively inflated session stats.

Changed the third argument from request.previous_location to abs_ts, with a fallback to 0.0 if abs_ts is None.

https://claude.ai/code/session_017vnjG8xbkqD7hrgmCg1Rtb