### PR TITLE
[Fix] ABSClient dynamic config: allow web UI settings to take effect without restart

### DIFF
--- a/src/api/hardcover_client.py
+++ b/src/api/hardcover_client.py
@@ -28,6 +28,11 @@ class HardcoverClient:
         self.token = os.environ.get("HARDCOVER_TOKEN")
         self.user_id = None
 
+        if self.token:
+            self.token = self.token.strip()
+            if self.token.lower().startswith("bearer "):
+                self.token = self.token[7:].strip()
+
         if not self.token:
             logger.info("HARDCOVER_TOKEN not set")
             return


### PR DESCRIPTION
Resolved configuration caching bug where ABSClient cached base_url and token at instantiation, preventing web UI settings changes from taking effect until container restart.

Changes:
- Converted base_url, token, and headers to @property decorators (dynamic from os.environ)
- Added _update_session_headers() helper called before all API requests
- Added URL scheme validation to warn about missing http:// or https://
- Matches KoSyncClient pattern for consistency

Impact:
- Web UI ABS settings changes now take effect immediately (no restart needed)
- Fixes "Invalid URL" and 401 auth errors after settings updates
- No breaking changes - all existing code continues to work

Also includes:
- Hardcover token cleanup (strip whitespace and "Bearer " prefix)