### PR TITLE
Fix time_listened calculation using wrong value type

### DIFF
--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -106,7 +106,7 @@ class ABSSyncClient(SyncClient):
                     'pct': self._abs_to_percentage(abs_ts, book.transcript_file) or 0
                 })
 
-            result, final_ts = self._update_abs_progress_with_offset(book.abs_id, ts_for_text, request.previous_location)
+            result, final_ts = self._update_abs_progress_with_offset(book.abs_id, ts_for_text, abs_ts or 0.0)
             # Calculate percentage from timestamp for state
             pct = self._abs_to_percentage(final_ts, book.transcript_file)
             updated_state = {


### PR DESCRIPTION
The _update_abs_progress_with_offset function expected a timestamp in seconds for calculating time_listened delta, but was receiving request.previous_location which is a percentage (e.g., 0.45). This caused time_listened to be calculated as new_timestamp - 0.45, resulting in massively inflated session stats.

Fixed by passing the current ABS timestamp (abs_ts) instead, with a default of 0.0 if it is None.

https://claude.ai/code/session_01JviRq1YWm3M51WiMc9Kr1Y