### PR TITLE
fix(sync): auto-migrate legacy storyteller links and improve search

### DIFF
--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -163,7 +163,8 @@ class Container(containers.DeclarativeContainer):
     storyteller_sync_client = providers.Singleton(
         StorytellerSyncClient,
         storyteller_client,
-        ebook_parser
+        ebook_parser,
+        database_service
     )
 
     booklore_sync_client = providers.Singleton(


### PR DESCRIPTION
## Summary

Found a bug while testing the tri-link-architecture where a book with a long title was struggling to link. PUshed up two fixes:

- Legacy Storyteller links (filename-based, no UUID) are now auto-migrated to UUID during sync
- Fix Link modal search uses tokenized word matching instead of literal substring, so long multi-author title strings actually return results