### PR TITLE
Fix nested head tags in index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -189,7 +189,6 @@
     </div>
     {% endmacro %}
 
-    <head>
         <title>ABS-KoSync Bridge</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="icon" type="image/jpeg" href="/static/icon.jpg">
@@ -1446,7 +1445,7 @@
                 }
             }
         </style>
-    </head>
+</head>
 
 <body>
     <div class="top-nav">


### PR DESCRIPTION
## Summary
- Removed duplicate nested `<head>` / `</head>` tags in `index.html` that were wrapping the actual head content inside the outer `<head>` already opened on line 4
- This produced invalid HTML that broke rendering on iPad Safari