### PR TITLE
Fix Booklore audiobook progress mapping and verification race

### DIFF
--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -1607,6 +1607,7 @@ class BookloreClient:
             if not response or response.status_code not in [200, 201, 204]:
                 last_status = response.status_code if response else "No response"
                 continue
+            time.sleep(0.25)
             verified = self.get_audiobook_progress(book_id)
             if verified:
                 observed_pct = verified.get('pct')
@@ -1625,7 +1626,7 @@ class BookloreClient:
                     f"pct_delta={pct_delta:.4f} ts_delta_ms={ts_delta_ms} "
                     f"position_verifiable={position_verifiable}"
                 )
-                if pct_delta > 0.005:
+                if pct_delta > 0.01:
                     last_status = f"verify_mismatch:{(observed_pct or 0.0) * 100:.2f}%"
                     continue
                 if position_verifiable and ts_delta_ms is not None and ts_delta_ms > 5000:

--- a/src/sync_clients/booklore_audio_sync_client.py
+++ b/src/sync_clients/booklore_audio_sync_client.py
@@ -111,6 +111,8 @@ class BookLoreAudioSyncClient(SyncClient):
                 book_file_id=self._resolve_booklore_file_id(book),
                 position_ms=0,
                 percentage=0.0,
+                track_index=0,
+                track_position_ms=0,
             )
             updated_state = {"pct": 0.0, "ts": 0.0}
             if success:
@@ -149,6 +151,8 @@ class BookLoreAudioSyncClient(SyncClient):
             book_file_id=self._resolve_booklore_file_id(book),
             position_ms=position_ms,
             percentage=percentage,
+            track_index=0,
+            track_position_ms=position_ms,
         )
         if success:
             try:


### PR DESCRIPTION
## Summary
- updated `BookLoreAudioSyncClient.update_progress` to always pass `track_index=0` for Booklore audiobook progress writes
- set `track_position_ms=0` in the 0% reset path and `track_position_ms=position_ms` in standard progress updates so global position maps correctly to single-file M4B media
- adjusted verification tolerance in `BookloreClient.update_audiobook_progress` from `pct_delta > 0.005` to `pct_delta > 0.01` to account for backend rounding
- added a `time.sleep(0.25)` before verification readback to reduce post-write race-condition mismatches

## Notes
- `time` import was already present in `src/api/booklore_client.py`, so no import changes were required.
- No tests were run (targeted code-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af097a561483338b0d6eb081e56a00)