### PR TITLE
Fix cross-format sync percentage comparison

### DIFF
--- a/test_baseline.txt
+++ b/test_baseline.txt
@@ -1,0 +1,16 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
+rootdir: C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced
+plugins: anyio-4.11.0
+collected 2 items
+
+tests\test_booklore_unittest.py .                                        [ 50%]
+tests\test_storyteller_unittest.py .                                     [100%]
+
+============================== warnings summary ===============================
+src\db\models.py:11
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\models.py:11: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    Base = declarative_base()
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 2 passed, 1 warning in 0.82s =========================

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,16 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
+rootdir: C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced
+plugins: anyio-4.11.0
+collected 2 items
+
+tests\test_abs_unittest.py .                                             [ 50%]
+tests\test_kosync_unittest.py .                                          [100%]
+
+============================== warnings summary ===============================
+src\db\models.py:11
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\models.py:11: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    Base = declarative_base()
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 2 passed, 1 warning in 0.80s =========================

--- a/test_output_full.txt
+++ b/test_output_full.txt
@@ -1,0 +1,171 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
+rootdir: C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced
+plugins: anyio-4.11.0
+collected 47 items
+
+tests\test_abs_ebook_sync_client.py ..                                   [  4%]
+tests\test_abs_unittest.py .                                             [  6%]
+tests\test_booklore_unittest.py F                                        [  8%]
+tests\test_clear_progress.py ....                                        [ 17%]
+tests\test_dependency_injection.py F                                     [ 19%]
+tests\test_hardcover_sync_client.py .........                            [ 38%]
+tests\test_kosync_server.py .......FFFFFF                                [ 65%]
+tests\test_kosync_unittest.py .                                          [ 68%]
+tests\test_nochanges_unittest.py .                                       [ 70%]
+tests\test_settings_comprehensive.py ..                                  [ 74%]
+tests\test_storyteller_unittest.py F                                     [ 76%]
+tests\test_suggestions_feature.py ...                                    [ 82%]
+tests\test_syncmanager_paths.py .                                        [ 85%]
+tests\test_webserver.py .......                                          [100%]
+
+================================== FAILURES ===================================
+__________________ TestBookLoreLeadsSync.test_booklore_leads __________________
+tests\test_booklore_unittest.py:71: in test_booklore_leads
+    super().run_test(60, 75)
+tests\base_sync_test.py:370: in run_test
+    mocks, manager, final_state = self.run_sync_test_with_leader_verification()
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests\base_sync_test.py:243: in run_sync_test_with_leader_verification
+    self.verify_common_assertions(mocks, manager)
+tests\base_sync_test.py:276: in verify_common_assertions
+    self.assertTrue(mocks['kosync_client'].update_progress.called, "KoSync update_progress was not called")
+E   AssertionError: False is not true : KoSync update_progress was not called
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:00,731 - INFO - === Sync Manager Starting ===\n2026-01-28 12:30:00,731 - INFO - \u2705 Sync client enabled: ABS\n2026-01-28 12:30:00,731 - INFO - \U0001f6ab Sync client disabled/unconfigured: ABS eBook\n2026-01-28 12:30:00,731 - INFO - \u2705 Sync client enabled: KoSync\n2026-01-28 12:30:00,731 - INFO - \u2705 Sync client enabled: Storyteller\n2026-01-28 12:30:00,731 - INFO - \u2705 Sync client enabled: BookLore\n2026-01-28 12:30:00,732 - INFO - \u2705 ABS connection verified\n2026-01-28 12:30:00,732 - INFO - \u2705 KoSync connection verified\n2026-01-28 12:30:00,732 - INFO - \u2705 Storyteller connection verified\n2026-01-28 12:30:00,732 - INFO - \u2705 BookLore connection verified\n2026-01-28 12:30:00,732 - INFO - [JOB] Reset crashed book status: BookLore Leader Test Book\n2026-01-28 12:30:00,732 - INFO - [JOB] Recovering interrupted job: BookLore Leader Test Book\n2026-01-28 12:30:00,732 - INFO - \U0001f50d Scanning for corrupted legacy transcripts...\n2026-01-28 12:30:00,744 - INFO - Background refreshing Booklore cache...\n2026-01-28 12:30:00,745 - INFO - \U0001f504 [test-abs-id-booklore] Syncing 'BookLore Leader Test Book'\n2026-01-28 12:30:00,746 - INFO - \U0001f504 [test-abs-id-booklore] [BookLore Leader Test Book] Change detected\n2026-01-28 12:30:00,746 - INFO - \U0001f4ca ABS: 30.0000% -> 40.0000%\n2026-01-28 12:30:00,747 - INFO - \U0001f4ca KoSync: 40.0000% -> 50.0000%\n2026-01-28 12:30:00,747 - INFO - \U0001f4ca BookLore: 60.0000% -> 75.0000%\n2026-01-28 12:30:00,747 - INFO - \U0001f4ca Storyteller: 50.0000% -> 65.0000%\n2026-01-28 12:30:00,747 - INFO - \U0001f4d6 [test-abs-id-booklore] [BookLore Leader Test Book] KoSync leads at 50.0000% (normalized: 750.0s)\n2026-01-28 12:30:00,748 - INFO - [test-abs-id-booklore] [BookLore Leader Test Book] Updated state data for ABS: {'ts': 750.0, 'pct': 0.75}\n2026-01-28 12:30:00,748 - INFO - [test-abs-id-booklore] [BookLore Leader Test Book] Updated state data for Storyteller: {'pct': 0.75}\n2026-01-28 12:30:00,748 - INFO - [test-abs-id-booklore] [BookLore Leader Test Book] Updated state data for BookLore: {'pct': 0.75}\n2026-01-28 12:30:00,748 - INFO - \U0001f4be [test-abs-id-booklore] [BookLore Leader Test Book] States saved to database
+------------------------------ Captured log call ------------------------------
+INFO     src.sync_manager:sync_manager.py:47 === Sync Manager Starting ===\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: ABS\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: ABS eBook\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: KoSync\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: Storyteller\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: BookLore\nINFO     src.sync_manager:sync_manager.py:93 \u2705 ABS connection verified\nINFO     src.sync_manager:sync_manager.py:93 \u2705 KoSync connection verified\nINFO     src.sync_manager:sync_manager.py:93 \u2705 Storyteller connection verified\nINFO     src.sync_manager:sync_manager.py:93 \u2705 BookLore connection verified\nINFO     src.sync_manager:sync_manager.py:105 [JOB] Reset crashed book status: BookLore Leader Test Book\nINFO     src.sync_manager:sync_manager.py:110 [JOB] Recovering interrupted job: BookLore Leader Test Book\nINFO     src.sync_manager:sync_manager.py:243 \U0001f50d Scanning for corrupted legacy transcripts...\nINFO     src.sync_manager:sync_manager.py:693 Background refreshing Booklore cache...\nINFO     src.sync_manager:sync_manager.py:728 \U0001f504 [test-abs-id-booklore] Syncing 'BookLore Leader Test Book'\nINFO     src.sync_manager:sync_manager.py:855 \U0001f504 [test-abs-id-booklore] [BookLore Leader Test Book] Change detected\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca ABS: 30.0000% -> 40.0000%\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca KoSync: 40.0000% -> 50.0000%\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca BookLore: 60.0000% -> 75.0000%\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca Storyteller: 50.0000% -> 65.0000%\nINFO     src.sync_manager:sync_manager.py:895 \U0001f4d6 [test-abs-id-booklore] [BookLore Leader Test Book] KoSync leads at 50.0000% (normalized: 750.0s)\nINFO     src.sync_manager:sync_manager.py:974 [test-abs-id-booklore] [BookLore Leader Test Book] Updated state data for ABS: {'ts': 750.0, 'pct': 0.75}\nINFO     src.sync_manager:sync_manager.py:974 [test-abs-id-booklore] [BookLore Leader Test Book] Updated state data for Storyteller: {'pct': 0.75}\nINFO     src.sync_manager:sync_manager.py:974 [test-abs-id-booklore] [BookLore Leader Test Book] Updated state data for BookLore: {'pct': 0.75}\nINFO     src.sync_manager:sync_manager.py:986 \U0001f4be [test-abs-id-booklore] [BookLore Leader Test Book] States saved to database
+__________________________ test_dependency_injection __________________________
+tests\test_dependency_injection.py:123: in test_dependency_injection
+    shutil.rmtree('test_data')
+C:\Python313\Lib\shutil.py:790: in rmtree
+    return _rmtree_unsafe(path, onexc)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+C:\Python313\Lib\shutil.py:629: in _rmtree_unsafe
+    onexc(os.unlink, fullname, err)
+C:\Python313\Lib\shutil.py:625: in _rmtree_unsafe
+    os.unlink(fullname)
+E   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'test_data\\database.db'
+---------------------------- Captured stdout call -----------------------------
+\U0001f9ea Testing Dependency Injection\n==================================================\n\U0001f4e6 Creating DI container...\n\u2705 DI container created successfully\n\n\U0001f527 Testing individual components...\n\u2705 ABSClient: ABSClient\n\u2705 KoSyncClient: KoSyncClient\n\u2705 BookloreClient: BookloreClient\n\u2705 EbookParser: EbookParser\n\n\U0001f3ed Testing factory components...\n\u2705 Storyteller DB: StorytellerDBWithAPI\n\u2705 DB: DatabaseService\n\n\U0001f504 Testing sync clients...\n\u2705 ABSSyncClient: ABSSyncClient\n\u2705 KoSyncSyncClient: KoSyncSyncClient\n\u2705 StorytellerSyncClient: StorytellerSyncClient\n\u2705 BookloreSyncClient: BookloreSyncClient\n\n\U0001f3af Testing SyncManager creation with DI...\n\u2705 SyncManager created: SyncManager\n\n\U0001f50d Verifying autowired dependencies...\n\u2705 All dependencies properly autowired\n\n\u2699\ufe0f  Testing sync client configurations...\n\u2705 Configured sync clients: ABS\n\n\U0001f389 All tests passed! Dependency injection is working correctly.
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:02,210 - INFO - EbookParser initialized (cache=3, hash=content, xpath_fallback=False)\n2026-01-28 12:30:02,227 - INFO - HARDCOVER_TOKEN not set\n2026-01-28 12:30:02,228 - INFO - === Sync Manager Starting ===\n2026-01-28 12:30:02,228 - INFO - \u2705 Sync client enabled: ABS\n2026-01-28 12:30:02,228 - INFO - \U0001f6ab Sync client disabled/unconfigured: ABSEbook\n2026-01-28 12:30:02,228 - INFO - \U0001f6ab Sync client disabled/unconfigured: KoSync\n2026-01-28 12:30:02,228 - INFO - \U0001f6ab Sync client disabled/unconfigured: Storyteller\n2026-01-28 12:30:02,228 - INFO - \U0001f6ab Sync client disabled/unconfigured: BookLore\n2026-01-28 12:30:02,228 - INFO - \U0001f6ab Sync client disabled/unconfigured: Hardcover\n2026-01-28 12:30:02,228 - WARNING - \u26a0\ufe0f Audiobookshelf not configured (skipping)\n2026-01-28 12:30:02,229 - INFO - \u2705 ABS connection verified\n2026-01-28 12:30:02,230 - INFO - \U0001f50d Scanning for corrupted legacy transcripts...
+------------------------------ Captured log call ------------------------------
+INFO     src.utils.ebook_utils:ebook_utils.py:60 EbookParser initialized (cache=3, hash=content, xpath_fallback=False)\nDEBUG    src.db.database_service:database_service.py:63 Database migrations completed successfully\nINFO     src.api.hardcover_client:hardcover_client.py:32 HARDCOVER_TOKEN not set\nINFO     src.sync_manager:sync_manager.py:47 === Sync Manager Starting ===\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: ABS\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: ABSEbook\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: KoSync\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: Storyteller\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: BookLore\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: Hardcover\nWARNING  src.api.api_clients:api_clients.py:28 \u26a0\ufe0f Audiobookshelf not configured (skipping)\nINFO     src.sync_manager:sync_manager.py:93 \u2705 ABS connection verified\nINFO     src.sync_manager:sync_manager.py:243 \U0001f50d Scanning for corrupted legacy transcripts...
+_____________ TestKosyncEndpoints.test_furthest_wins_allows_equal _____________
+tests\test_kosync_server.py:309: in test_furthest_wins_allows_equal
+    self.assertEqual(response.status_code, 200)
+E   AssertionError: 500 != 200
+---------------------------- Captured stderr setup ----------------------------
+2026-01-28 12:30:03,260 - INFO - Initializing database at C:\\Users\\cporc\\docker-utils\\stacks\\abs-kosync-enhanced\\test_data\\database.db\n2026-01-28 12:30:03,269 - INFO - Database already initialized, no migration needed\n2026-01-28 12:30:03,272 - INFO - \u2699\ufe0f  Loaded 50 settings from database\n2026-01-28 12:30:03,272 - INFO - \u2705 Settings loaded into environment variables\n2026-01-28 12:30:03,272 - INFO - \U0001f4dd Logging level updated to DEBUG\n2026-01-28 12:30:03,272 - INFO - \U0001f504 Globals reloaded from settings (ABS_SERVER=)\n2026-01-28 12:30:03,278 - INFO - Web server dependencies initialized (DATA_DIR=\\data)
+----------------------------- Captured log setup ------------------------------
+DEBUG    src.db.database_service:database_service.py:63 Database migrations completed successfully\nINFO     src.db.migration_utils:migration_utils.py:27 Initializing database at C:\\Users\\cporc\\docker-utils\\stacks\\abs-kosync-enhanced\\test_data\\database.db\nDEBUG    src.db.database_service:database_service.py:63 Database migrations completed successfully\nINFO     src.db.migration_utils:migration_utils.py:47 Database already initialized, no migration needed\nINFO     src.utils.config_loader:config_loader.py:149 \u2699\ufe0f  Loaded 50 settings from database\nINFO     src.web_server:web_server.py:65 \u2705 Settings loaded into environment variables\nINFO     src.web_server:web_server.py:39 \U0001f4dd Logging level updated to DEBUG\nINFO     src.web_server:web_server.py:103 \U0001f504 Globals reloaded from settings (ABS_SERVER=)\nINFO     src.web_server:web_server.py:139 Web server dependencies initialized (DATA_DIR=\\data)
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,306 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+2026-01-28 12:30:03,307 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+------------------------------ Captured log call ------------------------------
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+____________ TestKosyncEndpoints.test_furthest_wins_allows_forward ____________
+tests\test_kosync_server.py:348: in test_furthest_wins_allows_forward
+    self.assertEqual(response.status_code, 200)
+E   AssertionError: 500 != 200
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,313 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+2026-01-28 12:30:03,313 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+------------------------------ Captured log call ------------------------------
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+__________ TestKosyncEndpoints.test_furthest_wins_rejects_backwards ___________
+tests\test_kosync_server.py:271: in test_furthest_wins_rejects_backwards
+    self.assertEqual(response.status_code, 200)
+E   AssertionError: 500 != 200
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,318 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+2026-01-28 12:30:03,319 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+------------------------------ Captured log call ------------------------------
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+________ TestKosyncEndpoints.test_get_progress_returns_502_for_missing ________
+tests\test_kosync_server.py:206: in test_get_progress_returns_502_for_missing
+    self.assertEqual(response.status_code, 502)
+E   AssertionError: 500 != 502
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,324 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+------------------------------ Captured log call ------------------------------
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+___________ TestKosyncEndpoints.test_get_progress_returns_full_data ___________
+tests\test_kosync_server.py:232: in test_get_progress_returns_full_data
+    self.assertEqual(response.status_code, 200)
+E   AssertionError: 500 != 200
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,329 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+2026-01-28 12:30:03,329 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+------------------------------ Captured log call ------------------------------
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+___________ TestKosyncEndpoints.test_put_progress_creates_document ____________
+tests\test_kosync_server.py:191: in test_put_progress_creates_document
+    self.assertEqual(response.status_code, 200)
+E   AssertionError: 500 != 200
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,334 - ERROR - KOSync Integrated Server: Credentials not configured in settings
+------------------------------ Captured log call ------------------------------
+ERROR    src.api.kosync_server:kosync_server.py:50 KOSync Integrated Server: Credentials not configured in settings
+_______________ TestStorytellerLeadsSync.test_storyteller_leads _______________
+tests\test_storyteller_unittest.py:70: in test_storyteller_leads
+    super().run_test(30, 60)
+tests\base_sync_test.py:370: in run_test
+    mocks, manager, final_state = self.run_sync_test_with_leader_verification()
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests\base_sync_test.py:243: in run_sync_test_with_leader_verification
+    self.verify_common_assertions(mocks, manager)
+tests\base_sync_test.py:276: in verify_common_assertions
+    self.assertTrue(mocks['kosync_client'].update_progress.called, "KoSync update_progress was not called")
+E   AssertionError: False is not true : KoSync update_progress was not called
+---------------------------- Captured stderr call -----------------------------
+2026-01-28 12:30:03,417 - INFO - === Sync Manager Starting ===\n2026-01-28 12:30:03,417 - INFO - \u2705 Sync client enabled: ABS\n2026-01-28 12:30:03,417 - INFO - \U0001f6ab Sync client disabled/unconfigured: ABS eBook\n2026-01-28 12:30:03,418 - INFO - \u2705 Sync client enabled: KoSync\n2026-01-28 12:30:03,418 - INFO - \u2705 Sync client enabled: Storyteller\n2026-01-28 12:30:03,418 - INFO - \u2705 Sync client enabled: BookLore\n2026-01-28 12:30:03,418 - INFO - \u2705 ABS connection verified\n2026-01-28 12:30:03,418 - INFO - \u2705 KoSync connection verified\n2026-01-28 12:30:03,418 - INFO - \u2705 Storyteller connection verified\n2026-01-28 12:30:03,418 - INFO - \u2705 BookLore connection verified\n2026-01-28 12:30:03,418 - INFO - [JOB] Reset crashed book status: Storyteller Leader Test Book\n2026-01-28 12:30:03,419 - INFO - [JOB] Recovering interrupted job: Storyteller Leader Test Book\n2026-01-28 12:30:03,419 - INFO - \U0001f50d Scanning for corrupted legacy transcripts...\n2026-01-28 12:30:03,427 - INFO - Background refreshing Booklore cache...\n2026-01-28 12:30:03,427 - INFO - \U0001f504 [test-abs-id-storyteller] Syncing 'Storyteller Leader Test Book'\n2026-01-28 12:30:03,428 - INFO - \U0001f504 [test-abs-id-storyteller] [Storyteller Leader Test Book] Change detected\n2026-01-28 12:30:03,428 - INFO - \U0001f4ca KoSync: 25.0000% -> 35.0000%\n2026-01-28 12:30:03,429 - INFO - \U0001f4ca ABS: 20.0000% -> 30.0000%\n2026-01-28 12:30:03,429 - INFO - \U0001f4ca Storyteller: 30.0000% -> 60.0000%\n2026-01-28 12:30:03,429 - INFO - \U0001f4ca BookLore: 10.0000% -> 25.0000%\n2026-01-28 12:30:03,429 - INFO - \U0001f4d6 [test-abs-id-storyteller] [Storyteller Leader Test Book] KoSync leads at 35.0000% (normalized: 600.0s)\n2026-01-28 12:30:03,430 - INFO - [test-abs-id-storyteller] [Storyteller Leader Test Book] Updated state data for ABS: {'ts': 600.0, 'pct': 0.6}\n2026-01-28 12:30:03,430 - INFO - [test-abs-id-storyteller] [Storyteller Leader Test Book] Updated state data for Storyteller: {'pct': 0.6}\n2026-01-28 12:30:03,430 - INFO - [test-abs-id-storyteller] [Storyteller Leader Test Book] Updated state data for BookLore: {'pct': 0.6}\n2026-01-28 12:30:03,430 - INFO - \U0001f4be [test-abs-id-storyteller] [Storyteller Leader Test Book] States saved to database
+------------------------------ Captured log call ------------------------------
+INFO     src.sync_manager:sync_manager.py:47 === Sync Manager Starting ===\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: ABS\nINFO     src.sync_manager:sync_manager.py:86 \U0001f6ab Sync client disabled/unconfigured: ABS eBook\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: KoSync\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: Storyteller\nINFO     src.sync_manager:sync_manager.py:84 \u2705 Sync client enabled: BookLore\nINFO     src.sync_manager:sync_manager.py:93 \u2705 ABS connection verified\nINFO     src.sync_manager:sync_manager.py:93 \u2705 KoSync connection verified\nINFO     src.sync_manager:sync_manager.py:93 \u2705 Storyteller connection verified\nINFO     src.sync_manager:sync_manager.py:93 \u2705 BookLore connection verified\nINFO     src.sync_manager:sync_manager.py:105 [JOB] Reset crashed book status: Storyteller Leader Test Book\nINFO     src.sync_manager:sync_manager.py:110 [JOB] Recovering interrupted job: Storyteller Leader Test Book\nINFO     src.sync_manager:sync_manager.py:243 \U0001f50d Scanning for corrupted legacy transcripts...\nINFO     src.sync_manager:sync_manager.py:693 Background refreshing Booklore cache...\nINFO     src.sync_manager:sync_manager.py:728 \U0001f504 [test-abs-id-storyteller] Syncing 'Storyteller Leader Test Book'\nINFO     src.sync_manager:sync_manager.py:855 \U0001f504 [test-abs-id-storyteller] [Storyteller Leader Test Book] Change detected\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca KoSync: 25.0000% -> 35.0000%\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca ABS: 20.0000% -> 30.0000%\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca Storyteller: 30.0000% -> 60.0000%\nINFO     src.sync_manager:sync_manager.py:867 \U0001f4ca BookLore: 10.0000% -> 25.0000%\nINFO     src.sync_manager:sync_manager.py:895 \U0001f4d6 [test-abs-id-storyteller] [Storyteller Leader Test Book] KoSync leads at 35.0000% (normalized: 600.0s)\nINFO     src.sync_manager:sync_manager.py:974 [test-abs-id-storyteller] [Storyteller Leader Test Book] Updated state data for ABS: {'ts': 600.0, 'pct': 0.6}\nINFO     src.sync_manager:sync_manager.py:974 [test-abs-id-storyteller] [Storyteller Leader Test Book] Updated state data for Storyteller: {'pct': 0.6}\nINFO     src.sync_manager:sync_manager.py:974 [test-abs-id-storyteller] [Storyteller Leader Test Book] Updated state data for BookLore: {'pct': 0.6}\nINFO     src.sync_manager:sync_manager.py:986 \U0001f4be [test-abs-id-storyteller] [Storyteller Leader Test Book] States saved to database
+============================== warnings summary ===============================
+src\db\models.py:11
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\models.py:11: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    Base = declarative_base()
+
+tests/test_clear_progress.py: 4 warnings
+tests/test_kosync_server.py: 6 warnings
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\models.py:46: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    self.first_seen = datetime.utcnow()
+
+tests/test_clear_progress.py: 4 warnings
+tests/test_kosync_server.py: 6 warnings
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\models.py:47: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    self.last_updated = datetime.utcnow()
+
+tests/test_clear_progress.py: 4 warnings
+tests/test_kosync_server.py: 7 warnings
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\database_service.py:423: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    doc.last_updated = datetime.utcnow()
+
+tests/test_kosync_server.py::TestKosyncDocument::test_link_kosync_document
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\database_service.py:468: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+    doc.last_updated = datetime.utcnow()
+
+tests/test_syncmanager_paths.py::test_syncmanager_di_paths
+  C:\Users\cporc\AppData\Roaming\Python\Python313\site-packages\_pytest\python.py:170: PytestReturnNotNoneWarning: Test functions should return None, but tests/test_syncmanager_paths.py::test_syncmanager_di_paths returned <class 'bool'>.
+  Did you mean to use `assert` instead of `return`?
+  See https://docs.pytest.org/en/stable/how-to/assert.html#return-not-none for more information.
+    warnings.warn(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ===========================
+FAILED tests/test_booklore_unittest.py::TestBookLoreLeadsSync::test_booklore_leads
+FAILED tests/test_dependency_injection.py::test_dependency_injection - Permis...
+FAILED tests/test_kosync_server.py::TestKosyncEndpoints::test_furthest_wins_allows_equal
+FAILED tests/test_kosync_server.py::TestKosyncEndpoints::test_furthest_wins_allows_forward
+FAILED tests/test_kosync_server.py::TestKosyncEndpoints::test_furthest_wins_rejects_backwards
+FAILED tests/test_kosync_server.py::TestKosyncEndpoints::test_get_progress_returns_502_for_missing
+FAILED tests/test_kosync_server.py::TestKosyncEndpoints::test_get_progress_returns_full_data
+FAILED tests/test_kosync_server.py::TestKosyncEndpoints::test_put_progress_creates_document
+FAILED tests/test_storyteller_unittest.py::TestStorytellerLeadsSync::test_storyteller_leads
+================== 9 failed, 38 passed, 34 warnings in 3.81s ==================

--- a/test_sync_fix.txt
+++ b/test_sync_fix.txt
@@ -1,0 +1,18 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
+rootdir: C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced
+plugins: anyio-4.11.0
+collected 4 items
+
+tests\test_booklore_unittest.py .                                        [ 25%]
+tests\test_storyteller_unittest.py .                                     [ 50%]
+tests\test_abs_unittest.py .                                             [ 75%]
+tests\test_kosync_unittest.py .                                          [100%]
+
+============================== warnings summary ===============================
+src\db\models.py:11
+  C:\Users\cporc\docker-utils\stacks\abs-kosync-enhanced\src\db\models.py:11: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    Base = declarative_base()
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 4 passed, 1 warning in 0.86s =========================


### PR DESCRIPTION
When syncing between audiobook (ABS) and ebook clients (KoSync, etc.), raw percentages are not comparable because:
- Audiobook %% = time position / total duration
- Ebook %% = text position / total text

These don't correlate linearly. This fix adds _normalize_for_cross_format_comparison() which converts ebook positions to equivalent audiobook timestamps using text-matching, enabling accurate comparison of 'who is further in the story'.

Changes:
- Add _normalize_for_cross_format_comparison() helper method to sync_manager.py
- Modify leader selection logic to use normalized timestamps when cross-format sync
- Update base_sync_test.py with smart transcriber mock for proper test coverage