### PR TITLE
fix: send consistent KOReader headers on all KoSync client requests

### DIFF
--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -1,6 +1,5 @@
 # KoSync Server - Extracted from web_server.py for clean code separation
 # Implements KOSync protocol compatible with kosync-dotnet
-import hashlib
 import logging
 import os
 import threading
@@ -11,6 +10,8 @@ from pathlib import Path
 from typing import Optional
 
 from flask import Blueprint, jsonify, request
+
+from src.utils.kosync_headers import hash_kosync_key
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ def kosync_auth_required(f):
             logger.error("KOSync Integrated Server: Credentials not configured in settings")
             return jsonify({"error": "Server not configured"}), 500
 
-        expected_hash = hashlib.md5(expected_password.encode()).hexdigest()
+        expected_hash = hash_kosync_key(expected_password)
 
         if user and expected_user and user.lower() == expected_user.lower() and (key == expected_password or key == expected_hash):
             return f(*args, **kwargs)
@@ -87,7 +88,7 @@ def kosync_users_auth():
         logger.error("KOSync Auth: Server credentials not configured")
         return jsonify({"message": "Server not configured"}), 500
 
-    expected_hash = hashlib.md5(expected_password.encode()).hexdigest()
+    expected_hash = hash_kosync_key(expected_password)
 
     if user.lower() == expected_user.lower() and (key == expected_password or key == expected_hash):
         logger.debug(f"KOSync Auth: User '{user}' authenticated successfully")

--- a/src/utils/kosync_headers.py
+++ b/src/utils/kosync_headers.py
@@ -1,0 +1,29 @@
+"""KOReader/KoSync header utilities.
+
+Centralises the MD5 key hashing and header construction used by both
+the KoSync *client* (api_clients.KoSyncClient) and the KoSync
+*server* (kosync_server.kosync_auth_required).
+"""
+
+import hashlib
+
+KOSYNC_ACCEPT = "application/vnd.koreader.v1+json"
+
+
+def hash_kosync_key(plain_key: str) -> str:
+    """Return the MD5 hex-digest of a KoSync password/key."""
+    return hashlib.md5(plain_key.encode("utf-8")).hexdigest()
+
+
+def kosync_auth_headers(user: str, hashed_key: str) -> dict:
+    """Build the standard header dict expected by KoSync-compatible servers.
+
+    Includes auth credentials and the KOReader accept type on every
+    request — some servers (e.g. Booklore) require all three headers
+    even on unauthenticated endpoints like /healthcheck.
+    """
+    return {
+        "x-auth-user": user,
+        "x-auth-key": hashed_key,
+        "accept": KOSYNC_ACCEPT,
+    }


### PR DESCRIPTION
## Summary

Fixes #39 - KoSyncClient was sending incomplete headers, causing 403/405 errors when connecting to KoSync-compatible servers like Booklore.

## Details

I was experiencing the same bug when using Booklore's KoReader sync server. I took a look with the help of Claude Code and determined: 

- **Healthcheck** was missing `x-auth-user` and `x-auth-key` headers  - Booklore's `KoreaderAuthFilter` requires them on all `/api/koreader/*` endpoints, including `/healthcheck`
-  **Fallback connection check** was missing the `accept: application/vnd.koreader.v1+json` header

When fixing this, I realized that there was inline `hashlib` usage in both the KoSync client and server, which looked to be duplicating code. I extracted the header construction and MD5 key hashing into a shared `kosync_headers` utility (`src/utils/kosync_headers.py`) in order to avoid duplicate code. 

  ## How I Tested

  - [x] Verified against official [koreader-sync-server](https://github.com/koreader/koreader-sync-server) documentation to ensure that the headers and endpoints match the spec
  - [x] Tested locally with abs-kosync-bridge's built-in KoSync server 
  - [x] Tested locally with Booklore KoSync API enabled in my personal Booklore server — connection verified, progress synced correctly