### PR TITLE
fix(sync): allow initial sync when a new client appears with a discrepancy

### DIFF
--- a/src/sync_clients/storyteller_sync_client.py
+++ b/src/sync_clients/storyteller_sync_client.py
@@ -54,6 +54,7 @@ class StorytellerSyncClient(SyncClient):
         if not used_bulk:
             st_pct, st_ts, st_href, st_frag = self.storyteller_client.get_progress_with_fragment(epub)
 
+        no_position = False
         if st_pct is None:
             # Book may exist in Storyteller but have no reading position yet.
             # Treat as 0% so the sync cycle can push progress from other services.
@@ -61,6 +62,7 @@ class StorytellerSyncClient(SyncClient):
             if book_info:
                 st_pct = 0.0
                 st_ts = 0
+                no_position = True
                 logger.info(f"[{title_snip}] Storyteller: book exists but no position, treating as 0%")
             else:
                 logger.debug(f"[{title_snip}] Storyteller: book not found in library")
@@ -69,7 +71,10 @@ class StorytellerSyncClient(SyncClient):
         # Get previous Storyteller state
         prev_storyteller_pct = prev_state.percentage if prev_state else 0
 
-        delta = abs(st_pct - prev_storyteller_pct)
+        # "No position" means absence of data, not a genuine move to 0%.
+        # Force delta to 0 so Storyteller doesn't become leader by appearing
+        # to have jumped backwards from a previously synced position.
+        delta = 0 if no_position else abs(st_pct - prev_storyteller_pct)
 
         return ServiceState(
             current={"pct": st_pct, "ts": st_ts, "href": st_href, "frag": st_frag},

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -1147,7 +1147,14 @@ class SyncManager:
                 # If there's a discrepancy but no client actually changed, skip
                 # (discrepancy will resolve next time someone reads)
                 # Exception: if character delta triggered, we have a real change
-                if significant_diff and not any_significant_delta and not char_delta_triggered:
+                # Exception: if a client just appeared for the first time (no prior
+                #   saved state), its appearance IS the activity — e.g. Storyteller
+                #   book exists at 0% but was never in config before.
+                new_client_in_config = any(
+                    client_name.lower() not in prev_states_by_client
+                    for client_name in config.keys()
+                )
+                if significant_diff and not any_significant_delta and not char_delta_triggered and not new_client_in_config:
                     logger.debug(f"[{abs_id}] [{title_snip}] Discrepancy exists ({max_progress*100:.1f}% vs {min_progress*100:.1f}%) but no recent client activity detected. Waiting for a new read event to determine true leader.")
                     continue
 


### PR DESCRIPTION
The previous commit I pushed up (0d6c65f) made Storyteller return 0% instead of None for books that exist but have no reading position. This correctly added Storyteller to the sync config, but after letting it run longer, I realized the sync manager's "wait for activity" guard blocked progress from ever being pushed. 😬 

To fix this, I added a short `new_client_in_config` check that detects when a client has no prior saved state in the DB, and bypasses the "wait for activity" skip so the leading book can push progress correctly. 