### PR TITLE
Responsive card layout for dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,10 +6,28 @@
 
     {# Macro for rendering a book card - used by both currently-reading and all-books grids #}
     {% macro render_book_card(mapping, integrations) %}
-    <div class="book-card" data-progress="{{ mapping.unified_progress }}" data-last-sync="{{ mapping.last_sync }}"
+    {# Calculate sync discrepancy for highlighting #}
+    {% set progress_values = [] %}
+    {% if mapping.states.abs is defined and mapping.states.abs.percentage %}
+        {% set _ = progress_values.append(mapping.states.abs.percentage) %}
+    {% endif %}
+    {% if mapping.states.storyteller is defined and mapping.states.storyteller.percentage %}
+        {% set _ = progress_values.append(mapping.states.storyteller.percentage) %}
+    {% endif %}
+    {% if mapping.states.booklore is defined and mapping.states.booklore.percentage %}
+        {% set _ = progress_values.append(mapping.states.booklore.percentage) %}
+    {% endif %}
+    {% if mapping.states.kosync is defined and mapping.states.kosync.percentage %}
+        {% set _ = progress_values.append(mapping.states.kosync.percentage) %}
+    {% endif %}
+    {% set max_diff = (progress_values|max|default(0) - progress_values|min|default(0)) if progress_values|length > 1 else 0 %}
+
+    <div class="book-card {% if max_diff > 5 %}out-of-sync{% endif %}" data-progress="{{ mapping.unified_progress }}" data-last-sync="{{ mapping.last_sync }}"
         data-status="{{ mapping.status }}" data-title="{{ mapping.abs_title }}" data-sync-mode="{{ mapping.sync_mode }}"
         data-abs-id="{{ mapping.abs_id }}">
-        <div class="book-cover-container">
+
+        {# Cover image section #}
+        <div class="book-cover-section">
             {% if mapping.sync_mode == 'ebook_only' %}
             <img src="/covers/{{ mapping.kosync_doc_id }}.jpg" alt="Cover" class="book-cover"
                 onerror="this.style.display='none'; this.nextElementSibling.classList.remove('hidden');">
@@ -21,89 +39,102 @@
             {% else %}
             <div class="book-cover-placeholder">📖</div>
             {% endif %}
+        </div>
 
-            <div class="status-badge-mini status-{{ mapping.status }}">
-                {% if mapping.status == 'processing' and mapping.job_progress is defined %}
-                {{ mapping.job_progress }}%
-                {% else %}
-                {{ mapping.status }}
-                {% endif %}
+        {# Info section - always visible #}
+        <div class="book-info">
+            <div class="book-header">
+                <div class="book-title">{{ mapping.abs_title }}</div>
+                <div class="status-badge status-{{ mapping.status }}">
+                    {% if mapping.status == 'processing' and mapping.job_progress is defined %}
+                    {{ mapping.job_progress }}%
+                    {% else %}
+                    {{ mapping.status }}
+                    {% endif %}
+                </div>
             </div>
 
-            {% if mapping.status == 'active' and mapping.unified_progress > 0 and mapping.unified_progress < 100 %} <div
-                class="progress-ring reading">
-                {{ '%.0f' | format(mapping.unified_progress) }}%
-        </div>
-        {% endif %}
-
-        <div class="book-overlay">
-            <div class="book-title">{{ mapping.abs_title }}</div>
             <div class="book-filename">{{ mapping.ebook_filename }}</div>
 
+            {# Unified progress bar #}
+            <div class="unified-progress">
+                <div class="progress-bar">
+                    <div class="progress-bar-fill" style="width: {{ mapping.unified_progress }}%"></div>
+                </div>
+                <span class="progress-percent">{{ '%.1f' | format(mapping.unified_progress) }}%</span>
+            </div>
+
+            {% if max_diff > 5 %}
+            <div class="sync-warning">Out of sync by {{ '%.1f' | format(max_diff) }}%</div>
+            {% endif %}
+
             {% if mapping.status == 'active' %}
-            <div class="progress-details">
+            {# Service progress - always visible #}
+            <div class="service-progress">
                 {% if integrations.abs %}
-                <a href="{{ mapping.abs_url }}" target="_blank" rel="noopener"
-                    class="progress-item text-inherit-no-deco" title="Open in Audiobookshelf">
-                    <img src="/static/audiobookshelf.png" alt="ABS" class="icon-14">
+                <a href="{{ mapping.abs_url }}" target="_blank" rel="noopener" class="service-item" title="Open in Audiobookshelf">
+                    <img src="/static/audiobookshelf.png" alt="ABS" class="service-icon">
+                    <span class="service-name">ABS</span>
                     {% if mapping.states.abs is defined %}
-                    <span>{{ '%d:%02d:%02d' | format((mapping.states.abs.timestamp|default(0)|int) // 3600,
+                    <span class="service-value">{{ '%d:%02d:%02d' | format((mapping.states.abs.timestamp|default(0)|int) // 3600,
                         ((mapping.states.abs.timestamp|default(0)|int) % 3600) // 60,
                         (mapping.states.abs.timestamp|default(0)|int) % 60) }}</span>
                     {% else %}
-                    <span>0:00:00</span>
+                    <span class="service-value">0:00:00</span>
                     {% endif %}
                 </a>
                 {% endif %}
                 {% if integrations.kosync %}
-                <div class="progress-item cursor-pointer"
-                    title="Update KoReader Hash (Current: {{ mapping.kosync_doc_id }})"
+                <div class="service-item cursor-pointer" title="Update KoReader Hash (Current: {{ mapping.kosync_doc_id }})"
                     data-abs-id="{{ mapping.abs_id }}" data-title="{{ mapping.abs_title|escape }}"
                     data-hash="{{ mapping.kosync_doc_id }}" onclick="updateKoSyncHash(event)">
-                    <span>📖</span>
+                    <span class="service-icon-emoji">📖</span>
+                    <span class="service-name">KoSync</span>
                     {% if mapping.states.kosync is defined %}
-                    <span>{{ '%.1f' | format(mapping.states.kosync.percentage|default(0)) }}%</span>
+                    <span class="service-value">{{ '%.1f' | format(mapping.states.kosync.percentage|default(0)) }}%</span>
                     {% else %}
-                    <span>0.0%</span>
+                    <span class="service-value">0.0%</span>
                     {% endif %}
                 </div>
                 {% endif %}
                 {% if integrations.storyteller %}
-                <div class="progress-item" title="Storyteller">
-                    <img src="/static/storyteller.png" alt="ST" class="icon-14">
+                <div class="service-item" title="Storyteller">
+                    <img src="/static/storyteller.png" alt="ST" class="service-icon">
+                    <span class="service-name">Storyteller</span>
                     {% if mapping.states.storyteller is defined %}
-                    <span>{{ '%.1f' | format(mapping.states.storyteller.percentage|default(0)) }}%</span>
+                    <span class="service-value">{{ '%.1f' | format(mapping.states.storyteller.percentage|default(0)) }}%</span>
                     {% else %}
-                    <span>0.0%</span>
+                    <span class="service-value">0.0%</span>
                     {% endif %}
                 </div>
                 {% endif %}
                 {% if integrations.booklore %}
                 <a href="{{ mapping.booklore_url|default('#') }}" target="_blank" rel="noopener"
-                    class="progress-item text-inherit-no-deco {% if not mapping.booklore_id %}pe-none{% endif %}"
+                    class="service-item {% if not mapping.booklore_id %}disabled{% endif %}"
                     title="{% if mapping.booklore_id %}Open in Booklore{% else %}Not found in Booklore{% endif %}">
-                    <img src="/static/booklore.png" alt="BL"
-                        class="icon-14 {% if not mapping.booklore_id %}grayscale-muted{% endif %}">
+                    <img src="/static/booklore.png" alt="BL" class="service-icon {% if not mapping.booklore_id %}grayscale-muted{% endif %}">
+                    <span class="service-name">Booklore</span>
                     {% if mapping.states.booklore is defined %}
-                    <span>{{ '%.1f' | format(mapping.states.booklore.percentage|default(0)) }}%</span>
+                    <span class="service-value">{{ '%.1f' | format(mapping.states.booklore.percentage|default(0)) }}%</span>
                     {% else %}
-                    <span>0.0%</span>
+                    <span class="service-value">0.0%</span>
                     {% endif %}
                 </a>
                 {% endif %}
 
                 {% if integrations.hardcover %}
-                <div class="progress-item progress-item-hc">
+                <div class="service-item progress-item-hc">
                     <a href="{{ mapping.hardcover_url|default('https://hardcover.app') }}" target="_blank"
                         rel="noopener"
                         title="{% if mapping.hardcover_book_id %}Open {{ mapping.hardcover_title }} in Hardcover{% else %}Not linked to Hardcover{% endif %}"
                         class="hc-link {% if not mapping.hardcover_book_id %}pe-none{% endif %}">
                         <img src="/static/hardcover.png" alt="HC"
-                            class="icon-14 {% if not mapping.hardcover_book_id %}grayscale-muted{% endif %}"
+                            class="service-icon {% if not mapping.hardcover_book_id %}grayscale-muted{% endif %}"
                             onerror="this.style.display='none'; this.nextElementSibling.classList.remove('hidden');">
-                        <span class="hidden fs-12 {% if not mapping.hardcover_book_id %}opacity-50{% endif %}">📚</span>
+                        <span class="hidden service-icon-emoji">📚</span>
                     </a>
-                    <span class="cursor-pointer color-inherit" title="Click to edit Hardcover link"
+                    <span class="service-name">Hardcover</span>
+                    <span class="service-value cursor-pointer color-inherit" title="Click to edit Hardcover link"
                         data-abs-id="{{ mapping.abs_id }}" data-title="{{ mapping.hardcover_title|default('')|escape }}"
                         onclick="linkHardcover(event)">
                         {% if mapping.hardcover_book_id %}
@@ -113,35 +144,27 @@
                         0%
                         {% endif %}
                         {% else %}
-                        <span class="fs-10 opacity-50">+</span>
+                        <span class="link-icon">+</span>
                         {% endif %}
                     </span>
                 </div>
                 {% endif %}
             </div>
-
-            <div class="progress-bar-mini">
-                <div class="progress-bar-fill" style="width: {{ mapping.unified_progress }}%"></div>
-            </div>
-
-            <div class="last-sync">Synced {{ mapping.last_sync }}</div>
             {% endif %}
 
-            <div class="quick-actions">
-                <form method="POST" action="/clear-progress/{{ mapping.abs_id }}" class="flex-1-mr-6">
-                    <button type="submit" class="action-btn warning"
-                        onclick="return confirm('Clear all progress for this book? This will set progress to 0% on all systems.')">
-                        🔄 Clear
-                    </button>
-                </form>
-                <form method="POST" action="/delete/{{ mapping.abs_id }}" class="flex-1">
-                    <button type="submit" class="action-btn danger" onclick="return confirm('Delete this mapping?')">
-                        🗑️ Delete
-                    </button>
-                </form>
+            <div class="card-footer">
+                <div class="last-sync">Synced {{ mapping.last_sync }}</div>
+                <div class="quick-actions">
+                    <form method="POST" action="/clear-progress/{{ mapping.abs_id }}">
+                        <button type="submit" class="action-btn warning"
+                            onclick="return confirm('Clear all progress for this book?')">🔄</button>
+                    </form>
+                    <form method="POST" action="/delete/{{ mapping.abs_id }}">
+                        <button type="submit" class="action-btn danger" onclick="return confirm('Delete this mapping?')">🗑️</button>
+                    </form>
+                </div>
             </div>
         </div>
-    </div>
     </div>
     {% endmacro %}
 
@@ -373,114 +396,131 @@
                 background: rgba(255, 255, 255, 0.08);
             }
 
-            /* Book Grid - COMPACT DYNAMIC SCALING */
+            /* Book Grid */
             .book-grid {
                 display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-                gap: 24px;
+                grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+                gap: 20px;
                 margin-bottom: 60px;
             }
 
-            /* Book Card */
+            /* Book Card - Horizontal Layout */
             .book-card {
-                position: relative;
-                cursor: pointer;
-                transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+                display: flex;
+                background: rgba(255, 255, 255, 0.03);
+                border: 1px solid rgba(255, 255, 255, 0.08);
                 border-radius: 12px;
+                overflow: hidden;
+                transition: all 0.3s ease;
             }
 
             .book-card:hover {
-                transform: translateY(-8px) scale(1.02);
-                z-index: 10;
+                transform: translateY(-4px);
+                border-color: rgba(102, 126, 234, 0.4);
+                box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
             }
 
-            .book-card:hover .book-cover-container {
-                box-shadow: 0 24px 48px rgba(102, 126, 234, 0.3);
+            .book-card.out-of-sync {
+                border-color: rgba(255, 152, 0, 0.5);
+                box-shadow: 0 0 20px rgba(255, 152, 0, 0.15);
             }
 
-            .book-card:hover .book-overlay {
-                opacity: 1;
-            }
-
-            .book-cover-container {
+            /* Cover Section */
+            .book-cover-section {
+                width: 100px;
+                min-width: 100px;
+                min-height: 140px;
                 position: relative;
-                width: 100%;
-                aspect-ratio: 1/1;
-                border-radius: 12px;
-                overflow: hidden;
-                box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
-                transition: all 0.4s;
-                background: linear-gradient(135deg, rgba(102, 126, 234, 0.2) 0%, rgba(118, 75, 162, 0.2) 100%);
+                flex-shrink: 0;
             }
 
             .book-cover {
+                position: absolute;
+                top: 0;
+                left: 0;
                 width: 100%;
                 height: 100%;
                 object-fit: cover;
             }
 
             .book-cover-placeholder {
+                position: absolute;
+                top: 0;
+                left: 0;
                 width: 100%;
                 height: 100%;
                 background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                font-size: 48px;
+                font-size: 36px;
             }
 
-            /* Progress Ring Overlay */
-            .progress-ring {
-                position: absolute;
-                top: 8px;
-                right: 8px;
-                width: 36px;
-                height: 36px;
-                border-radius: 50%;
-                background: rgba(0, 0, 0, 0.7);
-                -webkit-backdrop-filter: blur(10px);
-                backdrop-filter: blur(10px);
+            /* Info Section */
+            .book-info {
+                flex: 1;
+                padding: 12px;
                 display: flex;
-                align-items: center;
-                justify-content: center;
-                font-size: 10px;
-                font-weight: 700;
-                color: #fff;
-                border: 2px solid transparent;
-                transition: all 0.3s;
+                flex-direction: column;
+                min-width: 0;
+                overflow: hidden;
             }
 
-            .progress-ring.reading {
-                border-color: #4CAF50;
-                box-shadow: 0 0 16px rgba(76, 175, 80, 0.6);
+            .book-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: flex-start;
+                gap: 10px;
+                margin-bottom: 4px;
+            }
+
+            .book-title {
+                font-size: 14px;
+                font-weight: 700;
+                color: #ffffff;
+                line-height: 1.3;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                word-break: break-word;
+            }
+
+            .book-filename {
+                font-size: 10px;
+                color: rgba(255, 255, 255, 0.4);
+                margin-bottom: 8px;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
 
             /* Status Badge */
-            .status-badge-mini {
-                position: absolute;
-                top: 8px;
-                left: 8px;
-                padding: 4px 8px;
-                border-radius: 6px;
-                font-size: 9px;
+            .status-badge {
+                padding: 3px 8px;
+                border-radius: 4px;
+                font-size: 10px;
                 font-weight: 700;
                 text-transform: uppercase;
-                background: rgba(0, 0, 0, 0.7);
-                -webkit-backdrop-filter: blur(10px);
-                backdrop-filter: blur(10px);
+                white-space: nowrap;
+                flex-shrink: 0;
             }
 
             .status-active {
+                background: rgba(76, 175, 80, 0.2);
                 color: #4CAF50;
                 border: 1px solid rgba(76, 175, 80, 0.3);
             }
 
             .status-pending {
+                background: rgba(255, 152, 0, 0.2);
                 color: #FF9800;
                 border: 1px solid rgba(255, 152, 0, 0.3);
             }
 
             .status-processing {
+                background: rgba(33, 150, 243, 0.2);
                 color: #2196F3;
                 border: 1px solid rgba(33, 150, 243, 0.3);
             }
@@ -488,83 +528,25 @@
             .status-failed,
             .status-crashed,
             .status-failed_retry_later {
+                background: rgba(244, 67, 54, 0.2);
                 color: #f44336;
                 border: 1px solid rgba(244, 67, 54, 0.3);
             }
 
-            /* Book Info Overlay */
-            .book-overlay {
-                position: absolute;
-                bottom: 0;
-                left: 0;
-                right: 0;
-                background: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.95) 60%);
-                padding: 40px 12px 12px 12px;
-                opacity: 0;
-                transition: opacity 0.3s;
-                border-radius: 0 0 12px 12px;
-            }
-
-            .book-title {
-                font-size: 14px;
-                font-weight: 700;
-                color: #ffffff;
-                margin-bottom: 4px;
-                line-height: 1.3;
-                display: -webkit-box;
-                -webkit-line-clamp: 2;
-                line-clamp: 2;
-                -webkit-box-orient: vertical;
-                overflow: hidden;
-            }
-
-            .book-filename {
-                font-size: 11px;
-                color: rgba(255, 255, 255, 0.6);
-                margin-bottom: 8px;
-                display: -webkit-box;
-                -webkit-line-clamp: 1;
-                line-clamp: 1;
-                -webkit-box-orient: vertical;
-                overflow: hidden;
-            }
-
-            /* Progress Details */
-            .progress-details {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 4px 12px;
-                margin-bottom: 8px;
-                font-size: 11px;
-            }
-
-            .progress-item {
+            /* Unified Progress */
+            .unified-progress {
                 display: flex;
                 align-items: center;
-                gap: 6px;
-                color: rgba(255, 255, 255, 0.8);
-            }
-
-            .progress-item img,
-            .progress-item span:first-child {
-                font-size: 12px;
-                width: 14px;
-                flex-shrink: 0;
-            }
-
-            .progress-item.cursor-pointer:hover,
-            a.progress-item:hover {
-                background: rgba(255, 255, 255, 0.1);
-                border-radius: 4px;
-                color: #ffffff;
-            }
-
-            .progress-bar-mini {
-                height: 3px;
-                background: rgba(255, 255, 255, 0.1);
-                border-radius: 2px;
-                overflow: hidden;
+                gap: 8px;
                 margin-bottom: 6px;
+            }
+
+            .progress-bar {
+                flex: 1;
+                height: 6px;
+                background: rgba(255, 255, 255, 0.1);
+                border-radius: 3px;
+                overflow: hidden;
             }
 
             .progress-bar-fill {
@@ -573,54 +555,148 @@
                 transition: width 0.5s ease;
             }
 
+            .progress-percent {
+                font-size: 12px;
+                font-weight: 700;
+                color: #667eea;
+                white-space: nowrap;
+            }
+
+            /* Sync Warning */
+            .sync-warning {
+                font-size: 11px;
+                color: #FF9800;
+                background: rgba(255, 152, 0, 0.1);
+                padding: 4px 8px;
+                border-radius: 4px;
+                margin-bottom: 8px;
+            }
+
+            /* Service Progress Grid */
+            .service-progress {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 4px;
+                margin-bottom: 8px;
+                overflow: hidden;
+            }
+
+            .service-item {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                padding: 3px 6px;
+                background: rgba(255, 255, 255, 0.04);
+                border-radius: 4px;
+                font-size: 11px;
+                color: rgba(255, 255, 255, 0.8);
+                text-decoration: none;
+                transition: background 0.2s;
+                min-height: 24px;
+                min-width: 0;
+                overflow: hidden;
+            }
+
+            .service-item:hover {
+                background: rgba(255, 255, 255, 0.1);
+                color: #fff;
+            }
+
+            .service-item.disabled {
+                opacity: 0.5;
+                pointer-events: none;
+            }
+
+            .service-icon {
+                width: 16px;
+                height: 16px;
+                flex-shrink: 0;
+            }
+
+            .service-icon-emoji {
+                font-size: 14px;
+                width: 16px;
+                flex-shrink: 0;
+            }
+
+            .service-name {
+                flex: 1;
+                font-size: 11px;
+                color: rgba(255, 255, 255, 0.6);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                min-width: 0;
+            }
+
+            .service-value {
+                font-weight: 600;
+                color: #fff;
+                flex-shrink: 0;
+                white-space: nowrap;
+            }
+
+            .link-icon {
+                opacity: 0.5;
+            }
+
+            /* Card Footer */
+            .card-footer {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-top: auto;
+                padding-top: 8px;
+                border-top: 1px solid rgba(255, 255, 255, 0.05);
+            }
+
             .last-sync {
-                font-size: 9px;
-                color: rgba(255, 255, 255, 0.5);
+                font-size: 11px;
+                color: rgba(255, 255, 255, 0.4);
             }
 
             /* Quick Actions */
             .quick-actions {
                 display: flex;
                 gap: 6px;
-                margin-top: 10px;
+            }
+
+            .quick-actions form {
+                margin: 0;
             }
 
             .action-btn {
-                flex: 1;
-                padding: 6px;
-                background: rgba(255, 255, 255, 0.1);
-                border: 1px solid rgba(255, 255, 255, 0.2);
+                padding: 5px 10px;
+                background: rgba(255, 255, 255, 0.08);
+                border: 1px solid rgba(255, 255, 255, 0.15);
                 border-radius: 4px;
                 color: white;
-                font-size: 10px;
-                font-weight: 600;
+                font-size: 12px;
                 cursor: pointer;
-                transition: all 0.3s;
+                transition: all 0.2s;
             }
 
             .action-btn:hover {
-                background: rgba(255, 255, 255, 0.2);
-                border-color: rgba(255, 255, 255, 0.4);
+                background: rgba(255, 255, 255, 0.15);
             }
 
             .action-btn.danger {
-                background: rgba(244, 67, 54, 0.2);
-                border-color: rgba(244, 67, 54, 0.4);
+                background: rgba(244, 67, 54, 0.15);
+                border-color: rgba(244, 67, 54, 0.3);
             }
 
             .action-btn.danger:hover {
-                background: rgba(244, 67, 54, 0.3);
+                background: rgba(244, 67, 54, 0.25);
             }
 
-            /* Added Warning Button Style from your code */
             .action-btn.warning {
-                background: rgba(255, 152, 0, 0.2);
-                border-color: rgba(255, 152, 0, 0.4);
+                background: rgba(255, 152, 0, 0.15);
+                border-color: rgba(255, 152, 0, 0.3);
                 color: #FF9800;
             }
 
             .action-btn.warning:hover {
-                background: rgba(255, 152, 0, 0.3);
+                background: rgba(255, 152, 0, 0.25);
             }
 
             /* Empty State */
@@ -650,40 +726,53 @@
             /* Responsive */
             @media (max-width: 1400px) {
                 .book-grid {
-                    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-                    gap: 20px;
+                    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+                    gap: 16px;
                 }
             }
 
             @media (max-width: 768px) {
                 .container {
-                    padding: 20px;
+                    padding: 16px;
                 }
 
                 .top-nav {
-                    padding: 16px 20px;
+                    padding: 12px 16px;
+                    flex-direction: column;
+                    gap: 12px;
                 }
 
                 .nav-actions {
                     flex-wrap: wrap;
+                    justify-content: center;
                 }
 
                 .section-header h2 {
-                    font-size: 24px;
+                    font-size: 22px;
                 }
 
                 .book-grid {
-                    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+                    grid-template-columns: 1fr;
                     gap: 12px;
+                }
+
+                .book-cover-section {
+                    width: 80px;
+                    min-width: 80px;
+                }
+
+                .service-progress {
+                    grid-template-columns: 1fr;
                 }
 
                 .controls-bar {
                     flex-direction: column;
                     align-items: stretch;
+                    gap: 12px;
                 }
 
                 .mt-80 {
-                    margin-top: 80px !important;
+                    margin-top: 40px !important;
                 }
             }
 
@@ -696,11 +785,6 @@
                 color: inherit !important;
             }
 
-            .icon-14 {
-                width: 14px !important;
-                height: 14px !important;
-            }
-
             .pe-none {
                 pointer-events: none !important;
             }
@@ -708,11 +792,6 @@
             .grayscale-muted {
                 opacity: 0.4 !important;
                 filter: grayscale(100%) !important;
-            }
-
-            .icon-14 {
-                width: 14px;
-                height: 14px;
             }
 
             .progress-item-hc {
@@ -728,33 +807,12 @@
                 align-items: center !important;
             }
 
-            .fs-12 {
-                font-size: 12px !important;
-            }
-
-            .opacity-50 {
-                opacity: 0.5 !important;
-            }
-
             .cursor-pointer {
                 cursor: pointer !important;
             }
 
             .color-inherit {
                 color: inherit !important;
-            }
-
-            .fs-10 {
-                font-size: 10px !important;
-            }
-
-            .flex-1-mr-6 {
-                flex: 1 !important;
-                margin-right: 6px !important;
-            }
-
-            .flex-1 {
-                flex: 1 !important;
             }
 
             .mb-16 {
@@ -1198,10 +1256,10 @@
                             const card = document.querySelector(`.book-card[data-abs-id="${book.abs_id}"]`);
                             if (!card) return;
 
-                            // Update progress ring if it exists
-                            const ring = card.querySelector('.progress-ring.reading');
-                            if (ring && book.unified_progress > 0 && book.unified_progress < 100) {
-                                ring.textContent = `${Math.round(book.unified_progress)}%`;
+                            // Update progress percentage text
+                            const progressPercent = card.querySelector('.progress-percent');
+                            if (progressPercent) {
+                                progressPercent.textContent = `${book.unified_progress.toFixed(1)}%`;
                             }
 
                             // Update progress bar
@@ -1210,24 +1268,24 @@
                                 barFill.style.width = `${book.unified_progress}%`;
                             }
 
-                            // Update individual progress items
-                            const absProgress = card.querySelector('.progress-item[title="Open in Audiobookshelf"] span');
-                            if (absProgress && book.states && book.states.abs) {
+                            // Update individual service values
+                            const absItem = card.querySelector('.service-item[title="Open in Audiobookshelf"] .service-value');
+                            if (absItem && book.states && book.states.abs) {
                                 const ts = book.states.abs.timestamp || 0;
                                 const h = Math.floor(ts / 3600);
                                 const m = Math.floor((ts % 3600) / 60);
                                 const s = Math.floor(ts % 60);
-                                absProgress.textContent = `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+                                absItem.textContent = `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
                             }
 
-                            const kosyncProgress = card.querySelector('.progress-item[title^="Update KoReader Hash"] span:last-child');
-                            if (kosyncProgress && book.states && book.states.kosync) {
-                                kosyncProgress.textContent = `${book.states.kosync.percentage.toFixed(1)}%`;
+                            const kosyncItem = card.querySelector('.service-item[title^="Update KoReader Hash"] .service-value');
+                            if (kosyncItem && book.states && book.states.kosync) {
+                                kosyncItem.textContent = `${book.states.kosync.percentage.toFixed(1)}%`;
                             }
 
-                            const stProgress = card.querySelector('.progress-item[title="Storyteller"] span:last-child');
-                            if (stProgress && book.states && book.states.storyteller) {
-                                stProgress.textContent = `${book.states.storyteller.percentage.toFixed(1)}%`;
+                            const stItem = card.querySelector('.service-item[title="Storyteller"] .service-value');
+                            if (stItem && book.states && book.states.storyteller) {
+                                stItem.textContent = `${book.states.storyteller.percentage.toFixed(1)}%`;
                             }
 
                             // Update last sync text


### PR DESCRIPTION
I redesigned the cards on the dashboard from square hover-overlay cards to a more horizontal layout where all information is visible without interaction. They are mobile responsive and show the % sync status for each service. If a service isn't activated, that section disappears - for example, if you don't use Booklore, the Booklore option doesn't appear on the card. 

## Changes:
  - Cover images sit left with progress bars, service status grid, and sync timestamps always visible to the right
  - Responsive breakpoints for mobile (single column, compact covers, stacked nav)
  - Yellow border highlight when sync discrepancy exceeds 5% across services

## Screenshots of suggested changes 
Mobile: 
<img width="463" height="880" alt="2026-01-30 - PR - mobile" src="https://github.com/user-attachments/assets/1eb4bf8e-427e-4356-b475-6e94ea3aeb9c" />

Desktop:
<img width="3456" height="1944" alt="2026-01-30 - PR - desktop" src="https://github.com/user-attachments/assets/7d5dded0-3a0b-4599-89a5-ded0852325c7" />

