### PR TITLE
fix: remove connection-level auth params from ABS socket, clean auth_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ All notable changes to ABS-KoSync Enhanced will be documented in this file.
 ### ✨ Enhancements
 
 - **Instant Sync Toggle**: Added `INSTANT_SYNC_ENABLED` setting to enable or disable event-driven instant sync globally. When off, the ABS Socket.IO listener and KoSync push trigger are both inactive and the bridge falls back to the standard background poll cycle.
+- **Instant Sync Settings**: Added `ABS_SOCKET_DEBOUNCE_SECONDS` (default 30s) to control how long the socket listener waits after a playback event before triggering a sync. Tune this lower for faster response or higher to avoid hammering downstream services during active scrubbing.
 - **Per-Client Polling**: Storyteller and Booklore can now be configured with their own poll intervals, independent of the global sync cycle. Set either client to `custom` mode in Settings and choose a polling interval (in seconds). The poller checks for position changes on active books only and triggers a targeted sync when a real change is detected.
 - **Shared Write Suppression**: Centralized write-tracking into a single `write_tracker` module. All clients (ABS, KoSync, Storyteller, Booklore) now share the same suppression logic to prevent feedback loops after the bridge pushes a progress update.
+
+### 🐛 Bug Fixes
+
+- **ABS Socket.IO Auth Reliability**: The socket connection was previously sending the auth token at the transport level (HTTP headers + Socket.IO CONNECT packet) in addition to the `"auth"` event. On some ABS setups this caused both the primary token and the fallback to be rejected immediately. Auth is now sent exclusively via the `"auth"` event (the canonical ABS flow). If authentication fails, the listener disconnects cleanly and the bridge automatically falls back to the standard poll cycle — sync continues uninterrupted.
 
 ---
 


### PR DESCRIPTION
…failed handler

- Remove `headers=` and `auth=` from `sio.connect()` — ABS socket auth must go through the "auth" event only; transport-level params were redundant and could cause immediate rejections on some ABS setups
- Replace the API key fallback in `on_auth_failed` with a clear error message and explicit `sio.disconnect()` — the API key is never valid for socket auth, so the double-failure was misleading and left a zombie connection open
- Remove `self._auth_retried` field (no longer needed)
- Use `self._socket_token` directly in `connect()` handler; the `or self._api_token` fallback was unreachable dead code
- Update CHANGELOG with socket auth reliability fix and debounce setting