### PR TITLE
fix: move ABS socket write-suppression check to debounce loop

### DIFF
--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -238,10 +238,10 @@ class ABSSyncClient(SyncClient):
             time_listened = 0
 
         logger.debug(f"   ⏱️ time_listened: {time_listened:.1f}s (prev: {prev_abs_ts:.1f}s → new: {adjusted_ts:.1f}s)")
-        abs_ok = self.abs_client.update_progress(abs_id, adjusted_ts, time_listened)
         try:
             from src.services.abs_socket_listener import record_abs_write
             record_abs_write(abs_id)
         except ImportError:
             pass
+        abs_ok = self.abs_client.update_progress(abs_id, adjusted_ts, time_listened)
         return abs_ok, adjusted_ts


### PR DESCRIPTION
The is_own_write() check was running at event-receipt time, before record_abs_write() had been called (the ABS API response hadn't returned yet), so suppression never fired.

- Move is_own_write() from _handle_progress_event() to _check_and_fire() so it runs 30s later, after record_abs_write() is guaranteed to have been called.
- Move record_abs_write() to before the ABS API call in _update_abs_progress_with_offset() so the suppression window is already open even if the socket event arrives mid-flight.