### PR TITLE
fix: suppress ABS socket feedback loop from BookBridge's own writes

### DIFF
--- a/src/sync_clients/abs_ebook_sync_client.py
+++ b/src/sync_clients/abs_ebook_sync_client.py
@@ -81,6 +81,11 @@ class ABSEbookSyncClient(SyncClient):
         target_id = book.abs_ebook_item_id if book.abs_ebook_item_id else book.abs_id
         cfi = locator.cfi
         success = self.abs_client.update_ebook_progress(target_id, pct, cfi)
+        try:
+            from src.services.abs_socket_listener import record_abs_write
+            record_abs_write(book.abs_id)
+        except ImportError:
+            pass
         updated_state = {
             'pct': pct,
             'cfi': cfi

--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -239,4 +239,9 @@ class ABSSyncClient(SyncClient):
 
         logger.debug(f"   ⏱️ time_listened: {time_listened:.1f}s (prev: {prev_abs_ts:.1f}s → new: {adjusted_ts:.1f}s)")
         abs_ok = self.abs_client.update_progress(abs_id, adjusted_ts, time_listened)
+        try:
+            from src.services.abs_socket_listener import record_abs_write
+            record_abs_write(abs_id)
+        except ImportError:
+            pass
         return abs_ok, adjusted_ts


### PR DESCRIPTION
Add a module-level write-suppression tracker to abs_socket_listener.py. After BookBridge pushes progress to ABS, record_abs_write() stamps the book ID with the current timestamp. When ABS fires the resulting user_item_progress_updated socket event, is_own_write() detects it was self-triggered and drops it before it enters the debounce queue.

This reduces a single real progress change from 3 sync cycles to 1. The suppression window is 60 seconds. The KoSync PUT feedback loop was already handled (abs-sync-bot device filter at kosync_server.py:403).