### PR TITLE
Fix Book Cover Display in Dashboard Cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,11 +26,11 @@
         data-status="{{ mapping.status }}" data-title="{{ mapping.abs_title }}" data-sync-mode="{{ mapping.sync_mode }}"
         data-abs-id="{{ mapping.abs_id }}">
 
-        {# Cover image section #}
+        {# Cover image section - prioritize ebook cover, fallback to ABS cover #}
         <div class="book-cover-section">
-            {% if mapping.sync_mode == 'ebook_only' %}
+            {% if mapping.kosync_doc_id %}
             <img src="/covers/{{ mapping.kosync_doc_id }}.jpg" alt="Cover" class="book-cover"
-                onerror="this.style.display='none'; this.nextElementSibling.classList.remove('hidden');">
+                onerror="{% if mapping.cover_url %}this.onerror=null; this.src='{{ mapping.cover_url }}';{% else %}this.style.display='none'; this.nextElementSibling.classList.remove('hidden');{% endif %}">
             <div class="book-cover-placeholder hidden">📖</div>
             {% elif mapping.cover_url %}
             <img src="{{ mapping.cover_url }}" alt="Cover" class="book-cover"
@@ -429,9 +429,13 @@
             .book-cover-section {
                 width: 100px;
                 min-width: 100px;
-                min-height: 140px;
+                aspect-ratio: 2/3;
                 position: relative;
                 flex-shrink: 0;
+                align-self: flex-start;
+                overflow: hidden;
+                border-radius: 8px;
+                background: rgba(0, 0, 0, 0.3);
             }
 
             .book-cover {
@@ -440,7 +444,7 @@
                 left: 0;
                 width: 100%;
                 height: 100%;
-                object-fit: cover;
+                object-fit: contain;
             }
 
             .book-cover-placeholder {


### PR DESCRIPTION
Issue: Book covers were stretching incorrectly in the new layout 

## Fix

**Changes** (templates/index.html)

 1. Cover Source Priority

 - Prioritize ebook cover (/covers/{kosync_doc_id}.jpg) over ABS audiobook cover - this helps keep the cover ratios consistent. Happy to pull this change out if you'd rather it prioritize the ABS cover!
 - Fallback to ABS cover if ebook cover fails to load - this ensures there's a cover if the epub doesn't have a cover available
 - This should help lead to better quality covers since ebook covers tend to be higher resolution

 2. CSS Fixes for .book-cover-section

 - aspect-ratio: 2/3 - Updated the aspect ratio to standard book cover proportions
 - align-self: flex-start - Prevents stretching with card height
 - overflow: hidden - Contains the cover image
 - border-radius: 8px - Slightly rounded corners
 - background: rgba(0, 0, 0, 0.3) - Subtle background for letterboxed covers

 3. CSS Fix for .book-cover

 - Changed object-fit: cover → object-fit: contain
 - Shows full cover without cropping

## Screenshots

**Out of sync:**
<img width="2864" height="1368" alt="2026-02-04 - out of sync screenshot" src="https://github.com/user-attachments/assets/bca12632-fd67-4783-9a2e-7622653ce372" />

**In sync:**
<img width="3002" height="1304" alt="2026-02-04 - in sync screenshot" src="https://github.com/user-attachments/assets/145bc563-cdfc-4b4a-b0f0-099e45a8279f" />