### PR TITLE
Feature/booklore audiobook support

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -2,16 +2,21 @@
 
 You are an expert software engineer and architect working on the ABS-KOSync-Bridge project.
 
+You plan first and do not execute until told to.
+
 ## 1. THE "LIVING CONTEXT" PROTOCOL (Strict Priority)
+
 **Rule:** Before writing any code, you MUST check the root directory for a file named `BRANCH_STATUS.md`.
 
 **IF `BRANCH_STATUS.md` EXISTS:**
+
 1. **Read it immediately.**
 2. **Trust it**: Use this file as your primary source of codebase context. Do NOT re-scan the entire repo unless necessary.
 3. Focus strictly on the files listed in the `CRITICAL FILE MAP`.
 4. Use the `CURRENT OBJECTIVE` as your primary directive.
 
 **IF `BRANCH_STATUS.md` IS MISSING:**
+
 1. **Stop.** Do not write code yet.
 2. **Perform Initial Deep Dive**: Scan the codebase to understand the existing architecture, key components, and data flow relevant to the new branch's goal.
 3. **Create** the file immediately using the template below.
@@ -22,7 +27,9 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 5. Fill in the "Current Objective" and "Critical File Map".
 
 ---
+
 ### 📄 TEMPLATE: BRANCH_STATUS.md
+
 ```markdown
 # BRANCH STATUS: [Feature/Bug Name]
 
@@ -55,6 +62,7 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 ## 4. CHANGE LOG (Newest Top)
 - **[YYYY-MM-DD HH:MM]**: [AI Name] Initialized branch with Deep Dive.
 ```
+
 ---
 
 ## 2. REFACTORING SAFEGUARDS (Anti-Breakage)
@@ -62,13 +70,16 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 **Rule:** You are PROHIBITED from renaming variables, functions, or files blindly.
 
 **Protocol for Renaming/Refactoring:**
+
 1. **Search First**: Detailed search for ALL occurrences of the symbol across the ENTIRE codebase.
 2. **Report**: List the files you found to the user.
 3. **Atomic Update**: Update ALL occurrences in a single "apply" step.
 4. **Verify**: If a file is not in your active context but was found in the search, you must request to edit it.
 
 ## 3. SCOPE DISCIPLINE
+
 **CRITICAL**: Only modify what is explicitly requested. Do not:
+
 - Refactor unrelated code "while you're there"
 - Reorganize imports unless asked
 - Change working logic to "improve" it
@@ -77,21 +88,25 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 **Exception**: You may fix obvious bugs (syntax errors, type mismatches) if they block your assigned task.
 
 ## 4. DEPENDENCY MANAGEMENT
+
 - **Cross-File Impact**: When adding/removing imports, search for all usages across the codebase.
 - **Verify Paths**: Do not hallucinate import paths—verify the module exists before adding it.
 - **Update All Files**: If a change affects multiple files, update them atomically in one operation.
 
 ## 5. DOCUMENTATION STANDARDS
+
 - **Comments**: Minimize inline comments. Only add when logic is genuinely complex or non-obvious.
 - **Docstrings**: Required for public functions/classes, but keep them concise.
 - **No Metadata Comments**: Never add comments like "# New line added" or "# Modified for feature X".
 
 ## 6. TESTING PROTOCOL
+
 - **After Every Change**: Run `pytest` to verify no regressions.
 - **Report Results**: Include test output in the changelog entry.
 - **No Merging**: Do not mark a task complete if tests fail.
 
 ## 7. CODING STANDARDS
+
 - **Style**: Follow PEP 8 guidelines.
 - **Type Hinting**: Use strict type hints for all function arguments and return values.
 - **Error Handling**: Use custom exceptions defined in the project; handle errors gracefully at the API boundary.
@@ -100,6 +115,7 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 - **Clean Cleanup**: Do not leave commented-out blocks of old code. Delete them.
 
 ## 8. POST-TASK HANDOFF
+
 **Rule:** When you have completed a task or are stopping for user feedback:
 
 1. **Update `BRANCH_STATUS.md`**:
@@ -111,6 +127,7 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 4. **Wait for Push**: Do not push to remote until user explicitly approves.
 
 ## 9. PROJECT CONTEXT
+
 - **Purpose**: Bridge between Audiobookshelf (ABS) and KOReader (KOSync) for synchronizing reading progress.
 - **Tech Stack**:
   - **Language**: Python 3.11+
@@ -120,22 +137,26 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
   - **Containerization**: Docker & Docker Compose
 
 ## 10. IMPORTANT PATHS
+
 - `src/`: Source code
 - `tests/`: Test suite
 - `alembic/`: Database migrations (Revisions: `alembic revision --autogenerate -m "message"`)
 - `docker-compose.yml`: Local development setup
 
 ## 11. COMMON COMMANDS
+
 - **Run Server**: `./start.sh` or `uvicorn src.main:app --reload`
 - **Run Tests**: `pytest`
 - **Database Upgrade**: `alembic upgrade head`
 
 ## 12. 🤖 MULTI-AGENT ORCHESTRATION PROTOCOL
 
-### TRIGGER:
+### TRIGGER
+
 **If I start a request with "PROJECT MANAGER MODE" or "PM MODE":**
 
 ### 12.1 THE ARCHITECT PHASE (The PM Agent)
+
 - **Role:** You are the Lead Architect. Do NOT write code yet.
 - **Action:**
   1. Analyze the request.
@@ -143,6 +164,7 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
   3. Create a `PLAN_OF_ACTION.md` file listing these tasks.
 
 ### 12.2 THE DELEGATION PHASE (Virtual Sub-Agents)
+
 - **Instruction:** You must execute the tasks sequentially (or in parallel if using Manager View), acting as a specific "Specialist" for each:
   - **[DB_AGENT]:** Only touches `models.py` and Alembic.
   - **[API_AGENT]:** Only touches `routes.py` and `schemas.py`.
@@ -150,6 +172,7 @@ You are an expert software engineer and architect working on the ABS-KOSync-Brid
 - **Constraint:** One agent must not edit files outside its domain.
 
 ### 12.3 THE MERGE PHASE (The PM Returns)
+
 - **Role:** Lead Architect.
 - **Action:**
   1. Review the code from all 3 "agents".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,25 @@
 
 All notable changes to ABS-KoSync Enhanced will be documented in this file.
 
-## [6.3.4] - 2026-03-05
+## [6.3.3] - 2026-03-08
 
-### Enhancements
+### Added
 
-- **Library Suggestions Workspace**: Added a dedicated `/suggestions` page with a split layout for suggestion review plus always-visible batch queue controls.
-- **Background Suggestions Scan**: Suggestions scanning now runs as an async background job with status polling and progress phases.
-- **Incremental Suggestions Cache**: Added persisted suggestions scan cache at `/data/suggestions_scan_cache.json` so normal scans can reuse prior results and only scan new unmatched audiobooks.
-- **Full Refresh Control**: Added explicit full refresh scanning to force a complete rescan when desired.
+- Added a dedicated **Library Suggestions** page for scanning unmatched titles, reviewing likely audiobook and ebook pairs, and queueing approved matches in bulk.
+- Added support for using **Booklore audiobooks** as the audio side of a sync, including matching, batch processing, suggestions, Forge, and dashboard tracking.
+- Added more flexible linking flows, including **ebook-only links**, **Storyteller-only links**, and a one-click **Refresh Booklore Cache** action in Settings.
 
-### Bug Fixes
+### Changed
 
-- **Suggestions Session Cookie Overflow**: Fixed oversized Flask session cookie failures (including 502 completion failures) by moving large scan payloads out of cookie-backed session storage into server-side state.
-- **Suggestions Provider Hammering**: Reduced ABS/Booklore scan load by switching suggestions matching to a one-time ebook candidate pool per scan with in-memory fuzzy matching, instead of per-audiobook provider searches.
-- **Booklore Scan Query Path**: `get_searchable_ebooks('')` now uses Booklore `get_all_books()` for scan workloads to avoid aggressive per-query refresh behavior.
-- **Booklore Duplicate Scan Suppression**: Added a non-blocking refresh lock around full-library scans to prevent overlapping `_refresh_book_cache()` runs under concurrent requests. Duplicate refresh attempts now skip safely, and lock release is guaranteed via `try/finally`.
-- **Booklore Search Miss Freshness**: Updated `search_books()` to use cache-first lookup with a single refresh-on-miss path. On non-empty misses, it performs one refresh only when cache age exceeds 60 seconds and cooldown is not active, then retries the in-memory search once.
-- **Booklore Search Refresh Guardrails**: Added explicit debug logs for miss-refresh trigger, fresh-cache skip, and cooldown skip to make runtime behavior and throttling decisions visible in logs.
+- Suggestions scans now run in the background with progress updates, cached repeat scans, and a **Full Refresh** option for rescanning the whole unmatched library.
+- Match, Batch Match, Suggestions, and the dashboard now show clearer source badges and audio-source details so it is easier to tell where each book came from.
+- Storyteller transcript import is more forgiving of real-world file layouts and continues to prefer Storyteller timing data before falling back to SMIL or Whisper.
+
+### Fixed
+
+- Fixed cases where small cross-format differences could cause progress bounce-backs or an incorrect reset when switching between audiobook and ebook apps.
+- Fixed ebook-only links getting stuck in processing by skipping audiobook preparation work they do not need.
+- Fixed edge cases where Storyteller-only links or stale Booklore data could break matching, hashing, or syncing until the book was refreshed.
 
 ---
 
@@ -280,6 +282,153 @@ If you see "Using Storyteller SQLite fallback", check your credentials.
 <!-- markdownlint-disable MD060 -->
 
 > [!NOTE]
+> All settings below can be configured via the **Web UI** at `/settings`. Environment variables are mainly for first boot or advanced overrides. Once a value is saved in the UI, the database value takes precedence.
+
+### Audiobookshelf (Required)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ABS_SERVER` | empty | Audiobookshelf server URL |
+| `ABS_KEY` | empty | Audiobookshelf API token |
+| `ABS_LIBRARY_ID` | empty | Audiobookshelf library ID used for matching and search scoping |
+| `ABS_COLLECTION_NAME` | `Synced with KOReader` | Collection name used for linked ABS audiobooks |
+| `ABS_PROGRESS_OFFSET_SECONDS` | `0` | Rewind progress written back to ABS by this many seconds |
+| `ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID` | `false` | Limit audiobook search to one ABS library. In direct env usage, this can also be set to a library ID string instead of `true`. |
+
+### KOSync
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KOSYNC_ENABLED` | `false` | Enable KOSync integration |
+| `KOSYNC_SERVER` | empty | Target KOSync server URL |
+| `KOSYNC_USER` | empty | KOSync username |
+| `KOSYNC_KEY` | empty | KOSync password |
+| `KOSYNC_HASH_METHOD` | `content` | Hash method: `content` (safer) or `filename` (faster) |
+| `KOSYNC_USE_PERCENTAGE_FROM_SERVER` | `false` | Use raw percentage from KOSync instead of text-based matching |
+| `KOSYNC_PORT` | empty | Optional dedicated KOSync listener port for split-port deployments |
+
+### Storyteller
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STORYTELLER_ENABLED` | `false` | Enable Storyteller integration |
+| `STORYTELLER_API_URL` | empty | Storyteller server URL |
+| `STORYTELLER_USER` | empty | Storyteller username |
+| `STORYTELLER_PASSWORD` | empty | Storyteller password |
+| `STORYTELLER_COLLECTION_NAME` | `Synced with KOReader` | Collection name used when linked books are added to Storyteller |
+| `STORYTELLER_POLL_MODE` | `global` | `global` uses the main sync cycle. `custom` gives Storyteller its own polling interval. |
+| `STORYTELLER_POLL_SECONDS` | `45` | Poll interval used when `STORYTELLER_POLL_MODE=custom` |
+| `STORYTELLER_ASSETS_DIR` | empty | Optional root path for Storyteller transcript assets |
+
+### Booklore
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BOOKLORE_ENABLED` | `false` | Enable Booklore integration |
+| `BOOKLORE_SERVER` | empty | Booklore server URL |
+| `BOOKLORE_USER` | empty | Booklore username |
+| `BOOKLORE_PASSWORD` | empty | Booklore password |
+| `BOOKLORE_SHELF_NAME` | `Kobo` | Shelf name used for linked ebooks |
+| `BOOKLORE_LIBRARY_ID` | empty | Optional Booklore library restriction |
+| `BOOKLORE_POLL_MODE` | `global` | `global` uses the main sync cycle. `custom` gives Booklore its own polling interval. |
+| `BOOKLORE_POLL_SECONDS` | `300` | Poll interval used when `BOOKLORE_POLL_MODE=custom` |
+
+### Booklore Advanced
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BOOKLORE_MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE` | `1200` | Caps how many detailed records a cache rebuild can hydrate in one pass |
+| `BOOKLORE_SEARCH_HIT_REFRESH_MIN_AGE` | `1800` | Minimum cache age before a successful search can trigger a quick validation refresh |
+| `BOOKLORE_SEARCH_HIT_REFRESH_COOLDOWN` | `600` | Cooldown between quick validation refreshes after search hits |
+| `BOOKLORE_LOGIN_RETRY_DELAY_SECONDS` | `1.1` | Delay before retrying duplicate refresh-token login conflicts |
+| `BOOKLORE_LOGIN_MAX_ATTEMPTS` | `2` | Maximum login attempts before failing |
+
+### CWA (Calibre-Web Automated)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CWA_ENABLED` | `false` | Enable OPDS / CWA ebook search and downloads |
+| `CWA_SERVER` | empty | Calibre-Web Automated server URL |
+| `CWA_USERNAME` | empty | Optional Calibre-Web Automated username |
+| `CWA_PASSWORD` | empty | Optional Calibre-Web Automated password |
+
+### Hardcover.app
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HARDCOVER_ENABLED` | `false` | Enable Hardcover updates |
+| `HARDCOVER_TOKEN` | empty | API token from hardcover.app/account/api |
+
+### Telegram Notifications
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TELEGRAM_ENABLED` | `false` | Enable Telegram notifications |
+| `TELEGRAM_BOT_TOKEN` | empty | Telegram bot token |
+| `TELEGRAM_CHAT_ID` | empty | Telegram user or group ID |
+| `TELEGRAM_LOG_LEVEL` | `ERROR` | Lowest log severity that gets forwarded |
+
+### Shelfmark
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SHELFMARK_URL` | empty | URL to your Shelfmark instance |
+
+### Sync Behavior
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SYNC_PERIOD_MINS` | `5` | Main background sync interval in minutes |
+| `SYNC_DELTA_ABS_SECONDS` | `60` | Minimum ABS timestamp change before it counts as real movement |
+| `SYNC_DELTA_KOSYNC_PERCENT` | `0.5` | Minimum ebook percentage change before it counts as real movement |
+| `SYNC_DELTA_KOSYNC_WORDS` | `400` | Extra guardrail for ebook movement |
+| `SYNC_DELTA_BETWEEN_CLIENTS_PERCENT` | `0.5` | Minimum gap between clients before propagation begins |
+| `FUZZY_MATCH_THRESHOLD` | `80` | Matching threshold used by book and text lookups |
+| `SYNC_ABS_EBOOK` | `false` | Also sync progress to the ABS ebook item when present |
+| `XPATH_FALLBACK_TO_PREVIOUS_SEGMENT` | `false` | Try the previous segment if a locator lookup fails |
+| `SUGGESTIONS_ENABLED` | `false` | Enable the Suggestions workspace and background discovery |
+| `REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT` | `true` | Rebuild missing alignment data after clearing progress when needed |
+| `INSTANT_SYNC_ENABLED` | `true` | Turns ABS playback-triggered sync and KOReader push-triggered sync on or off together |
+| `ABS_SOCKET_ENABLED` | `true` | Enable the ABS socket listener used by instant sync |
+| `ABS_SOCKET_DEBOUNCE_SECONDS` | `30` | Wait time after ABS playback activity before syncing |
+| `CROSSFORMAT_DEADBAND_SECONDS` | `2.0` | Ignores tiny audiobook-to-ebook differences so the leader does not flap between apps |
+| `CROSSFORMAT_ROUNDTRIP_TOLERANCE_CHARS` | `2` | Locator tolerance used when stabilizing cross-format position roundtrips |
+
+### Transcription
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRANSCRIPTION_PROVIDER` | `local` | Provider: `local`, `deepgram`, or `whispercpp` |
+| `WHISPER_MODEL` | `tiny` | Local Whisper model size |
+| `WHISPER_DEVICE` | `auto` | `auto`, `cpu`, or `cuda` |
+| `WHISPER_COMPUTE_TYPE` | `auto` | Precision mode for local Whisper |
+| `WHISPER_CPP_URL` | empty | URL to your Whisper.cpp HTTP endpoint |
+| `DEEPGRAM_API_KEY` | empty | Deepgram API key |
+| `DEEPGRAM_MODEL` | `nova-2` | Deepgram model tier |
+| `SMIL_VALIDATION_THRESHOLD` | `60` | Minimum match percentage required before SMIL timing data is trusted |
+
+### System
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TZ` | `America/New_York` | Container timezone |
+| `LOG_LEVEL` | `INFO` | Application log level |
+| `DATA_DIR` | `/data` | Database, cache, and working state |
+| `BOOKS_DIR` | `/books` | Local ebook library path inside the container |
+| `AUDIOBOOKS_DIR` | `/audiobooks` | Optional local audiobook path |
+| `STORYTELLER_LIBRARY_DIR` | `/storyteller_library` | Forge destination path |
+| `PROCESSING_DIR` | `/tmp` | Temporary Forge staging directory |
+| `EBOOK_CACHE_SIZE` | `3` | Parsed-ebook cache size |
+| `JOB_MAX_RETRIES` | `5` | Retry count for failed background jobs |
+| `JOB_RETRY_DELAY_MINS` | `15` | Delay before retrying failed jobs |
+
+<details>
+<summary>Archived legacy reference</summary>
+
+
+<!-- markdownlint-disable MD060 -->
+
+> [!NOTE]
 > All settings below can be configured via the **Web UI** at `/settings`. Environment variables are only used for initial bootstrapping on first launch.
 
 ### Audiobookshelf (Required)
@@ -375,7 +524,7 @@ If you see "Using Storyteller SQLite fallback", check your credentials.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TRANSCRIPTION_PROVIDER` | `local` | Provider: `local` (faster-whisper), `deepgram`, or `whisper_cpp` |
+| `TRANSCRIPTION_PROVIDER` | `local` | Provider: `local` (faster-whisper), `deepgram`, or `whispercpp` |
 | `WHISPER_MODEL` | `tiny` | Whisper model size (`tiny`, `base`, `small`, `medium`, `large`) |
 | `WHISPER_DEVICE` | `auto` | Device: `auto`, `cpu`, or `cuda` |
 | `WHISPER_COMPUTE_TYPE` | `auto` | Precision: `int8`, `float16`, `float32` |
@@ -396,3 +545,5 @@ If you see "Using Storyteller SQLite fallback", check your credentials.
 | `EBOOK_CACHE_SIZE` | `3` | LRU cache size for parsed ebooks |
 | `JOB_MAX_RETRIES` | `5` | Max transcription job retry attempts |
 | `JOB_RETRY_DELAY_MINS` | `15` | Minutes to wait between job retries |
+
+</details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,6 @@ All notable changes to ABS-KoSync Enhanced will be documented in this file.
 - **Booklore Search Miss Freshness**: Updated `search_books()` to use cache-first lookup with a single refresh-on-miss path. On non-empty misses, it performs one refresh only when cache age exceeds 60 seconds and cooldown is not active, then retries the in-memory search once.
 - **Booklore Search Refresh Guardrails**: Added explicit debug logs for miss-refresh trigger, fresh-cache skip, and cooldown skip to make runtime behavior and throttling decisions visible in logs.
 
-### Tests
-
-- **Booklore Search Miss Coverage**: Added unit tests for refresh-on-miss success, fresh-cache skip, cooldown skip, and refresh-failure single-attempt behavior.
-
-### Maintenance
-
-- **Suggestions Service Layer**: Isolated suggestions scan logic in `src/services/suggestions_service.py` to keep route handlers focused on web actions and state handling.
-
 ---
 
 ## [6.3.2] - 2026-02-27
@@ -79,6 +71,7 @@ All notable changes to ABS-KoSync Enhanced will be documented in this file.
 - **Comment Cleanup**: Removed reflective/speculative inline comments for clearer, more maintainable code.
 
 ---
+
 ## [6.3.0] - 2026-02-23
 
 ### � Critical Update Requirements

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,32 +1,43 @@
 # Quick Start Guide - ABS-KoSync Enhanced
 
-## 🎯 Goal
-Get your audiobooks and ebooks syncing in 10 minutes!
+## Goal
+
+Get your library syncing in about 10 minutes.
 
 ---
 
-## Step 1: Get Your API Keys
+## Step 1: Grab the basics
 
-### Audiobookshelf API Key
-1. Log into your ABS server
-2. Go to **Settings** → **Users** → Your user
-3. Click **"Generate API Token"**
-4. Copy the token (starts with `eyJ...`)
+You will want:
 
-### Find Your ABS Library ID
-1. In ABS, go to your audiobook library
-2. Look at the URL: `https://your-server.com/library/LIBRARY_ID_HERE`
-3. Copy that ID
+- Your Audiobookshelf URL
+- Your Audiobookshelf API token
+- Your ABS library ID
+- Your ebook folder path on the Docker host
 
-### KOSync Credentials
-- Your Calibre/KOSync username and password
-- KOSync server URL (usually `https://your-calibre.com/api/koreader`)
+Optional for later:
+
+- KOSync credentials
+- Booklore credentials
+- Storyteller credentials
+
+### Find your ABS API token
+
+1. Open Audiobookshelf.
+2. Go to **Settings -> Users -> Your user**.
+3. Click **Generate API Token**.
+4. Copy the token.
+
+### Find your ABS library ID
+
+1. Open your audiobook library in Audiobookshelf.
+2. Look at the URL.
+3. Copy the part after `/library/`.
 
 ---
 
-## Step 2: Prepare Your Folders
+## Step 2: Prepare a working folder
 
-Create a directory for the app:
 ```bash
 mkdir ~/abs-kosync
 cd ~/abs-kosync
@@ -34,144 +45,141 @@ cd ~/abs-kosync
 
 ---
 
-## Step 3: Create docker-compose.yml
+## Step 3: Create `docker-compose.yml`
 
-Copy this template and fill in YOUR values:
+Use this compose file:
 
 ```yaml
 services:
-  abs-kosync-enhanced:
-    image: your-username/abs-kosync-enhanced:latest
-    container_name: abs-kosync
+  abs-kosync:
+    container_name: abs_kosync
+    image: ghcr.io/cporcellijr/abs-kosync-bridge:latest
     restart: unless-stopped
-    
-    environment:
-      # REQUIRED - Fill these in!
-      - ABS_SERVER=https://YOUR_ABS_SERVER.com
-      - ABS_KEY=YOUR_API_TOKEN_HERE
-      - ABS_LIBRARY_ID=YOUR_LIBRARY_ID
-      
-      - KOSYNC_SERVER=https://YOUR_CALIBRE_SERVER.com/api/koreader
-      - KOSYNC_USER=YOUR_USERNAME
-      - KOSYNC_KEY=YOUR_PASSWORD
-      - KOSYNC_HASH_METHOD=content
-      
-      # OPTIONAL - Basic settings
-      - TZ=America/New_York
-      - LOG_LEVEL=INFO
-      - SYNC_PERIOD_MINS=5
-      - FUZZY_MATCH_THRESHOLD=88
-    
-    volumes:
-      # REQUIRED
-      - ./data:/data
-      - /path/to/your/ebooks:/books
-      # OPTIONAL - Storyteller forced-alignment transcript ingestion
-      # - /path/to/storyteller/assets:/storyteller/assets
-    
     ports:
       - "8080:5757"
+      # - "5758:5758"  # Optional: expose the sync-only port when using KOSYNC_PORT=5758
+    environment:
+      - TZ=America/New_York
+      - LOG_LEVEL=INFO
+      # - KOSYNC_PORT=5758  # Optional: enable split-port mode
+      # Configure ABS, KOSync, Booklore, Storyteller, and other services in the Web UI.
+    volumes:
+      - ./data:/data
+      - /path/to/ebooks:/books
+      # - /path/to/storyteller/library:/storyteller_library  # Optional: Forge output
+      # - /path/to/storyteller/assets:/storyteller/assets    # Optional: Storyteller transcript ingest
 ```
 
-**Replace these:**
-- `YOUR_ABS_SERVER.com` → Your Audiobookshelf URL
-- `YOUR_API_TOKEN_HERE` → The API key from Step 1
-- `YOUR_LIBRARY_ID` → The library ID from Step 1
-- `YOUR_CALIBRE_SERVER.com` → Your Calibre/KOSync server
-- `YOUR_USERNAME` → Your KOSync username
-- `YOUR_PASSWORD` → Your KOSync password
-- `/path/to/your/ebooks` → Where your EPUB files are
+Replace:
+
+- `/path/to/ebooks` with your real EPUB folder
+- The optional Storyteller paths if you plan to use Forge or transcript ingest
 
 ---
 
-## Step 4: Start the Container
+## Step 4: Start it
 
 ```bash
 docker compose up -d
 ```
 
-Check if it's running:
+Check the logs:
+
 ```bash
 docker compose logs -f
 ```
 
-Look for:
-- ✅ Connected to Audiobookshelf
-- ✅ Connected to KOSync Server
-
-Press `Ctrl+C` to exit logs.
+Press `Ctrl+C` when you are done watching.
 
 ---
 
-## Step 5: Open the Web UI
+## Step 5: Finish setup in the Web UI
 
-Open your browser to: **http://localhost:8080**
+Open **http://localhost:8080** and go to **Settings**.
 
-You should see the ABS-KoSync dashboard!
+Add your:
 
-If you mounted Storyteller assets:
+1. **Audiobookshelf Server URL**
+2. **Audiobookshelf API Token**
+3. **ABS Library ID**
 
-1. Go to **Settings**.
-2. Set **Storyteller Assets Path** to `/storyteller` (not `/storyteller/assets`).
-3. Save settings.
+Then add any optional services you want:
 
----
+- **KOSync** for KOReader sync
+- **Booklore** for ebook sync and Booklore audiobook matching
+- **Storyteller** for read-along links and transcript ingest
 
-## Step 6: Create Your First Mapping
+If you mounted Storyteller assets, set **Storyteller Assets Path** to `/storyteller` and not `/storyteller/assets`.
 
-1. Click **"Single Match"** button
-2. Find an audiobook you're currently listening to
-3. Find the matching ebook
-4. Click **"Create Mapping"**
-
-That's it! The sync will start automatically.
+Save settings and wait for the app to restart.
 
 ---
 
-## 🎉 Success!
+## Step 6: Create your first link
 
-Your progress should now sync between:
-- Audiobookshelf (when listening)
-- KOReader (when reading)
+You now have two easy options:
 
-The system checks every 5 minutes by default.
+### Fast path: Suggestions
+
+1. Open **Suggestions**.
+2. Click **Scan Library**.
+3. Review the likely matches.
+4. Click **Add to Queue** for the good ones.
+5. Click **Process All**.
+
+### Manual path: Add Book
+
+1. Open **Add Book**.
+2. Pick an ABS audiobook, a Booklore audiobook, or leave audio on **None / Skip** for an ebook-only link.
+3. Optionally pick a Storyteller title.
+4. Pick the standard ebook.
+5. Click **Create Mapping**.
 
 ---
 
-## 🔧 Troubleshooting
+## Success
 
-### Container won't start?
+You should now be able to sync between:
+
+- Audiobookshelf
+- KOReader / KOSync
+- Booklore
+- Storyteller
+- Hardcover, if enabled
+
+The normal background sync runs every 5 minutes by default, and instant sync can react faster when supported.
+
+---
+
+## Quick fixes
+
+### The container will not start
+
 ```bash
 docker compose logs
 ```
-Look for error messages about API keys or server connections.
 
-### Can't access web UI?
-- Check if port 8080 is available: `docker compose ps`
-- Try http://localhost:8080 or http://YOUR_SERVER_IP:8080
+Look for path, permission, or connection errors.
 
-### Sync not working?
-- Wait 5 minutes (default sync period)
-- Check the dashboard - does it show progress?
-- Make sure you're using the same ebook file in both systems
+### The web UI will not open
 
----
+- Check that port `8080` is free.
+- Run `docker compose ps`.
+- Try `http://YOUR_SERVER_IP:8080` from another device on your LAN.
 
-## ➡️ What's Next?
+### New Booklore matches are missing
 
-Once basic sync is working, you can add:
-- **Storyteller integration** (three-way sync)
-- **Storyteller transcript backfill** (Settings -> Storyteller Backfill)
-- **Book Linker** (automated Storyteller workflows)
-- **Booklore integration** (shelf organization)
-
-See the full README.md for advanced features!
+- Open **Settings**.
+- Click **Refresh Booklore Cache**.
+- Run **Full Refresh** from the Suggestions page if you changed a lot of books.
 
 ---
 
-## 🆘 Need Help?
+## What next?
 
-- Check the logs: `docker compose logs -f`
-- Read the full README.md
-- Open an issue on GitHub with your logs
+Once the basics work, try:
 
+- **Suggestions** for bulk review and queueing
+- **Forge** for Storyteller processing
+- **Storyteller Backfill** in Settings
+- **Split-port mode** if you want to expose only the sync endpoint

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 ## ✨ Key Features
 
 - **Five-Way Sync**: Syncs Audiobookshelf, KOReader, Storyteller, Booklore, and Hardcover.
+- **Flexible Match Flows**: Link ABS or Booklore audiobooks, or create ebook-only links when you only want text sync.
 - **Smart Alignment Sources**: Uses Storyteller forced-alignment transcripts when available, then SMIL, then Whisper fallback.
 - **Web UI**: Full management dashboard for tracking syncs and matching books.
 - **Library Suggestions Page**: Scan your library for likely audiobook + ebook pairs, review them, and queue matches in bulk.
@@ -37,19 +38,22 @@
 ```yaml
 services:
   abs-kosync:
+    container_name: abs_kosync
     image: ghcr.io/cporcellijr/abs-kosync-bridge:latest
+    restart: unless-stopped
     ports:
       - "8080:5757"
-      # - "5758:5758"  # Optional: Expose separate sync-only port (requires KOSYNC_PORT=5758)
+      # - "5758:5758"  # Optional: expose the sync-only port when using KOSYNC_PORT=5758
     environment:
       - TZ=America/New_York
-      # - KOSYNC_PORT=5758  # Optional: Enable split-port mode for security
-      # NOTE: All configuration is managed in the Web UI.
+      - LOG_LEVEL=INFO
+      # - KOSYNC_PORT=5758  # Optional: enable split-port mode
+      # Configure ABS, KOSync, Booklore, Storyteller, and other services in the Web UI.
     volumes:
       - ./data:/data
-      - /books:/books
-      # - /path/to/storyteller/library:/storyteller_library # Optional: For Forge
-      # - /path/to/storyteller/assets:/storyteller/assets # Optional: Storyteller transcript ingestion
+      - /path/to/ebooks:/books
+      # - /path/to/storyteller/library:/storyteller_library  # Optional: Forge output
+      # - /path/to/storyteller/assets:/storyteller/assets    # Optional: Storyteller transcript ingest
 ```
 
 For full installation instructions, checking logs, and advanced configuration, please visit the **[Documentation Site](https://cporcellijr.github.io/abs-kosync-bridge/)**.

--- a/alembic/versions/a7c9e1d3f4b2_add_generic_audio_source_columns.py
+++ b/alembic/versions/a7c9e1d3f4b2_add_generic_audio_source_columns.py
@@ -1,0 +1,96 @@
+"""add generic audio source columns to books
+
+Revision ID: a7c9e1d3f4b2
+Revises: f6b2c4d8e9a1
+Create Date: 2026-03-07
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c9e1d3f4b2"
+down_revision: Union[str, Sequence[str], None] = "f6b2c4d8e9a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns(table_name)}
+    if column.name not in columns:
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns(table_name)}
+    if column_name in columns:
+        op.drop_column(table_name, column_name)
+
+
+def upgrade() -> None:
+    _add_column_if_missing("books", sa.Column("audio_source", sa.String(length=32), nullable=True))
+    _add_column_if_missing("books", sa.Column("audio_source_id", sa.String(length=255), nullable=True))
+    _add_column_if_missing("books", sa.Column("audio_title", sa.String(length=500), nullable=True))
+    _add_column_if_missing("books", sa.Column("audio_cover_url", sa.String(length=1000), nullable=True))
+    _add_column_if_missing("books", sa.Column("audio_duration", sa.Float(), nullable=True))
+    _add_column_if_missing("books", sa.Column("audio_provider_book_id", sa.String(length=255), nullable=True))
+    _add_column_if_missing("books", sa.Column("audio_provider_file_id", sa.String(length=255), nullable=True))
+    _add_column_if_missing("books", sa.Column("ebook_source", sa.String(length=32), nullable=True))
+    _add_column_if_missing("books", sa.Column("ebook_source_id", sa.String(length=255), nullable=True))
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = {idx["name"] for idx in inspector.get_indexes("books")}
+    if "ix_books_audio_source" not in indexes:
+        op.create_index("ix_books_audio_source", "books", ["audio_source"])
+    if "ix_books_audio_source_id" not in indexes:
+        op.create_index("ix_books_audio_source_id", "books", ["audio_source_id"])
+
+    books = sa.table(
+        "books",
+        sa.column("abs_id", sa.String()),
+        sa.column("abs_title", sa.String()),
+        sa.column("audio_source", sa.String()),
+        sa.column("audio_source_id", sa.String()),
+        sa.column("audio_title", sa.String()),
+        sa.column("audio_duration", sa.Float()),
+        sa.column("duration", sa.Float()),
+        sa.column("sync_mode", sa.String()),
+    )
+    bind.execute(
+        books.update()
+        .where(books.c.sync_mode != "ebook_only")
+        .values(
+            audio_source="ABS",
+            audio_source_id=books.c.abs_id,
+            audio_title=books.c.abs_title,
+            audio_duration=books.c.duration,
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = {idx["name"] for idx in inspector.get_indexes("books")}
+    if "ix_books_audio_source_id" in indexes:
+        op.drop_index("ix_books_audio_source_id", table_name="books")
+    if "ix_books_audio_source" in indexes:
+        op.drop_index("ix_books_audio_source", table_name="books")
+
+    _drop_column_if_present("books", "ebook_source_id")
+    _drop_column_if_present("books", "ebook_source")
+    _drop_column_if_present("books", "audio_provider_file_id")
+    _drop_column_if_present("books", "audio_provider_book_id")
+    _drop_column_if_present("books", "audio_duration")
+    _drop_column_if_present("books", "audio_cover_url")
+    _drop_column_if_present("books", "audio_title")
+    _drop_column_if_present("books", "audio_source_id")
+    _drop_column_if_present("books", "audio_source")

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -5,6 +5,7 @@
 
 services:
   abs-kosync:
+    container_name: abs_kosync
     image: ghcr.io/cporcellijr/abs-kosync-bridge:latest
 
     # Optional: Build locally if you need specific modifications or GPU libraries included
@@ -13,28 +14,34 @@ services:
     #   args:
     #     # Set to "true" to download NVIDIA CUDA libraries (adds ~800MB to image)
     #     INSTALL_GPU: "false"
-    container_name: abs_kosync
     restart: unless-stopped
+
+    ports:
+      - "8080:5757"   # Admin Dashboard (keep private to LAN or reverse proxy)
+      # - "5758:5758" # Optional: expose the sync-only port when using KOSYNC_PORT=5758
 
     environment:
       # ============================================
       # General Settings
       - TZ=America/New_York
       - LOG_LEVEL=INFO
-      # - KOSYNC_PORT=5758 # Enable Split-Port Mode (Safe for Internet Exposure)
+      # - KOSYNC_PORT=5758 # Optional: enable split-port mode
 
       # === OPTIONAL: Initial Configuration ===
       # It is recommended to configure these in the Web UI, but you can bootstrap them here.
 
       # Audiobookshelf
       # - ABS_SERVER=http://your-abs-server:13378
-      # - ABS_TOKEN=your-api-token
-      # - ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID=false # Set to true to restrict search to one library
+      # - ABS_KEY=your-api-token
+      # - ABS_LIBRARY_ID=your-library-id
+      # - ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID=false # Or set this directly to a library ID
 
       # Integrations
-      # - KOSYNC_URL=https://koreader.example.com
-      # - BOOKLORE_URL=http://booklore.example.com
-      # - STORYTELLER_URL=http://storyteller.example.com
+      # - KOSYNC_SERVER=https://koreader.example.com
+      # - BOOKLORE_SERVER=http://booklore.example.com
+      # - STORYTELLER_API_URL=http://storyteller.example.com
+      # - STORYTELLER_ASSETS_DIR=/storyteller
+      # Configure ABS, KOSync, Booklore, Storyteller, and other services in the Web UI.
 
       # CWA (Calibre-Web Automated) - For syncing ebooks without local files
       # - CWA_ENABLED=true
@@ -48,11 +55,8 @@ services:
       - /path/to/ebooks:/books          # Your EPUB library (Required unless using CWA/Booklore exclusively)
 
       # === OPTIONAL: Forge (Storyteller) ===
-      - /path/to/storyteller/library:/storyteller_library
-
-    ports:
-      - "8080:5757"   # Admin Dashboard (Keep Internal/LAN)
-      # - "5758:5758" # Sync Protocol (Enable if KOSync Port is set)
+      # - /path/to/storyteller/library:/storyteller_library
+      # - /path/to/storyteller/assets:/storyteller/assets
 
     networks:
       - your-network

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,41 +4,24 @@ For the full history of changes, please refer to the **[GitHub Releases](https:/
 
 ---
 
-## [6.3.4] - 2026-03-04
+## [6.3.3] - 2026-03-08
 
-### Enhancements
+### Added
 
-- Added a dedicated **Library Suggestions** workspace at `/suggestions` with a split review + queue layout.
-- Added asynchronous background scan execution with progress polling.
-- Added persisted incremental scan cache (`/data/suggestions_scan_cache.json`) so routine scans can reuse prior work.
-- Added an explicit **Full Refresh** action to force a complete rescan when needed.
+- Added a dedicated **Library Suggestions** workspace with background scans, cached repeat scans, and a **Full Refresh** option.
+- Added **Booklore audiobook** support across Match, Batch Match, Suggestions, Forge, and the dashboard.
+- Added more flexible linking flows, including ebook-only links, Storyteller-only links, and a **Refresh Booklore Cache** action in Settings.
 
-### Fixes
+### Changed
 
-- Fixed suggestion-scan completion failures caused by oversized cookie-backed Flask sessions by moving large payloads to server-side state.
-- Reduced heavy ABS/Booklore scan traffic by loading ebook candidates once per scan and fuzzy matching in memory, rather than searching external providers per audiobook.
-- Updated scan workload behavior to use Booklore `get_all_books()` for empty-query suggestions scans.
+- Match and dashboard views now show clearer source badges and audio-source details.
+- Storyteller transcript ingest now accepts more real-world layouts while staying the preferred timing source when available.
 
-### Maintenance
+### Fixed
 
-- Kept suggestions scan logic centralized in `src/services/suggestions_service.py` for cleaner route handling.
-
----
-
-## [6.3.3] - 2026-02-27
-
-### Enhancements
-
-- Storyteller forced-alignment transcript JSON is now a top-priority transcript source (before SMIL and Whisper).
-- Added optional **Storyteller Assets Path** support (`STORYTELLER_ASSETS_DIR`) for ingesting files from `{root}/assets/{title}/transcriptions`.
-- Added storyteller-native direct alignment map generation from `wordTimeline`.
-- Added direct timestamp-to-EPUB locator resolution for Storyteller transcript books (bypasses fuzzy-search lookup path).
-- Added a Settings maintenance action to bulk backfill Storyteller transcripts and regenerate alignment maps for existing Storyteller-linked books.
-
-### Fixes
-
-- Accepted both `00000-xxxxx.json` and `00001-xxxxx.json` Storyteller chapter filename prefixes.
-- Added chapter format validation guardrails so incompatible JSON files are skipped cleanly during ingest/backfill.
+- Fixed cross-format drift cases that could cause bounce-backs or bad resets.
+- Fixed ebook-only links getting stuck in processing.
+- Fixed edge cases where Storyteller-only links or stale Booklore data could break matching or syncing.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,162 +1,222 @@
 # Configuration
 
 > [!NOTE]
-> All configuration is managed via the **Web UI** at `/settings`.
-> Environment variables can be used for initial bootstrapping, but values set in the database (via UI) take precedence.
+> All configuration is managed through the **Web UI** at `/settings`.
+> Environment variables are mainly for first boot or advanced overrides. Once a value is saved in the UI, the database value takes precedence.
 
 ## Web UI Settings
 
-The most convenient way to manage configuration is via the **Settings** page in the Web UI. Changes made here are applied instantly (triggering a soft restart).
+The **Settings** page is the easiest way to manage the bridge. Saving settings restarts the app automatically and sends you back to the dashboard when it is ready.
 
 ### Split-Port Security (Optional)
 
-You can configure the system to listen on two separate ports:
+You can run the admin UI and the KOSync protocol on separate ports:
 
-1. **Primary Port (8080)**: Hosts the Admin Dashboard and all API routes. Keep this private/LAN-only.
-2. **KOSync Port**: Hosts *only* the KOSync protocol routes needed for KOReader devices. This is safe to expose to the internet.
+1. **Primary port (`8080`)**: Dashboard, Settings, logs, matcher, suggestions, and API routes.
+2. **KOSync port**: KOSync routes only. This is the one you can expose to the internet.
 
-To enable this mode, set the `KOSYNC_PORT` environment variable (e.g., `KOSYNC_PORT=5758`) and map it in Docker.
+To enable split-port mode, set `KOSYNC_PORT` and map the same port in Docker.
 
 ```yaml
 ports:
-  - "8080:5757"   # Admin Dashboard
-  - "5758:5758"   # Sync Protocol (Internet Safe)
+  - "8080:5757"
+  - "5758:5758"
 ```
 
 ### Integrations
 
-#### KOSync (KOReader)
+#### Audiobookshelf
 
-- **Server**: Your KOSync server URL (e.g., `https://koreader.mydomain.com/api/koreader`).
-- **Username**: Your KOSync username.
-- **Password**: Your KOSync password.
-- **Save Hash Method**: How KOReader calculates document integrity. Keep as default (`content`) unless you know what you're doing.
+Audiobookshelf remains the default audiobook source when a mapping is not explicitly using Booklore audio.
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Server URL | `ABS_SERVER` | empty | Required. |
+| API Token | `ABS_KEY` | empty | Required. |
+| Library ID | `ABS_LIBRARY_ID` | empty | Used by the matcher and search scoping. |
+| Auto-add Collection | `ABS_COLLECTION_NAME` | `Synced with KOReader` | Collection used for matched audiobooks. |
+| Progress Offset | `ABS_PROGRESS_OFFSET_SECONDS` | `0` | Rewinds progress written back to ABS by this many seconds. |
+| Limit Search to Configured Library | `ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID` | `false` | In the UI this is a checkbox. Direct env usage can also be set to a library ID string. |
+
+#### KOSync / KOReader
+
+Use this when you want KOReader devices to sync directly with the bridge.
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `KOSYNC_ENABLED` | `false` | Turns on KOSync support. |
+| Target KOSync URL | `KOSYNC_SERVER` | empty | External server URL, or the built-in bridge URL if you use the internal server. |
+| Username | `KOSYNC_USER` | empty | KOReader username. |
+| Password | `KOSYNC_KEY` | empty | KOReader password. |
+| Hash Method | `KOSYNC_HASH_METHOD` | `content` | `content` is safest. `filename` is faster but less reliable. |
+| Use Percentage from Server | `KOSYNC_USE_PERCENTAGE_FROM_SERVER` | `false` | Uses raw percentage instead of text matching. |
+| Split-Port Listener | `KOSYNC_PORT` | empty | Optional dedicated KOSync port for internet-safe exposure. |
 
 #### Storyteller
 
-- **Storyteller URL**: URL to your Storyteller instance.
-- **Storyteller Username / Password**: Credentials for your Storyteller admin account.
-- **Sync Mode**: REST API only. The bridge communicates exclusively via the Storyteller API.
-- **Storyteller Assets Path (Optional)**: Root path containing Storyteller `assets/`.
-  - Expected structure: `{assets_root}/assets/{book_title}/transcriptions/`
-  - If your Docker volume is `/path/to/storyteller/assets:/storyteller/assets`, set this value to `/storyteller`.
-  - This setting is optional and can be configured in the Web UI (no compose env var required).
-- **Storyteller Backfill**: Settings includes a maintenance action to scan all Storyteller-linked books, ingest available transcript JSON files, and rebuild alignment maps without re-running SMIL/Whisper.
-- **Forge Staging Directory (Optional env)**: `PROCESSING_DIR` controls temporary Forge staging before files are atomically presented to Storyteller.
-  - Default is `/tmp`, so no dedicated `PROCESSING_DIR` volume mount is required.
+The bridge talks to Storyteller through the REST API only.
 
-> [!NOTE]
-> The legacy method of mapping a local Storyteller database (`/storyteller_data`) has been removed. The bridge now communicates strictly via the Storyteller API.
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `STORYTELLER_ENABLED` | `false` | Turns on Storyteller support. |
+| API URL | `STORYTELLER_API_URL` | empty | Base URL for Storyteller. |
+| Username | `STORYTELLER_USER` | empty | Storyteller username. |
+| Password | `STORYTELLER_PASSWORD` | empty | Storyteller password. |
+| Collection Name | `STORYTELLER_COLLECTION_NAME` | `Synced with KOReader` | Collection used when linked books are added to Storyteller. |
+| Library Path | `STORYTELLER_LIBRARY_DIR` | `/storyteller_library` | Where Forge writes Storyteller-ready books. |
+| Assets Path | `STORYTELLER_ASSETS_DIR` | empty | Root path that contains `/assets/{title}/transcriptions`. |
+| Poll Mode | `STORYTELLER_POLL_MODE` | `global` | `global` uses the main sync cycle. `custom` polls Storyteller separately. |
+| Poll Interval | `STORYTELLER_POLL_SECONDS` | `45` | Used when Poll Mode is `custom`. |
 
-#### Hardcover.app
+Storyteller notes:
 
-- **Enable**: Toggle `HARDCOVER_ENABLED` to `true`.
-- **API Token**: Your personal API token from [hardcover.app/account/api](https://hardcover.app/account/api).
-- **Behavior**: Write-only tracking. The bridge auto-matches books by title/author and updates your reading progress and status (e.g., marks as "Finished" when complete).
-
-#### Telegram Notifications
-
-- **Enable**: Toggle `TELEGRAM_ENABLED` to `true`.
-- **Bot Token**: Your Telegram bot token (from [@BotFather](https://t.me/botfather)).
-- **Chat ID**: The chat ID to send messages to (your user ID or a group ID).
-- **Min Log Level**: The minimum severity level to forward (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Default: `ERROR`.
-
-#### Shelfmark
-
-- **Shelfmark URL**: URL to your Shelfmark instance. When configured, a Shelfmark icon appears in the navigation bar for quick access.
+- If you mount `/path/to/storyteller/assets:/storyteller/assets`, set **Storyteller Assets Path** to `/storyteller`.
+- Storyteller timing data stays the preferred alignment source whenever valid transcript assets are available.
+- **Settings -> Storyteller Backfill** rechecks existing Storyteller-linked books and rebuilds their alignment data without rerunning Whisper.
 
 #### Booklore
 
-- **Booklore URL**: URL to your Booklore/Calibre-Web instance.
-- **API Key**: For managing shelves/collections.
-- **Target Library**: (Optional) To prevent cross-library contamination, you can specify the Booklore Library ID to use.
+Booklore now supports both ebook sync and Booklore audiobook-backed mappings.
 
-#### CWA (Calibre-Web Automated)
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `BOOKLORE_ENABLED` | `false` | Turns on Booklore support. |
+| Server URL | `BOOKLORE_SERVER` | empty | Booklore base URL. |
+| Username | `BOOKLORE_USER` | empty | Booklore username. |
+| Password | `BOOKLORE_PASSWORD` | empty | Booklore password. |
+| Shelf Name | `BOOKLORE_SHELF_NAME` | `Kobo` | Shelf used for matched ebooks. |
+| Library ID | `BOOKLORE_LIBRARY_ID` | empty | Optional library restriction. |
+| Poll Mode | `BOOKLORE_POLL_MODE` | `global` | `global` uses the main sync cycle. `custom` polls Booklore separately. |
+| Poll Interval | `BOOKLORE_POLL_SECONDS` | `300` | Used when Poll Mode is `custom`. |
 
-- **CWA Server URL**: URL to your Calibre-Web OPDS feed (e.g. `http://my-calibre-web/opds`).
-- **CWA Username/Password**: Credentials for Calibre-Web.
-- **Enabled**: Set to `true` to enable.
-- **Note**: CWA allows the bridge to download ebooks directly from Calibre-Web for Forge/Sync without needing a local `/books` volume.
+Booklore notes:
 
-#### Audiobookshelf
+- Match, Batch Match, Suggestions, and Forge can now use **Booklore audiobooks** as the audio source.
+- The dashboard shows **BL Audio** progress when a mapping is driven by Booklore audio.
+- **Settings -> Refresh Booklore Cache** forces a fresh cache rebuild after imports, removals, or large metadata changes.
 
-- **ABS Server URL**: Your ABS instance.
-- **ABS API Token**: Your secret token.
-- **Limit Search to Library**: (Optional) If set, the bridge will only search for audiobooks within this specific ABS Library ID.
+Advanced Booklore cache tuning:
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Max Detail Fetches per Refresh | `BOOKLORE_MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE` | `1200` | Caps how many detailed records a refresh can hydrate in one pass. |
+| Search Hit Refresh Min Age | `BOOKLORE_SEARCH_HIT_REFRESH_MIN_AGE` | `1800` | Minimum cache age before a successful search can trigger a quick validation refresh. |
+| Search Hit Refresh Cooldown | `BOOKLORE_SEARCH_HIT_REFRESH_COOLDOWN` | `600` | Cooldown between quick validation refreshes after search hits. |
+| Login Retry Delay | `BOOKLORE_LOGIN_RETRY_DELAY_SECONDS` | `1.1` | Delay before retrying duplicate refresh-token login conflicts. |
+| Login Max Attempts | `BOOKLORE_LOGIN_MAX_ATTEMPTS` | `2` | Maximum login attempts before failing. |
+
+#### Calibre-Web Automated (CWA)
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `CWA_ENABLED` | `false` | Turns on OPDS / CWA ebook search and download. |
+| Server URL | `CWA_SERVER` | empty | CWA base URL. |
+| Username | `CWA_USERNAME` | empty | Optional username. |
+| Password | `CWA_PASSWORD` | empty | Optional password. |
+
+#### Hardcover.app
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `HARDCOVER_ENABLED` | `false` | Turns on Hardcover updates. |
+| API Token | `HARDCOVER_TOKEN` | empty | Personal API token from Hardcover. |
+
+#### Telegram Notifications
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `TELEGRAM_ENABLED` | `false` | Turns on Telegram notifications. |
+| Bot Token | `TELEGRAM_BOT_TOKEN` | empty | BotFather token. |
+| Chat ID | `TELEGRAM_CHAT_ID` | empty | Target user or group ID. |
+| Min Log Level | `TELEGRAM_LOG_LEVEL` | `ERROR` | Lowest log severity that gets forwarded. |
+
+#### Shelfmark
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Shelfmark URL | `SHELFMARK_URL` | empty | Adds the Shelfmark shortcut when configured. |
+
+### Suggestions
+
+The Suggestions page is a review workspace, not an auto-linker. It always waits for your approval before creating mappings.
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable Suggestions | `SUGGESTIONS_ENABLED` | `false` | Enables the Suggestions page and background suggestion discovery. |
+
+Suggestions notes:
+
+- A normal scan reuses cached results so repeat scans are faster.
+- **Full Refresh** rescans the whole unmatched library from scratch.
+- Suggestions can queue ABS-backed links, Booklore-audio links, ebook-only links, and Storyteller-only links.
 
 ### Transcription Settings
 
-Configure the engine used for audio-to-text alignment.
-
 > [!TIP]
-> For books with Storyteller forced-alignment transcript files, that source is prioritized over SMIL and Whisper.
+> Storyteller transcript assets are preferred over SMIL and Whisper whenever they are available and valid.
 
-| Setting | Default | Description |
-| :--- | :--- | :--- |
-| **Provider** | `local` | `local` (faster-whisper), `deepgram`, or `whisper_cpp` (via server). |
-| **Whisper Model** | `tiny` | Model size (`tiny`, `base`, `small`, `medium`, `large`). |
-| **Whisper Device** | `auto` | `auto`, `cpu`, or `cuda`. See [GPU Support](#gpu-support-optional) below. |
-| **Compute Type** | `auto` | Precision (`int8`, `float16`, `float32`). Use `float16` for GPU. |
-
-#### Deepgram
-
-- **API Key**: Your Deepgram API Key.
-- **Model**: Specific Deepgram model tier (e.g., `nova-2`).
-
-#### WhisperCPP
-
-- **Server URL**: URL to your running `whisper.cpp` server (e.g. `http://my-whisper-server:8080/inference`).
-- **Model**: Now controls the `model` parameter sent to the server (e.g. `small`, `medium`).
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Provider | `TRANSCRIPTION_PROVIDER` | `local` | `local`, `deepgram`, or `whispercpp`. |
+| Whisper Model | `WHISPER_MODEL` | `tiny` | Local Whisper model size. |
+| Whisper Device | `WHISPER_DEVICE` | `auto` | `auto`, `cpu`, or `cuda`. |
+| Whisper Compute Type | `WHISPER_COMPUTE_TYPE` | `auto` | Precision mode for local Whisper. |
+| Whisper.cpp URL | `WHISPER_CPP_URL` | empty | URL to your Whisper.cpp HTTP endpoint. |
+| Deepgram API Key | `DEEPGRAM_API_KEY` | empty | Deepgram API key. |
+| Deepgram Model | `DEEPGRAM_MODEL` | `nova-2` | Deepgram model tier. |
+| SMIL Validation Threshold | `SMIL_VALIDATION_THRESHOLD` | `60` | Minimum token match percentage for accepting SMIL timing data. |
 
 ### Sync Tuning
 
-Advanced settings to fine-tune the synchronization logic.
-
-| Setting | Default | Description |
-| :--- | :--- | :--- |
-| **Sync Period (Minutes)** | `5` | How often the background sync runs. |
-| **ABS Delta (Seconds)** | `60` | Minimum progress change (in seconds) required to trigger an update *from* ABS. |
-| **KoSync Delta (%)** | `0.5` | Minimum progress change (0.5%) required to trigger an update *from* KOReader. |
-| **KoSync Delta (Words)** | `400` | Minimum word-count change required to trigger a KOSync update (used alongside the % delta). |
-| **Fuzzy Match Threshold** | `0.80` | (0.0-1.0) Confidence required for text matching (80%). |
-| **Job Retries** | `5` | How many times to retry failed transcription jobs. |
-| **Job Retry Delay (Mins)** | `15` | Minutes to wait before retrying a failed transcription job. |
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Sync Period (Minutes) | `SYNC_PERIOD_MINS` | `5` | Main background sync interval. |
+| Min ABS Change (Seconds) | `SYNC_DELTA_ABS_SECONDS` | `60` | Minimum ABS timestamp change before it counts as real movement. |
+| Min Ebook Change (%) | `SYNC_DELTA_KOSYNC_PERCENT` | `0.5` | Minimum ebook percentage change before it counts as real movement. |
+| Min Ebook Change (Words) | `SYNC_DELTA_KOSYNC_WORDS` | `400` | Extra guardrail for ebook movement. |
+| Client Diff Threshold (%) | `SYNC_DELTA_BETWEEN_CLIENTS_PERCENT` | `0.5` | Minimum gap between clients before propagation begins. |
+| Fuzzy Match Threshold | `FUZZY_MATCH_THRESHOLD` | `80` | Matching threshold used by several book and text lookups. |
+| Job Max Retries | `JOB_MAX_RETRIES` | `5` | Retry count for failed background jobs. |
+| Job Retry Delay (Minutes) | `JOB_RETRY_DELAY_MINS` | `15` | Delay before retrying failed jobs. |
+| Cross-Format Deadband (Seconds) | `CROSSFORMAT_DEADBAND_SECONDS` | `2.0` | Prevents tiny cross-format gaps from causing leader flips. |
+| Cross-Format Roundtrip Tolerance | `CROSSFORMAT_ROUNDTRIP_TOLERANCE_CHARS` | `2` | Locator roundtrip tolerance used when stabilizing cross-format locators. |
 
 ### Advanced Toggles
 
-- **Sync ABS Ebook**: If enabled, also syncs progress to the *ebook* item in ABS (if you have both mapped). This allows you to read the ebook in the ABS web reader and have that progress sync to KOReader.
-- **Use KOSync Percentage from Server**: If enabled, uses the raw percentage value returned by the KOSync server instead of performing text-based position matching. Useful if text matching is unreliable for a specific book.
-- **XPath Fallback**: Strategy for handling position lookups when exact paths fail.
-- **Reprocess on Clear**: (`REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT`) If enabled, clearing a mapping in the UI will also delete the alignment cache, forcing a full re-transcription next time.
-- **Instant Sync**: (`INSTANT_SYNC_ENABLED`) Controls whether event-driven instant sync is active. When disabled, the ABS Socket.IO listener and KoSync PUT trigger are both turned off — sync falls back to the regular background poll only.
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Sync ABS Ebook | `SYNC_ABS_EBOOK` | `false` | Also syncs to the ABS ebook item when present. |
+| XPath Fallback | `XPATH_FALLBACK_TO_PREVIOUS_SEGMENT` | `false` | Tries the previous segment if a locator lookup fails. |
+| Reprocess on Clear | `REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT` | `true` | Rebuilds missing data after resetting progress when needed. |
+| Instant Sync | `INSTANT_SYNC_ENABLED` | `true` | Turns ABS playback-triggered sync and KOReader push-triggered sync on or off together. |
+| ABS Socket Listener | `ABS_SOCKET_ENABLED` | `true` | Enables the ABS socket listener used by instant sync. |
+| ABS Socket Debounce | `ABS_SOCKET_DEBOUNCE_SECONDS` | `30` | Wait time after ABS playback activity before syncing. |
 
-### Per-Client Polling
+### Paths and System
 
-By default, Storyteller and Booklore are only checked during the global sync cycle. If you want the bridge to watch those clients more (or less) frequently than everything else, set their poll mode to **Custom**.
-
-| Setting | Default | Description |
-| :--- | :--- | :--- |
-| **Storyteller Poll Mode** | `global` | `global` uses the normal sync cycle. `custom` polls at its own interval. |
-| **Storyteller Poll Interval** | `45s` | How often (in seconds) to check Storyteller for position changes when in `custom` mode. |
-| **Booklore Poll Mode** | `global` | `global` uses the normal sync cycle. `custom` polls at its own interval. |
-| **Booklore Poll Interval** | `300s` | How often (in seconds) to check Booklore for position changes when in `custom` mode. |
-
-> [!NOTE]
-> Per-client polling only watches for changes *from* that client and triggers a targeted sync when one is detected. It is much lighter than a full global sync cycle.
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Timezone | `TZ` | `America/New_York` | Container timezone. |
+| Log Level | `LOG_LEVEL` | `INFO` | Application log level. |
+| Data Directory | `DATA_DIR` | `/data` | Database, cache, and working state. |
+| Books Directory | `BOOKS_DIR` | `/books` | Local ebook library path inside the container. |
+| Audiobooks Directory | `AUDIOBOOKS_DIR` | `/audiobooks` | Optional local audiobook path. |
+| Storyteller Library Directory | `STORYTELLER_LIBRARY_DIR` | `/storyteller_library` | Forge destination path. |
+| Storyteller Assets Directory | `STORYTELLER_ASSETS_DIR` | empty | Optional transcript asset root. |
+| Forge Processing Directory | `PROCESSING_DIR` | `/tmp` | Temporary staging area before Forge moves files into Storyteller. |
+| Ebook Cache Size | `EBOOK_CACHE_SIZE` | `3` | Parsed-ebook cache size. |
 
 ---
 
 ## GPU Support (Optional)
 
-For significantly faster transcription (when using `local` provider), you can enable NVIDIA GPU acceleration.
+For faster local transcription, you can give the container access to an NVIDIA GPU.
 
 ### 1. Install NVIDIA Container Toolkit
 
-Follow the official guide to install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) for your host OS.
+Follow the official guide for the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 
 ### 2. Update Docker Compose
-
-Uncomment/Add the `deploy` section to your `docker-compose.yml`:
 
 ```yaml
 services:
@@ -171,10 +231,11 @@ services:
               capabilities: [gpu]
 ```
 
-### 3. Configure Settings
+### 3. Configure the bridge
 
-In the Web UI Settings:
+In **Settings**:
 
-1. Set **Whisper Device** to `cuda`.
-2. Set **Whisper Compute Type** to `float16`.
-3. Set **Whisper Model** to `small` or `medium` (GPUs can handle larger models easily).
+1. Set **Transcription Provider** to `local`.
+2. Set **Whisper Device** to `cuda`.
+3. Set **Whisper Compute Type** to `float16`.
+4. Use a larger model such as `small` or `medium` if your GPU can handle it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,59 +1,50 @@
 # Getting Started
 
-## 🎯 Goal
+## Goal
 
-Get your audiobooks and ebooks syncing in 10 minutes!
+Get your library syncing in about 10 minutes.
 
 ---
 
 ## Prerequisites
 
-Before you begin, ensure you have the following:
+Before you begin, you should have:
 
-- **Docker** and **Docker Compose** installed.
-- An **Audiobookshelf** server running.
-- (Optional) A **Booklore** instance (for syncing ebooks).
-- (Optional) A **KOReader** sync server (either the official one, a self-hosted instance, or none if just syncing ABS <-> Storyteller).
-- Your ebook and audiobook files accessible to the host machine.
+- Docker and Docker Compose
+- A working Audiobookshelf server
+- An ebook folder on the Docker host
+- Optional: KOSync, Booklore, Storyteller, or Hardcover if you want those integrations
 
 ---
 
-## Step 1: Get Your API Keys
+## Step 1: Gather your ABS details
 
-### Audiobookshelf API Key
+### Audiobookshelf API token
 
-1. Log into your ABS server.
-2. Go to **Settings** → **Users** → Your user.
-3. Click **"Generate API Token"**.
+1. Log into Audiobookshelf.
+2. Go to **Settings -> Users -> Your user**.
+3. Click **Generate API Token**.
 4. Copy the token.
 
-### (Optional) Find Your ABS Library ID
+### ABS library ID
 
-If you want to limit the sync mapping search to a specific library (recommended for performance):
+If you want searches scoped to one ABS library:
 
-1. In ABS, go to your audiobook library.
-2. Look at the URL: `https://your-server.com/library/LIBRARY_ID_HERE`
-3. Copy that ID.
+1. Open the audiobook library in Audiobookshelf.
+2. Look at the URL.
+3. Copy the part after `/library/`.
 
-### (Optional) KOSync Credentials
+### Optional service credentials
 
-If using KOReader sync:
+If you plan to use them, also keep these handy:
 
-- Your Calibre/KOSync username and password.
-- KOSync server URL (usually `https://your-calibre.com/api/koreader`).
-
-### (Optional) Booklore Credentials
-
-If using Booklore:
-
-- Your Booklore server URL.
-- Username and password.
+- KOSync URL, username, and password
+- Booklore URL, username, and password
+- Storyteller URL, username, and password
 
 ---
 
-## Step 2: Prepare Your Work Directory
-
-Create a directory for the application on your server:
+## Step 2: Prepare a working directory
 
 ```bash
 mkdir ~/abs-kosync
@@ -63,60 +54,56 @@ mkdir data
 
 ---
 
-## Step 3: Create docker-compose.yml
-
-Copy this template and fill in YOUR values:
+## Step 3: Create `docker-compose.yml`
 
 ```yaml title="docker-compose.yml"
 services:
   abs-kosync:
-    image: ghcr.io/cporcellijr/abs-kosync-bridge:latest
     container_name: abs_kosync
+    image: ghcr.io/cporcellijr/abs-kosync-bridge:latest
     restart: unless-stopped
     ports:
-      - "8080:5757" # Admin Panel (Keep Private)
-      # - "5758:5758" # Sync Protocol (Safe to Expose)
+      - "8080:5757"
+      # - "5758:5758"  # Optional: expose the sync-only port when using KOSYNC_PORT=5758
     environment:
       - TZ=America/New_York
       - LOG_LEVEL=INFO
-      
-      # NOTE: All configuration (ABS, etc.) is managed in the Web UI.
-      
+      # - KOSYNC_PORT=5758  # Optional: enable split-port mode
+      # Configure ABS, KOSync, Booklore, Storyteller, and other services in the Web UI.
     volumes:
-      # === REQUIRED ===
-      - ./data:/data                    # App data
-      - /path/to/ebooks:/books          # Your EPUB library
-      
-      # === OPTIONAL: Forge ===
-      - /path/to/storyteller/library:/storyteller_library
-      # === OPTIONAL: Storyteller transcript ingestion ===
-      - /path/to/storyteller/assets:/storyteller/assets
+      - ./data:/data
+      - /path/to/ebooks:/books
+      # - /path/to/storyteller/library:/storyteller_library  # Optional: Forge output
+      # - /path/to/storyteller/assets:/storyteller/assets    # Optional: Storyteller transcript ingest
 ```
 
-### Security Note: Split-Port Mode
+### Split-port mode
 
-By default, the container listens on port **8080** (mapped to 5757 int). This port exposes **everything**: the Admin Dashboard, Settings, and API.
+By default, port `8080` exposes the full web UI and API.
 
-If you want to expose the KOSync endpoint to the internet (for syncing on the go) but keep the Dashboard private, you can use **Split-Port Mode**:
+If you want to expose only the KOSync endpoint to the internet:
 
-1. Set `KOSYNC_PORT=5758` (or any other port) in your environment variables.
-2. Map that port in `docker-compose.yml` (as shown in the commented example).
+1. Uncomment `KOSYNC_PORT=5758`.
+2. Uncomment the `5758:5758` port mapping.
+3. Keep `8080` private to your LAN or reverse proxy.
 
 !!! tip "Optional Integrations"
-    You can configure KOSync, Storyteller, and other integrations via enviroment variables during bootstrap, but it is easier to do it later in the Web UI!
-    
+    It is usually easiest to start with the minimal compose file above and finish configuration in the Web UI.
+
+    If you enable Booklore, the bridge can use it for both ebook matching and Booklore audiobook sources.
+
     If you mount Storyteller assets at `/storyteller/assets`, set **Storyteller Assets Path** in Settings to `/storyteller`.
-    The assets path can be configured fully in the UI; `STORYTELLER_ASSETS_DIR` env is optional.
+    The assets path can be configured entirely in the UI; `STORYTELLER_ASSETS_DIR` is optional.
 
 ---
 
-## Step 4: Start the Service
+## Step 4: Start the service
 
 ```bash
 docker compose up -d
 ```
 
-Check the logs to ensure everything is running smoothly:
+Check the logs:
 
 ```bash
 docker compose logs -f
@@ -124,23 +111,38 @@ docker compose logs -f
 
 ---
 
-## Step 5: Initial Configuration
+## Step 5: Finish configuration in the Web UI
 
-1. Open your browser and go to `http://localhost:8080/settings` (or your server IP).
-2. Enter your **Audiobookshelf Server URL** and **API Key** (from Step 1).
-3. (Optional) Enter your **KOSync**, **Booklore**, or **Storyteller** credentials.
-4. (Optional) If Storyteller assets are mounted, set **Storyteller Assets Path** to `/storyteller`.
-5. Click **Save Settings**. The application will restart automatically to apply changes.
+1. Open `http://localhost:8080/settings`.
+2. Enter your **Audiobookshelf Server URL**, **API Token**, and **Library ID**.
+3. Add any optional services you want to use:
+   - KOSync
+   - Booklore
+   - Storyteller
+   - Hardcover
+4. If you mounted Storyteller assets, set **Storyteller Assets Path** to `/storyteller`.
+5. Click **Save Settings** and wait for the app to restart.
 
 ---
 
-## Step 6: Create Your First Mapping
+## Step 6: Create your first mapping
 
-1. Go to the **Match** page (or click "Single Match" on the dashboard).
-2. **Search** for an audiobook (e.g., "The Martian").
-3. **Select** the audiobook from the first column.
-4. (Optional) Select a **Storyteller** artifact if one was found. If not, choose "None".
-5. **Select** the standard EPUB file from the third column.
-6. Click **Create Mapping**.
+You can start in either of these ways:
 
-That's it! The system will now automatically sync progress between your audiobook and ebook every 5 minutes (default).
+### Suggestions
+
+1. Open **Suggestions**.
+2. Click **Scan Library**.
+3. Review the likely pairs.
+4. Add the good ones to the queue.
+5. Click **Process All**.
+
+### Add Book
+
+1. Open **Add Book**.
+2. Pick an ABS audiobook, a Booklore audiobook, or leave audio on **None / Skip** for an ebook-only link.
+3. Optionally pick a Storyteller title.
+4. Pick the standard ebook.
+5. Click **Create Mapping**.
+
+That is enough to get syncing started. The normal background cycle runs every 5 minutes by default, and instant sync can react faster when supported by the source.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,89 +13,80 @@
 
 ---
 
-## 📖 What is it?
+## What is it?
 
-**ABS-KoSync Enhanced** is a powerful, automated synchronization engine designed to unify your reading and listening experiences. It bridges the gap between audiobooks and ebooks, ensuring that whether you're listening on the go or reading on your e-reader, your progress is always perfectly aligned.
+**ABS-KoSync Enhanced** is a self-hosted sync engine for audiobooks and ebooks. It keeps your reading and listening position aligned across multiple apps, whether the source is Audiobookshelf, Booklore, KOReader, or Storyteller.
 
-### 🔄 Five-Way Synchronization
-
-The system keeps your progress in sync across all major platforms:
+### Five-Way Synchronization
 
 | Platform | Type | Capability |
 | :--- | :--- | :--- |
-| **Audiobookshelf** | Audiobooks | Full Read/Write Sync |
-| **KOReader / KOSync** | Ebooks | Full Read/Write Sync |
-| **Storyteller** | Enhanced Reader | Full Read/Write Sync (REST API) |
-| **Booklore** | Library Management | Full Read/Write Sync |
-| **Hardcover.app** | Book Tracking | Write-Only Tracking (Auto-Update Finished Status) |
+| **Audiobookshelf** | Audiobooks + optional ebooks | Full read/write sync |
+| **KOReader / KOSync** | Ebooks | Full read/write sync |
+| **Storyteller** | Read-along reader | Full read/write sync |
+| **Booklore** | Ebooks + audiobooks | Full read/write sync |
+| **Hardcover.app** | Reading tracker | Write-only tracking |
 
 ---
 
-## ✨ Features
+## Features
 
-### 🚀 Core Sync Engine
+### Core Sync Engine
 
-- **Robust Synchronization**: Syncs progress bi-directionally between Audiobookshelf and KOReader.
-- **Split-Port Security**: Optionally run the sync service on a separate port from the admin dashboard for safe internet exposure.
-- **Forge**: Active tooling to prepare and trigger "Read-Along" books for Storyteller.
-- **Multi-Device Support**: Handles multiple KOReader devices seamlessly.
-- **Multi-Platform Support**: Synchronize progress across five different ecosystems simultaneously.
-- **Smart Conflict Resolution**: "Furthest progress wins" logic with built-in anti-regression protection.
-- **Rich Positioning**: Support for XPath, CSS selectors, and EPUB CFI for pixel-perfect positioning.
-- **Storyteller Native Alignment**: For books with Storyteller forced-alignment transcripts, timestamp-to-text mapping is built directly from `wordTimeline` data.
-- **Resumable Jobs**: Background transcription jobs resume automatically if interrupted.
+- **Five-way sync** across Audiobookshelf, KOReader, Storyteller, Booklore, and Hardcover.
+- **Flexible source support**: use Audiobookshelf or Booklore as the audio source, or create ebook-only links when no audiobook is needed.
+- **Split-port security** so the KOSync endpoint can be exposed separately from the dashboard.
+- **Smart conflict handling** with anti-regression guardrails and a deadband to avoid tiny cross-format bounce-backs.
+- **Rich locators** using timestamps, href/fragment data, XPath, and EPUB CFI where available.
+- **Storyteller-first alignment** when valid Storyteller transcript assets exist, followed by SMIL and Whisper fallback.
+- **Resumable jobs** for background processing and transcript work.
 
-### 🖥️ Management Web UI
+### Management Web UI
 
-- **Real-Time Dashboard**: Monitor progress and sync status across all your books.
-- **Advanced Matcher**: Manual mapping for complex titles or different editions.
-- **Batch Processing**: Queue and process multiple books for synchronization in bulk.
-- **Library Suggestions**: Scan for likely audiobook + ebook pairs and send the good ones straight to your queue.
-- **Forge**: Automated workflow for Storyteller readaloud generation.
-- **Dynamic Settings**: Configure your entire system from the Web UI with instant hot-reloading.
+- **Dashboard** for live sync status, direct service links, and source badges.
+- **Add Book** for ABS, Booklore, Storyteller, or ebook-only matching flows.
+- **Batch Match** for queue-based review and bulk linking.
+- **Library Suggestions** for background scanning, review, and queue building.
+- **Forge** for Storyteller read-along preparation.
+- **Dynamic Settings** with automatic restart after saving.
 
-### 🤖 Automation & Reliability
+### Automation and Reliability
 
-- **Background Daemon**: Configurable sync intervals for hands-off operation.
-- **Auto-Organization**: Automatic addition to ABS collections and Booklore shelves.
-- **Error Recovery**: Automatic retry logic for failed transcription or sync tasks.
+- **Background daemon** with configurable polling.
+- **Instant sync** from ABS playback events and KOReader pushes when enabled.
+- **Per-client polling** for Storyteller and Booklore.
+- **Booklore cache refresh** and Storyteller backfill maintenance tools.
 
 ---
 
-## 🛠️ How It Works
+## How It Works
 
-The sync engine operates on a sophisticated event-driven architecture (V2):
-
-1. **Triggers**: Changes are detected via **Instant Pushes** (Internal KOSync) or **Periodic Polling** (ABS/Booklore).
-2. **Normalization**: Progress from all clients is normalized into a common format (timestamp or percentage).
-3. **Discrepancy Check**: The system identifies if a significant change has occurred.
-4. **Leader Election**: The client with the most recent explicit progress becomes the "Leader".
-5. **Translation**: If the Leader is an Audiobook and followers are Ebooks (or vice-versa), the system resolves position via the best available transcript source:
-   - Storyteller forced-alignment transcript (direct mapping),
-   - then SMIL,
-   - then Whisper fallback.
-6. **Propagation**: The new position is sent to all other configured clients.
+1. **Triggers**: the bridge reacts to ABS playback events, KOReader pushes, or scheduled polling.
+2. **Normalization**: timestamps, percentages, CFI, and Storyteller locators are converted into a shared timeline.
+3. **Change check**: tiny gaps are ignored so harmless drift does not cause sync churn.
+4. **Leader election**: the bridge picks the most trustworthy current position.
+5. **Translation**: if audio and text need to cross formats, the bridge resolves that position through Storyteller transcript data, SMIL, or Whisper alignment.
+6. **Propagation**: the resolved position is written back to every applicable client for that mapping.
 
 ```mermaid
 graph TD
     A[Start Sync Cycle] --> B{Trigger?}
-    B -->|Poll Timer| C[Fetch Progress (All Clients)]
-    B -->|Instance Sync| C
-    B -->|KoSync Push| C
-    C --> D[Normalize Positions]
-    D --> E{Leader Check}
-    E -->|Significant Delta| F[Identify Leader]
-    E -->|No Change| A
-    F --> G{Format Mismatch?}
-    G -->|Yes| H[Audio <--> Text Translation]
-    G -->|No| I[Direct Sync]
-    H --> J[Calculate New Position]
+    B -->|Poll Timer| C[Fetch Progress]
+    B -->|Instant Sync| C
+    B -->|KOReader Push| C
+    C --> D[Normalize to Shared Timeline]
+    D --> E{Real Change?}
+    E -->|No| A
+    E -->|Yes| F[Choose Stable Leader]
+    F --> G{Audio/Text Translation Needed?}
+    G -->|Yes| H[Use Storyteller, SMIL, or Whisper Alignment]
+    G -->|No| I[Direct Update]
+    H --> J[Generate Locator or Timestamp]
     I --> J
-    J --> K[Update Follower Clients]
-    K --> L[Save State to DB]
+    J --> K[Update Applicable Clients]
+    K --> L[Save State]
     L --> A
 ```
 
-!!! note "Audio to Text Conversion"
-    For Storyteller-transcript books, the system can map timestamps directly to character offsets without fuzzy search.
-    For non-Storyteller transcript paths, it still uses transcript text extraction and fuzzy search in the EPUB.
+!!! note "Storyteller and Booklore"
+    Storyteller transcript assets improve locator quality, and Booklore can now act as either an ebook target or the audiobook source for a mapping.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,64 +2,72 @@
 
 ## Common Issues
 
-### Books not showing up?
+### Books are not showing up
 
-- **Check Volumes**: Ensure your `/books` volume is correctly mounted in `docker-compose.yml`. The path inside the container must match where you are looking.
-- **Permissions**: Ensure the user running the container has read permissions for the ebook files.
+- Make sure your `/books` volume is mounted correctly in `docker-compose.yml`.
+- Check file permissions for the user running the container.
+- If the missing books should come from Booklore, run **Settings -> Refresh Booklore Cache**.
 
-### Storyteller transcripts not found?
+### Suggestions look stale or new imports are missing
 
-- **Issue**: You know transcript files exist on disk, but logs show "Storyteller transcripts not found" or "directory missing".
-- **Checks**:
-  - Verify the Docker volume is mounted: host storyteller assets -> container `/storyteller/assets`.
-  - In Settings, set **Storyteller Assets Path** to `/storyteller` (not `/storyteller/assets`).
-  - Confirm expected structure inside container: `/storyteller/assets/{title}/transcriptions/*.json`.
+- A normal **Scan Library** run reuses cached results on purpose.
+- Use **Full Refresh** after large imports, removals, or metadata cleanup.
+- If Booklore titles are missing from Suggestions, refresh the Booklore cache first.
 
-### Storyteller backfill shows invalid chapter format?
+### Booklore audiobook links are not syncing
 
-- **Issue**: Logs mention invalid storyteller chapter format for a chapter JSON file.
-- **Cause**: The file name pattern matches, but JSON is not Storyteller `wordTimeline` format.
-- **Behavior**: Backfill now skips these books as missing/incompatible instead of failing the whole run.
+- Confirm **Booklore** is enabled and the audiobook still exists in the selected Booklore library.
+- Run **Refresh Booklore Cache** after moving, rescanning, or replacing Booklore items.
+- If the old Booklore item was deleted and recreated with a new ID, rematch that book.
 
-### Transcription taking too long?
+### Storyteller transcripts are not found
 
-- **Model Size**: Try setting `WHISPER_MODEL=tiny` in the Settings page.
-- **Hardware**: Transcription is CPU-intensive. If possible, enable [GPU Acceleration](#gpu-acceleration-optional).
+- Verify the Docker volume is mounted as host Storyteller assets -> container `/storyteller/assets`.
+- In Settings, set **Storyteller Assets Path** to `/storyteller`, not `/storyteller/assets`.
+- Confirm the expected structure exists inside the container: `/storyteller/assets/{title}/transcriptions/*.json`.
 
-### KOSync Port Not Working
+### Storyteller transcripts are still rejected
 
-- **Issue**: You set `KOSYNC_PORT` but cannot connect on that port.
-- **Solution**: Ensure you have mapped the port in your `docker-compose.yml`.
-  - Example: `ports: - "5758:5758"` if `KOSYNC_PORT=5758`.
+- The bridge now accepts more Storyteller filename layouts, but the files still need real Storyteller timeline data.
+- Each chapter JSON should contain `wordTimeline` or compatible Storyteller timeline data.
+- If the filenames are right but the data format is wrong, the bridge will skip those files and fall back to SMIL or Whisper.
 
-### WhisperCpp Model Ignored
+### KOSync split-port mode is not working
 
-- **Issue**: WhisperCpp seems to use 'large-v3' even if I select 'small' in the UI.
-- **Solution**: Previous versions had a bug where the model parameter wasn't sent. This is fixed in the latest release.
-  - Ensure `WHISPER_MODEL` is set in your environment variables (e.g., `WHISPER_MODEL=small`).
-  - Check the logs to see the request URL and data being sent.
+- If you set `KOSYNC_PORT`, you also need to map that same port in Docker.
+- Example:
 
-### Syncing backwards?
+```yaml
+ports:
+  - "8080:5757"
+  - "5758:5758"
+```
 
-The system includes anti-regression logic, but if you switch devices rapidly, issues can occur.
+### Transcription is taking too long
 
-- **Solution**: Go to the Dashboard and click **"Reset Progress"** for the affected book. This clears the stored sync state without affecting your external accounts.
+- Use a smaller local Whisper model such as `tiny`.
+- If you have an NVIDIA GPU, enable GPU support as described in the [Configuration Guide](configuration.md#gpu-support-optional).
+- If Storyteller transcript assets are available, configure them so the bridge can skip Whisper entirely for those books.
 
 ---
 
 ## Logs
 
-Documentation and live logs are available directly in the Web UI.
-Alternatively, you can view them via the terminal:
+You can inspect logs in the web UI or from the terminal:
 
 ```bash
 docker compose logs -f
 ```
 
-Look for lines starting with `[INFO]` or `[ERROR]`.
+Useful places to look:
+
+- Match and Suggestions actions
+- Storyteller transcript ingest
+- Booklore cache refreshes
+- Background job failures
 
 ---
 
 ## GPU Acceleration
 
-See the **[Configuration Guide](configuration.md#gpu-support-optional)** for instructions on enabling NVIDIA GPU acceleration.
+See the **[Configuration Guide](configuration.md#gpu-support-optional)** for NVIDIA GPU setup instructions.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,227 +1,233 @@
 # User Guide
 
-This guide covers the features and workflows available in the ABS-KoSync Enhanced Web UI.
+This guide covers the main workflows in the ABS-KoSync Enhanced web UI.
 
 ## Dashboard
 
-The **Dashboard** is your command center. It shows:
+The **Dashboard** is the main status view for your library.
 
-- **Active Syncs**: A list of all books currently being tracked.
-- **Sync Status**: Real-time progress bars for each book.
-- **Recent Activity**: A log of the latest sync actions.
-- **Single Match**: Manually link an audiobook to an ebook.
-- **Batch Match**: Switch to the Batch Matcher view.
-- **Library Suggestions**: Scan your library for likely pairs and review them quickly.
+It shows:
+
+- **Active Syncs** for every tracked mapping
+- **Unified Progress** across all connected clients
+- **Source badges** so you can tell whether the audio side is coming from Audiobookshelf or Booklore
+- **Direct links** into supported services, including Booklore audio when a mapping uses it
+- Quick access to **Add Book**, **Batch Match**, **Suggestions**, **Forge**, **Settings**, and **Logs**
+
+If a book is significantly out of sync, the card is highlighted so you can spot it quickly.
 
 ---
 
 ## Sync Modes
 
-When creating a mapping, the system operates in one of two modes:
+Each mapping runs in one of two modes.
 
-### 1. Audiobook Sync (Default)
+### 1. Audiobook Sync
 
-Links an **Audiobook** in ABS to an **Ebook** in KOReader (and other platforms).
+This is the normal mode when a mapping has an audiobook source.
 
-- **Mechanism**: Transcription-based alignment.
-- **Use Case**: Listening on phone, reading on Kindle/Kobo.
-- **Process**:
-  - If Storyteller forced-alignment transcripts are available, they are ingested and used first.
-  - Otherwise, the system falls back to SMIL extraction, then Whisper transcription.
+- The audio source can be **Audiobookshelf** or **Booklore**.
+- The text side can include a standard ebook, a Storyteller artifact, or both.
+- The bridge prefers Storyteller transcript timing when available, then falls back to SMIL, then Whisper.
+
+Use this when you want listening and reading progress to stay aligned.
 
 ### 2. Ebook-Only Sync
 
-Links your ebook status across platforms.
+This mode tracks reading progress without attaching an audiobook source.
 
-- **Mechanism**: Direct percentage/text position sync.
-- **Triggers**:
-  - **KOReader**: Instant — syncs the moment you close or pause reading.
-  - **Audiobookshelf**: Near-instant (~30s) during audiobook playback.
-  - **Booklore/Others**: Picked up on the regular background sync (every ~5 mins).
-- **Supported Clients**:
-  - **KOReader** (via Internal KOSync Server)
-  - **Booklore** (Requires `BOOKLORE_ENABLED=true`)
-  - **ABS Ebook** (Requires `SYNC_ABS_EBOOK=true`)
-- **Hardcover**: Updates Hardcover.app presence (if configured).
+- Create it by leaving audio on **None / Skip** in **Add Book**.
+- You can still link a standard ebook, a Storyteller title, or both.
+- Ebook-only links skip audiobook preparation work, so they activate faster.
+
+Use this when you only want reading sync between KOReader, Booklore, Storyteller, and optional ABS ebook progress.
 
 ---
 
 ## Real-Time Sync
 
-By default, the bridge checks all your clients for progress changes every 5 minutes. **Real-time sync** makes this happen much faster — within seconds instead of minutes.
+The bridge still runs a normal background sync every 5 minutes by default, but it can also react much faster when supported.
 
-### How It Works
+### Instant triggers
 
-There are two ways progress can sync instantly:
+1. **Audiobookshelf playback**: when playback changes in Audiobookshelf, the bridge can sync shortly after the activity settles.
+2. **KOReader push**: if you use the built-in KOSync bridge, KOReader can push progress directly to the bridge.
 
-1. **Audiobook Playback** — When you listen to an audiobook in Audiobookshelf (web player, mobile app, etc.), the bridge detects the playback activity automatically. Once you stop or pause for about 30 seconds, it syncs your position to all your other platforms right away.
+### Per-client polling
 
-2. **KOReader Reading** — If you use the built-in KoSync server (configured in Settings), KOReader sends your reading position to the bridge the moment you close a book or turn the page. The bridge then pushes that position to all your other clients immediately.
+Storyteller and Booklore can also use their own polling intervals:
 
-> [!NOTE]
-> The regular 5-minute background sync still runs as a safety net. Real-time sync just adds faster updates on top of it.
+- **Global** uses the normal background cycle.
+- **Custom** lets that client be checked on its own schedule.
 
-### Disabling Instant Sync
-
-If you prefer to rely solely on the background poll (e.g., to reduce network activity), you can turn off instant sync entirely from **Settings → Sync Behavior → Instant Sync**. This disables the ABS socket listener and the KoSync push trigger. The global poll cycle continues as normal.
-
-### Per-Client Polling (Storyteller & Booklore)
-
-By default, Storyteller and Booklore are only checked during the global sync cycle. If you make changes directly in one of those apps and want the bridge to notice faster, you can configure a **custom poll interval** for that client under **Settings → Sync Behavior → Per-Client Polling**.
-
-Set the mode to **Custom** and choose how often (in seconds) the bridge should check that client for position changes. Only books with an active mapping are checked, and a full sync is triggered only when a real change is detected — so the overhead is minimal.
+This is useful when you often read directly in Storyteller or Booklore and want the bridge to notice sooner.
 
 ---
 
-## Matcher
+## Add Book
 
-The **Matcher** is where you link an Audiobookshelf audiobook to its corresponding text format. The new **3-Column Interface** makes it easy to select the best source for your needs.
+**Add Book** is the main manual linking tool.
 
-### 1. The 3-Step Flow
+### Step 1: Choose audio
 
-#### Step 1: Select Audiobook (Required)
+You can choose:
 
-First, search for your audiobook. The system queries your ABS library. Select the correct title to proceed.
+- An **Audiobookshelf audiobook**
+- A **Booklore audiobook**
+- **None / Skip** for an ebook-only link
 
-#### Step 2: Storyteller Link (Optional)
+The source badge on each card tells you where the audiobook came from.
 
-If you use **Storyteller**, the system will try to find a matching "Artifact" (the processed ebook) in your Storyteller library.
+### Step 2: Choose Storyteller (optional)
 
-- **Match Found**: Select the card to link it via its precise UUID.
-- **No Match/Incorrect**: Select **"None - Do not link"**. This tells the system to ignore Storyteller for this book and use the standard ebook instead.
+If Storyteller is configured, you can also link a Storyteller title.
 
-> [!TIP]
-> **Tri-Link Feature**: You can link *both* a Storyteller Artifact (for voice-synced reading) AND a standard Retail EPUB (for lightweight reading on other devices). The progress will sync between all three!
+- Pick the Storyteller card when you want read-along support.
+- Leave it on **None / Skip** if you only want the standard ebook.
 
-#### Step 3: Select Standard Ebook (Fallback)
+### Step 3: Choose the standard ebook
 
-Select the standard EPUB file you want to use for regular sync. The system searches multiple sources:
+The bridge can pull ebook choices from:
 
-1. **ABS Direct**: Checks if the Audiobook item in ABS already contains an EPUB file.
-2. **Booklore**: Checks your curated metadata database.
-3. **CWA**: Searches your Calibre-Web Automated OPDS feed.
-4. **ABS Search**: Searches other ABS libraries for a matching title.
-5. **Filesystem**: Scans your local `/books` directory.
+1. Audiobookshelf ebook files
+2. Booklore
+3. CWA
+4. Local `/books` files
 
-**Source Badges**: Look for the colored badges on ebook cards to know where the file is coming from (e.g., `BOOKLORE`, `ABS`, `CWA`, `LOCAL`).
+### Final actions
 
-### Creating the Mapping
+- **Create Mapping** creates the link immediately.
+- **Forge & Match** stages the book for Storyteller processing first, then finishes the link when Forge completes.
 
-Once you've made your selections, click **Create Mapping**. The system will download any necessary files (from CWA/ABS) and begin the alignment process.
-
-If Storyteller transcript files exist in your configured assets path, the mapping uses those directly and skips SMIL/Whisper for that book.
-
-### Batch Match
-
-For users with large libraries, the **Batch Matcher** speeds up the process.
-
-1. **Queue**: Add multiple books to the matching queue.
-2. **Auto-Suggest**: The system will attempt to find the best matching EPUB for each audiobook based on filename similarity.
-3. **Confirm**: Review the suggestions and confirm them in bulk.
+If you skip audio, **Create Mapping** makes an ebook-only link instead.
 
 ---
 
-## Forge (Storyteller Integration)
+## Batch Match
 
-The **Forge** is a powerful tool designed to prepare "Synced Books" for **Storyteller**. It handles the complex file management required to get audio and text aligned.
+**Batch Match** is the queue-based version of Add Book.
 
-### What it does
+Use it when you want to review multiple links and process them together.
 
-1. **Staging**: Copies audio files (from ABS) and ebook files (from Booklore/Local/CWA) to a temporary staging area in the correct `StorytellerLibrary/Title/` structure.
-2. **Processing**: Automatically triggers Storyteller to scan and process the new book.
-3. **Cleanup**: Monitors the output folder. Once Storyteller finishes generating the "Readaloud" ebook, Forge automatically deletes the source files to save space.
-
-### Two Ways to Forge
-
-#### 1. Auto-Forge (from the Matcher — Recommended)
-
-When creating a mapping in the **Matcher**, you can choose **"Forge & Match"** instead of "Create Mapping". This:
-
-- Stages and processes the book through Storyteller automatically.
-- **Automatically creates the sync mapping** once Storyteller finishes, linking the ABS audiobook, the original EPUB, and the new Storyteller artifact in one step.
-
-This is the recommended workflow for most users.
-
-#### 2. Manual Forge (from the Forge page)
-
-The standalone **Forge** page (`/forge`) lets you stage and process a book through Storyteller without creating a sync mapping. Use this if you want to prepare a book for Storyteller independently and then link it manually via the Matcher later.
-
-Forge staging uses `PROCESSING_DIR` if configured, and defaults to `/tmp` if not set. This staging path does not require a dedicated Docker volume mount.
-
-### When to use it
-
-Use Forge if you want the **immersive Read-Along experience** in the Storyteller app.
-
-> [!IMPORTANT]
-> **Active Processing**: Forge is an **active** tool. It communicates directly with the Storyteller API to trigger processing. Ensure your Storyteller integration is configured in Settings.
-
----
-
-## Auto-Discovery (Internal KOSync Only)
-
-If you configure your KOReader devices to sync directly to **this bridge** (using the Built-in KOSync Bridge), the system can automatically detect and link books for you. This is the **only way** to automatically create Ebook-Only links without manual approval.
-
-> [!TIP]
-> **Built-in KOSync Bridge**: In the Settings page, under **KOSync Integration**, enable the integration and check **"Use Built-in KOSync Bridge"**. The UI will display the URL to enter into KOReader's sync settings.
-
-### How it works
-
-1. **Push**: You open a book in KOReader. It pushes progress to the bridge instantaneously.
-2. **Match**: The bridge looks for a matching audiobook in your ABS library.
-3. **Action**:
-    - **Audiobook Found**: Creates a **Suggestion** on your Dashboard (requires approval).
-    - **No Audiobook Found**: Automatically creates an **Ebook-Only Sync** mapping, allowing immediate cross-device tracking.
-
-> [!IMPORTANT]
-> **Trigger Constraint**: This "Auto-Creation" feature requires using the **Internal KOSync Server**. Polling traditional services (ABS/Booklore) will simply create **Suggestions**, which always require manual approval.
+- Queue entries can use **Audiobookshelf** or **Booklore** as the audio source.
+- You can attach a standard ebook, a Storyteller title, or both.
+- Queue items created from **Suggestions** land here too.
 
 ---
 
 ## Suggestions
 
-The **Library Suggestions** page helps you find books that are not linked yet.
+The **Suggestions** page is a review workspace for likely matches that are not linked yet.
 
 ### What it does
 
-- Scans your library and shows likely audiobook + ebook pairs.
-- Lets you review each suggestion before anything is linked.
-- Sends approved picks into the same batch queue used by Batch Match.
+- Scans unmatched titles in your library
+- Shows likely audiobook + ebook pairs
+- Lets you review one suggestion at a time
+- Sends approved picks into the same queue used by Batch Match
 
-### How to use it
+### Scan options
 
-1. Open **Suggestions** in the top navigation.
-2. Click **Scan Library** to load suggestions.
-3. Click a suggestion to review the audiobook and ebook pick.
-4. Click **Add to Queue** for the ones you want.
-5. Click **Process All** to create the mappings.
+- **Scan Library** reuses cached results so repeat scans are faster.
+- **Full Refresh** ignores the previous cache and rescans the whole unmatched library.
 
-### Buttons
+### Actions
 
-- **Scan Library**: Runs a normal scan and keeps previous scan work so repeat scans are faster.
-- **Full Refresh**: Rechecks your whole unmatched library from scratch.
-- **Dismiss**: Hides a suggestion for now.
-- **Never**: Hides a suggestion permanently so it will not come back.
+- **Add to Queue** sends the current pick to the batch queue.
+- **Dismiss** hides a suggestion for now.
+- **Never** hides it permanently so it does not come back.
+
+Suggestions can create:
+
+- Standard ABS-backed links
+- Booklore-audio links
+- Ebook-only links
+- Storyteller-only links when that is enough for the workflow you want
+
+---
+
+## Forge
+
+**Forge** prepares books for Storyteller read-along processing.
+
+### What Forge stages
+
+- Audio from **Audiobookshelf** or **Booklore**
+- Text from **Booklore**, **CWA**, **local files**, or **Audiobookshelf**
+
+### Two ways to use it
+
+1. **Forge & Match from Add Book**
+   - Starts the Storyteller workflow
+   - Finishes the mapping when processing completes
+
+2. **Standalone Forge page**
+   - Stages a Storyteller-ready book without creating a sync mapping yet
+
+Forge uses `PROCESSING_DIR` if you set it, and falls back to `/tmp` if you do not.
+
+---
+
+## Storyteller Transcript Tools
+
+When Storyteller transcript assets are available, the bridge can use them directly for better timing and locator quality.
+
+### Storyteller Backfill
+
+Use **Settings -> Storyteller Backfill** to:
+
+- Re-scan all Storyteller-linked books
+- Ingest any newly available transcript assets
+- Rebuild alignment data without rerunning Whisper
+
+This is useful after importing old Storyteller assets or fixing your Storyteller assets mount.
+
+---
+
+## Booklore Audio
+
+Booklore is no longer only an ebook target.
+
+You can now use **Booklore audiobooks** in:
+
+- **Add Book**
+- **Batch Match**
+- **Suggestions**
+- **Forge**
+- The main **Dashboard**
+
+If Booklore imports change and results look stale, open **Settings** and run **Refresh Booklore Cache**.
+
+---
+
+## Auto-Discovery
+
+If KOReader devices sync directly to the built-in KOSync bridge, the system can discover new reading activity automatically.
+
+### What happens
+
+1. KOReader pushes progress to the bridge.
+2. The bridge looks for a matching audiobook source.
+3. One of two things happens:
+   - If a likely audio match exists, the bridge creates a **Suggestion** for you to review.
+   - If no audiobook source is found, it can create an **ebook-only** workflow instead.
+
+Suggestions still require approval before a real mapping is created.
 
 ---
 
 ## Management
 
-### Editing Mappings
+### Delete mapping
 
-You can edit or delete existing mappings from the Dashboard.
+Stops syncing that book. It does not delete your original media files.
 
-- **Delete**: Stops syncing the book. Does NOT delete the files.
-- **Reset Progress**: Clears the stored sync state if things get out of whack.
+### Reset progress
 
-### Storyteller Backfill
+Clears the stored sync state for a mapping.
 
-Use **Settings -> Storyteller Backfill** to bulk re-check all Storyteller-linked books:
+If **Regenerate Missing Data on Reset** is enabled, the bridge can also rebuild missing alignment data when needed.
 
-- Ingests any newly available Storyteller transcript files.
-- Sets transcript source to Storyteller where valid transcripts exist.
-- Rebuilds alignment maps from Storyteller word timelines (no Whisper/SMIL recompute).
-- Leaves books unchanged when transcripts are missing or incompatible.
+### Logs
 
-### Viewing Logs
-
-Navigate to **Logs** in the sidebar to view the live application logs. This is useful for troubleshooting why a specific book might not be syncing.
+Open **Logs** to inspect live application logs for matching, syncing, Storyteller ingest, Booklore refreshes, and background jobs.

--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -92,19 +92,101 @@ class ABSClient:
                 all_audiobooks.extend(r_items)
             return all_audiobooks
         except Exception as e:
-            logger.error(f"❌ Exception fetching audiobooks: {e}")
+            logger.error(f"ABS: Exception fetching audiobooks: {e}")
             return []
+
+    @staticmethod
+    def _item_has_audio(item: dict) -> bool:
+        media = (item or {}).get('media', {}) or {}
+        audio_files = media.get('audioFiles') or []
+        if isinstance(audio_files, list) and len(audio_files) > 0:
+            return True
+        num_audio_files = media.get('numAudioFiles')
+        try:
+            if int(num_audio_files or 0) > 0:
+                return True
+        except (TypeError, ValueError):
+            pass
+        duration = media.get('duration')
+        try:
+            return float(duration or 0) > 0
+        except (TypeError, ValueError):
+            return False
 
     def get_audiobooks_for_lib(self, lib: str):
         if not self.is_configured(): return []
         self._update_session_headers()
         items_url = f"{self.base_url}/api/libraries/{lib}/items"
-        params = {"mediaType": "audiobook"}
-        r_items = self.session.get(items_url, params=params, timeout=self.timeout)
+
+        # Preferred path for dedicated audiobook libraries.
+        r_items = self.session.get(items_url, params={"mediaType": "audiobook"}, timeout=self.timeout)
         if r_items.status_code == 200:
-            return r_items.json().get('results', [])
-        logger.warning(f"⚠️ ABS - Failed to fetch audiobooks for library '{lib}'")
+            filtered = r_items.json().get('results', []) or []
+            if filtered:
+                return filtered
+
+        # Fallback for ABS "book" libraries where audio and ebook content are mixed.
+        r_fallback = self.session.get(items_url, timeout=self.timeout)
+        if r_fallback.status_code == 200:
+            all_items = r_fallback.json().get('results', []) or []
+            return [item for item in all_items if self._item_has_audio(item)]
+
+        logger.warning(f"ABS: Failed to fetch audiobooks for library '{lib}'")
         return []
+
+    def search_audiobooks(self, query: str, library_id: str = None):
+        """Search libraries for audiobook-capable items."""
+        if not self.is_configured():
+            return []
+        self._update_session_headers()
+        results = []
+        seen_ids = set()
+        try:
+            r_libs = self.session.get(f"{self.base_url}/api/libraries", timeout=self.timeout)
+            if r_libs.status_code != 200:
+                logger.warning(f"ABS Audio Search: Failed to get libraries (status {r_libs.status_code})")
+                return []
+
+            libraries = r_libs.json().get('libraries', []) or []
+            if library_id:
+                libraries = [lib for lib in libraries if str(lib.get('id')) == str(library_id)]
+
+            logger.debug(f"ABS Audio Search: Found {len(libraries)} libraries to search")
+            for lib in libraries:
+                lib_name = lib.get('name', 'Unknown')
+                lib_type = lib.get('mediaType', 'unknown')
+                logger.debug(f"   Searching audio in library '{lib_name}' (type: {lib_type})")
+                search_url = f"{self.base_url}/api/libraries/{lib['id']}/search"
+                r = self.session.get(search_url, params={'q': query, 'limit': 20}, timeout=self.timeout)
+                if r.status_code != 200:
+                    continue
+
+                data = r.json() or {}
+                items = data.get('book', []) or data.get('libraryItem', []) or data.get('results', []) or []
+                hit_count = 0
+                for item in items:
+                    lib_item = item.get('libraryItem', item) if isinstance(item, dict) else {}
+                    if not isinstance(lib_item, dict):
+                        continue
+                    item_id = lib_item.get('id') or item.get('id')
+                    if not item_id or item_id in seen_ids:
+                        continue
+                    if not self._item_has_audio(lib_item):
+                        # ABS search in mixed "book" libraries can return skeletal matches
+                        # without media/audio fields. Re-hydrate details before rejecting.
+                        details = self.get_item_details(item_id)
+                        if not details or not self._item_has_audio(details):
+                            continue
+                        lib_item = details
+                    seen_ids.add(item_id)
+                    results.append(lib_item)
+                    hit_count += 1
+                logger.debug(f"   ABS Audio Search: Found {hit_count} audio hits in library '{lib_name}'")
+
+            return results
+        except Exception as e:
+            logger.error(f"ABS: Error searching audiobooks: {e}")
+            return []
 
     def get_audio_files(self, item_id):
         if not self.is_configured(): return []
@@ -689,3 +771,4 @@ class KoSyncClient:
             logger.error(f"❌ Failed to update KoSync: {e}")
             return False
 # [END FILE]
+

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -349,6 +349,36 @@ class BookloreClient:
         with self._cache_lock:
             return list(self._book_id_cache.items())
 
+    def _dedupe_book_results(self, books):
+        canonical_by_id = {
+            str(bid): book_info
+            for bid, book_info in self._snapshot_book_id_items()
+            if bid is not None and isinstance(book_info, dict)
+        }
+        deduped = []
+        seen = set()
+
+        for book_info in books:
+            if not isinstance(book_info, dict):
+                continue
+
+            bid = book_info.get('id')
+            if bid is not None:
+                canonical = canonical_by_id.get(str(bid))
+                if canonical is not None:
+                    book_info = canonical
+                key = f"id:{bid}"
+            else:
+                key = f"file:{(book_info.get('fileName') or '').lower()}"
+
+            if key in seen:
+                continue
+
+            seen.add(key)
+            deduped.append(book_info)
+
+        return deduped
+
     def _evict_cached_book(self, book_id=None, filename=None, reason=None):
         """Remove a stale Booklore entry from memory and persistent cache."""
         target_id = str(book_id) if book_id is not None else None
@@ -508,17 +538,59 @@ class BookloreClient:
         )
         return str(raw_book_type or '').upper()
 
+    @staticmethod
+    def _iter_audio_format_candidates(book):
+        if not isinstance(book, dict):
+            return []
+
+        candidates = []
+        primary_file = book.get('primaryFile') or {}
+        if isinstance(primary_file, dict):
+            candidates.append(primary_file)
+
+        for key in ('bookFiles', 'alternativeFormats', 'supplementaryFiles'):
+            entries = book.get(key) or []
+            if isinstance(entries, list):
+                candidates.extend(entry for entry in entries if isinstance(entry, dict))
+
+        return candidates
+
+    @staticmethod
+    def _has_audiobook_metadata(book):
+        if not isinstance(book, dict):
+            return False
+
+        audiobook_metadata = book.get('audiobookMetadata')
+        if not isinstance(audiobook_metadata, dict):
+            metadata = book.get('metadata') or {}
+            audiobook_metadata = metadata.get('audiobookMetadata') if isinstance(metadata, dict) else None
+        if not isinstance(audiobook_metadata, dict):
+            return False
+
+        return any(
+            audiobook_metadata.get(key) is not None
+            for key in ('durationSeconds', 'durationMs', 'chapterCount', 'chapters')
+        )
+
+    @staticmethod
+    def _has_audio_shape_fields(book):
+        if not isinstance(book, dict):
+            return False
+        return any(
+            key in book
+            for key in ('alternativeFormats', 'supplementaryFiles', 'audiobookMetadata')
+        )
+
     def _book_supports_audiobook(self, book):
         if not isinstance(book, dict):
             return False
         if self._get_book_type(book) == 'AUDIOBOOK':
             return True
-        primary_file = book.get('primaryFile') or {}
-        if str(primary_file.get('bookType') or '').upper() == 'AUDIOBOOK':
-            return True
-        for file_info in book.get('bookFiles') or []:
+        for file_info in self._iter_audio_format_candidates(book):
             if str(file_info.get('bookType') or '').upper() == 'AUDIOBOOK':
                 return True
+        if self._has_audiobook_metadata(book):
+            return True
         if book.get('audiobookProgress') is not None:
             return True
         return False
@@ -526,10 +598,7 @@ class BookloreClient:
     def _get_audiobook_file_id(self, book):
         if not isinstance(book, dict):
             return None
-        primary_file = book.get('primaryFile') or {}
-        if str(primary_file.get('bookType') or '').upper() == 'AUDIOBOOK':
-            return primary_file.get('id') or primary_file.get('bookFileId')
-        for file_info in book.get('bookFiles') or []:
+        for file_info in self._iter_audio_format_candidates(book):
             if str(file_info.get('bookType') or '').upper() == 'AUDIOBOOK':
                 return file_info.get('id') or file_info.get('bookFileId')
         info_file_id = book.get('audiobookInfo', {}).get('bookFileId') if isinstance(book.get('audiobookInfo'), dict) else None
@@ -875,6 +944,7 @@ class BookloreClient:
         subtitle = metadata.get('subtitle') or ''
         title = metadata.get('title') or detail.get('title') or filename
 
+        stale_filenames = []
         book_info = {
             'id': detail.get('id'),
             'fileName': filename,
@@ -885,6 +955,9 @@ class BookloreClient:
             'bookType': book_type,
             'primaryFile': detail.get('primaryFile'),
             'bookFiles': detail.get('bookFiles'),
+            'alternativeFormats': detail.get('alternativeFormats'),
+            'supplementaryFiles': detail.get('supplementaryFiles'),
+            'audiobookMetadata': metadata.get('audiobookMetadata'),
             'audiobookProgress': detail.get('audiobookProgress'),
             'epubProgress': detail.get('epubProgress'),
             'pdfProgress': detail.get('pdfProgress'),
@@ -895,8 +968,34 @@ class BookloreClient:
 
         # Let's keep it consistent with what we see in database migration
         with self._cache_lock:
+            detail_id = detail.get('id')
+            current_filename = filename.lower()
+            if detail_id is not None:
+                for cached_filename, cached_info in list(self._book_cache.items()):
+                    if cached_filename == current_filename:
+                        continue
+                    cached_id = cached_info.get('id') if isinstance(cached_info, dict) else None
+                    if cached_id is None or str(cached_id) != str(detail_id):
+                        continue
+                    self._book_cache.pop(cached_filename, None)
+                    stale_filenames.append(cached_filename)
+
             self._book_cache[filename.lower()] = book_info
             self._book_id_cache[detail['id']] = book_info
+
+        for stale_filename in stale_filenames:
+            if self.db:
+                try:
+                    self.db.delete_booklore_book(stale_filename)
+                except Exception as e:
+                    logger.error(f"❌ Failed to remove stale Booklore alias '{stale_filename}': {e}")
+
+        if stale_filenames:
+            logger.info(
+                "📚 Booklore: Removed stale filename aliases for book %s: %s",
+                detail.get('id'),
+                stale_filenames,
+            )
 
         # Persist to DB
         if self.db:
@@ -916,11 +1015,11 @@ class BookloreClient:
 
         return None
 
-    def _fetch_and_cache_detail(self, book_id):
+    def _fetch_and_cache_detail(self, book_id, force_refresh=False):
         """Fetch detail for a single book on demand and add it to cache."""
         with self._cache_lock:
             cached = self._book_id_cache.get(book_id)
-            if cached and not cached.get('_needs_detail'):
+            if cached and not cached.get('_needs_detail') and not force_refresh:
                 return cached
 
         token = self._get_fresh_token()
@@ -1019,7 +1118,7 @@ class BookloreClient:
             for bid, book_info in self._book_id_cache.items():
                 if str(bid) not in fully_cached_ids and book_info.get('_needs_detail'):
                     all_books.append(book_info)
-        return all_books
+        return self._dedupe_book_results(all_books)
 
     def search_audiobooks(self, search_term):
         """Search Booklore for audiobook-capable books."""
@@ -1033,8 +1132,16 @@ class BookloreClient:
             if bid in seen_ids:
                 continue
             hydrated = book
+            requires_audio_refresh = (
+                not book.get('_needs_detail')
+                and not self._book_supports_audiobook(book)
+                and not self._has_audio_shape_fields(book)
+            )
             if book.get('_needs_detail') or not self._book_supports_audiobook(book):
-                hydrated = self._fetch_and_cache_detail(bid) or book
+                hydrated = self._fetch_and_cache_detail(
+                    bid,
+                    force_refresh=requires_audio_refresh,
+                ) or book
             if not self._book_supports_audiobook(hydrated):
                 continue
             info = self.get_audiobook_info(bid)
@@ -1084,7 +1191,7 @@ class BookloreClient:
             matches = []
             matched_ids = set()
 
-            for book_info in self._snapshot_book_cache_values():
+            for book_info in self._dedupe_book_results(self._snapshot_book_cache_values()):
                 title = (book_info.get('title') or '').lower()
                 authors = (book_info.get('authors') or '').lower()
                 filename = (book_info.get('fileName') or '').lower()
@@ -1152,7 +1259,7 @@ class BookloreClient:
                     matches.append(hydrated)
                     matched_ids.add(str(hydrated.get('id')))
 
-            return matches
+            return self._dedupe_book_results(matches)
 
         # Avoid expensive full-library refreshes on rapid UI search requests.
         # Keep refresh cadence aligned with other read paths.

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -14,7 +14,11 @@ from src.sync_clients.sync_client_interface import LocatorResult
 
 logger = logging.getLogger(__name__)
 
-BULK_DETAIL_FETCH_LIMIT = 500
+BULK_DETAIL_FETCH_LIMIT = 5000
+STALE_REFRESH_BATCH_SIZE = 1000
+MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE = int(
+    os.getenv("BOOKLORE_MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE", "1200")
+)
 MAX_DETAIL_FETCHES_PER_SEARCH = 20
 
 class BookloreClient:
@@ -715,6 +719,7 @@ class BookloreClient:
                 if str(book.get('id')) in existing_lightweight_ids:
                     self._upsert_lightweight_entry(book)
 
+            new_detail_fetch_count = 0
             if new_book_ids:
                 if len(new_book_ids) > BULK_DETAIL_FETCH_LIMIT:
                     for book in all_books_list:
@@ -727,6 +732,7 @@ class BookloreClient:
                         f"Consider setting BOOKLORE_LIBRARY_ID to reduce scan scope."
                     )
                 else:
+                    new_detail_fetch_count = len(new_book_ids)
                     logger.debug(f"Booklore: Fetching details for {len(new_book_ids)} new books...")
                     token = self._get_fresh_token()
                     if not token:
@@ -745,6 +751,66 @@ class BookloreClient:
                                     self._process_book_detail(detail)
                             except Exception as e:
                                 logger.debug(f"Booklore: Error fetching details: {e}")
+
+            id_snapshot = self._snapshot_book_id_items()
+            if id_snapshot:
+                stale_refresh_budget = max(
+                    0,
+                    MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE - new_detail_fetch_count
+                )
+                if stale_refresh_budget <= 0:
+                    logger.debug(
+                        "Booklore: Skipping stale details refresh this cycle "
+                        f"(new_details={new_detail_fetch_count}, "
+                        f"max_per_cycle={MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE})"
+                    )
+                    stale_ids = []
+                else:
+                    stale_batch_size = min(STALE_REFRESH_BATCH_SIZE, stale_refresh_budget)
+                    logger.debug(
+                        "Booklore: Stale details refresh budget "
+                        f"(new_details={new_detail_fetch_count}, "
+                        f"stale_batch={stale_batch_size}, "
+                        f"max_per_cycle={MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE})"
+                    )
+                stale_candidates = []
+                for bid, book_info in id_snapshot:
+                    if bid is None:
+                        continue
+                    detail_fetched_at = 0
+                    if isinstance(book_info, dict):
+                        raw_detail_fetched_at = book_info.get('_detail_fetched_at', 0)
+                        try:
+                            detail_fetched_at = float(raw_detail_fetched_at or 0)
+                        except (TypeError, ValueError):
+                            detail_fetched_at = 0
+                    stale_candidates.append((detail_fetched_at, bid))
+
+                stale_candidates.sort(key=lambda item: item[0])
+                if stale_refresh_budget > 0:
+                    stale_ids = [bid for _, bid in stale_candidates[:stale_batch_size]]
+                if stale_ids:
+                    logger.debug(
+                        f"Booklore: Refreshing stale details for {len(stale_ids)} books "
+                        f"(batch_size={len(stale_ids)})"
+                    )
+                    token = self._get_fresh_token()
+                    if not token:
+                        self._last_refresh_failed = True
+                        return False
+
+                    def fetch_stale_one(book_id):
+                        return book_id, self._fetch_book_detail(book_id, token)
+
+                    with ThreadPoolExecutor(max_workers=10) as executor:
+                        futures = {executor.submit(fetch_stale_one, bid): bid for bid in stale_ids}
+                        for future in as_completed(futures):
+                            try:
+                                _, detail = future.result()
+                                if detail and isinstance(detail, dict):
+                                    self._process_book_detail(detail)
+                            except Exception as e:
+                                logger.debug(f"Booklore: Error refreshing stale detail: {e}")
 
             self._cache_timestamp = time.time()
             self._last_refresh_failed = False
@@ -780,10 +846,14 @@ class BookloreClient:
             'subtitle': subtitle,
             'authors': author_str,
             'bookType': book_type,
+            'primaryFile': detail.get('primaryFile'),
+            'bookFiles': detail.get('bookFiles'),
+            'audiobookProgress': detail.get('audiobookProgress'),
             'epubProgress': detail.get('epubProgress'),
             'pdfProgress': detail.get('pdfProgress'),
             'cbxProgress': detail.get('cbxProgress'),
             'koreaderProgress': detail.get('koreaderProgress'),
+            '_detail_fetched_at': time.time(),
         }
 
         # Let's keep it consistent with what we see in database migration
@@ -911,6 +981,37 @@ class BookloreClient:
                 if str(bid) not in fully_cached_ids and book_info.get('_needs_detail'):
                     all_books.append(book_info)
         return all_books
+
+    def clear_and_refresh(self):
+        """Clear all Booklore cache state (memory + DB) and run a full refresh."""
+        acquired = self._refresh_lock.acquire(timeout=30)
+        if not acquired:
+            logger.warning("⚠️ Booklore: Cache refresh already in progress, cannot clear cache right now")
+            return False
+
+        try:
+            with self._cache_lock:
+                self._book_cache = {}
+                self._book_id_cache = {}
+                self._cache_timestamp = 0
+
+            self._last_refresh_failed = False
+            self._last_refresh_attempt = 0
+            self._server_side_filter_supported = None
+
+            if self.db:
+                if not self.db.clear_all_booklore_books():
+                    logger.error("❌ Booklore: Failed to clear DB cache table")
+                    return False
+
+            logger.info("📚 Booklore: Cache cleared (memory + DB), starting full refresh...")
+        except Exception as e:
+            logger.error(f"❌ Booklore: Failed to clear cache before refresh: {e}")
+            return False
+        finally:
+            self._refresh_lock.release()
+
+        return self._refresh_book_cache()
 
     def search_books(self, search_term):
         """Search books by title, author, or filename. Returns list of matching books."""

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -1607,6 +1607,7 @@ class BookloreClient:
             if not response or response.status_code not in [200, 201, 204]:
                 last_status = response.status_code if response else "No response"
                 continue
+            time.sleep(0.25)
             verified = self.get_audiobook_progress(book_id)
             if verified:
                 observed_pct = verified.get('pct')
@@ -1625,7 +1626,7 @@ class BookloreClient:
                     f"pct_delta={pct_delta:.4f} ts_delta_ms={ts_delta_ms} "
                     f"position_verifiable={position_verifiable}"
                 )
-                if pct_delta > 0.005:
+                if pct_delta > 0.01:
                     last_status = f"verify_mismatch:{(observed_pct or 0.0) * 100:.2f}%"
                     continue
                 if position_verifiable and ts_delta_ms is not None and ts_delta_ms > 5000:

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -39,7 +39,13 @@ class BookloreClient:
         self._last_refresh_attempt = 0
         self._refresh_cooldown = 300  # 5 min cooldown after failed refresh
         self._search_miss_refresh_min_age = 60  # Avoid repeated refreshes on rapid search misses
-        self._search_hit_refresh_min_age = 60  # Periodically validate positive hits to evict deleted remote books
+        self._search_hit_refresh_min_age = int(
+            os.getenv("BOOKLORE_SEARCH_HIT_REFRESH_MIN_AGE", "1800")
+        )  # Validate hit results periodically without hammering full scans
+        self._search_hit_refresh_cooldown = int(
+            os.getenv("BOOKLORE_SEARCH_HIT_REFRESH_COOLDOWN", "600")
+        )
+        self._last_search_hit_refresh_attempt = 0
         self._refresh_lock = threading.Lock()
         self._cache_lock = threading.RLock()
 
@@ -502,6 +508,33 @@ class BookloreClient:
         )
         return str(raw_book_type or '').upper()
 
+    def _book_supports_audiobook(self, book):
+        if not isinstance(book, dict):
+            return False
+        if self._get_book_type(book) == 'AUDIOBOOK':
+            return True
+        primary_file = book.get('primaryFile') or {}
+        if str(primary_file.get('bookType') or '').upper() == 'AUDIOBOOK':
+            return True
+        for file_info in book.get('bookFiles') or []:
+            if str(file_info.get('bookType') or '').upper() == 'AUDIOBOOK':
+                return True
+        if book.get('audiobookProgress') is not None:
+            return True
+        return False
+
+    def _get_audiobook_file_id(self, book):
+        if not isinstance(book, dict):
+            return None
+        primary_file = book.get('primaryFile') or {}
+        if str(primary_file.get('bookType') or '').upper() == 'AUDIOBOOK':
+            return primary_file.get('id') or primary_file.get('bookFileId')
+        for file_info in book.get('bookFiles') or []:
+            if str(file_info.get('bookType') or '').upper() == 'AUDIOBOOK':
+                return file_info.get('id') or file_info.get('bookFileId')
+        info_file_id = book.get('audiobookInfo', {}).get('bookFileId') if isinstance(book.get('audiobookInfo'), dict) else None
+        return info_file_id
+
     def _upsert_lightweight_entry(self, book):
         bid = book.get('id')
         if bid is None:
@@ -554,7 +587,7 @@ class BookloreClient:
         if stale_entries:
             logger.info(f"📚 Booklore: Pruned {len(stale_entries)} books no longer in library")
 
-    def _refresh_book_cache(self):
+    def _refresh_book_cache(self, refresh_stale_details=True):
         """
         Refresh the book cache using robust pagination.
         Fetches books in batches to ensure complete library sync.
@@ -753,7 +786,7 @@ class BookloreClient:
                                 logger.debug(f"Booklore: Error fetching details: {e}")
 
             id_snapshot = self._snapshot_book_id_items()
-            if id_snapshot:
+            if id_snapshot and refresh_stale_details:
                 stale_refresh_budget = max(
                     0,
                     MAX_DETAIL_FETCHES_PER_REFRESH_CYCLE - new_detail_fetch_count
@@ -811,6 +844,10 @@ class BookloreClient:
                                     self._process_book_detail(detail)
                             except Exception as e:
                                 logger.debug(f"Booklore: Error refreshing stale detail: {e}")
+            elif id_snapshot and not refresh_stale_details:
+                logger.debug(
+                    "Booklore: Skipping stale details refresh for quick search-triggered cache validation"
+                )
 
             self._cache_timestamp = time.time()
             self._last_refresh_failed = False
@@ -971,8 +1008,10 @@ class BookloreClient:
     def get_all_books(self):
         """Get all books from cache, refreshing if necessary."""
         # Use a reasonable cache time of 1 hour, similar to find_book_by_filename
-        if time.time() - self._cache_timestamp > 3600 and not self._is_refresh_on_cooldown(): self._refresh_book_cache()
-        if not self._has_cached_books() and not self._is_refresh_on_cooldown(): self._refresh_book_cache()
+        if time.time() - self._cache_timestamp > 3600 and not self._is_refresh_on_cooldown():
+            self._refresh_book_cache(refresh_stale_details=False)
+        if not self._has_cached_books() and not self._is_refresh_on_cooldown():
+            self._refresh_book_cache(refresh_stale_details=False)
 
         with self._cache_lock:
             all_books = list(self._book_cache.values())
@@ -981,6 +1020,30 @@ class BookloreClient:
                 if str(bid) not in fully_cached_ids and book_info.get('_needs_detail'):
                     all_books.append(book_info)
         return all_books
+
+    def search_audiobooks(self, search_term):
+        """Search Booklore for audiobook-capable books."""
+        results = []
+        seen_ids = set()
+        books = self.search_books(search_term) if search_term else self.get_all_books()
+        for book in books or []:
+            if not isinstance(book, dict):
+                continue
+            bid = book.get('id')
+            if bid in seen_ids:
+                continue
+            hydrated = book
+            if book.get('_needs_detail') or not self._book_supports_audiobook(book):
+                hydrated = self._fetch_and_cache_detail(bid) or book
+            if not self._book_supports_audiobook(hydrated):
+                continue
+            info = self.get_audiobook_info(bid)
+            if info:
+                hydrated = dict(hydrated)
+                hydrated['audiobookInfo'] = info
+            results.append(hydrated)
+            seen_ids.add(bid)
+        return results
 
     def clear_and_refresh(self):
         """Clear all Booklore cache state (memory + DB) and run a full refresh."""
@@ -1093,8 +1156,10 @@ class BookloreClient:
 
         # Avoid expensive full-library refreshes on rapid UI search requests.
         # Keep refresh cadence aligned with other read paths.
-        if time.time() - self._cache_timestamp > 3600 and not self._is_refresh_on_cooldown(): self._refresh_book_cache()
-        if not self._has_cached_books() and not self._is_refresh_on_cooldown(): self._refresh_book_cache()
+        if time.time() - self._cache_timestamp > 3600 and not self._is_refresh_on_cooldown():
+            self._refresh_book_cache(refresh_stale_details=False)
+        if not self._has_cached_books() and not self._is_refresh_on_cooldown():
+            self._refresh_book_cache(refresh_stale_details=False)
 
         if not search_term:
             return self.get_all_books()
@@ -1103,13 +1168,27 @@ class BookloreClient:
         cache_age = time.time() - self._cache_timestamp
         safe_term = sanitize_log_data(search_term)
         if results:
-            if cache_age > self._search_hit_refresh_min_age and not self._is_refresh_on_cooldown():
+            now = time.time()
+            hit_refresh_ready = (
+                (now - self._last_search_hit_refresh_attempt) >= self._search_hit_refresh_cooldown
+            )
+            if (
+                cache_age > self._search_hit_refresh_min_age
+                and not self._is_refresh_on_cooldown()
+                and hit_refresh_ready
+            ):
+                self._last_search_hit_refresh_attempt = now
                 logger.debug(
-                    f"Booklore search hit: validating cache once "
+                    f"Booklore search hit: validating cache once (quick mode, no stale rotation) "
                     f"(term='{safe_term}', cache_age={cache_age:.0f}s, hits={len(results)})"
                 )
-                if self._refresh_book_cache():
+                if self._refresh_book_cache(refresh_stale_details=False):
                     return search_in_cache(search_term)
+            elif cache_age > self._search_hit_refresh_min_age and not hit_refresh_ready:
+                logger.debug(
+                    f"Booklore search hit: quick validation throttled "
+                    f"(term='{safe_term}', cooldown={self._search_hit_refresh_cooldown}s)"
+                )
             return results
 
         if self._is_refresh_on_cooldown():
@@ -1127,10 +1206,10 @@ class BookloreClient:
             return results
 
         logger.debug(
-            f"Booklore search miss: refreshing cache once "
+            f"Booklore search miss: refreshing cache once (quick mode, no stale rotation) "
             f"(term='{safe_term}', cache_age={cache_age:.0f}s)"
         )
-        if self._refresh_book_cache():
+        if self._refresh_book_cache(refresh_stale_details=False):
             return search_in_cache(search_term)
 
         return results
@@ -1223,11 +1302,146 @@ class BookloreClient:
         logger.debug(f"Booklore verify read: book_id={book_id} unknown book_type={book_type!r}")
         return None, None
 
+    def get_audiobook_info(self, book_id):
+        response = self._make_request("GET", f"/api/v1/audiobook/{book_id}/info")
+        if not response or response.status_code != 200:
+            return None
+        data = self._parse_json_response(response, f"Booklore audiobook info for book {book_id}")
+        return data if isinstance(data, dict) else None
+
+    def get_audiobook_progress(self, book_id):
+        response = self._make_request("GET", f"/api/v1/books/{book_id}")
+        if not response:
+            return None
+        if response.status_code == 404:
+            self._evict_cached_book(book_id=book_id, reason="audiobook progress lookup returned 404")
+            return None
+        if response.status_code != 200:
+            return None
+        data = self._parse_json_response(response, f"Booklore audiobook progress for book {book_id}")
+        if not isinstance(data, dict):
+            return None
+        progress = data.get('audiobookProgress') or {}
+        if not isinstance(progress, dict):
+            return None
+        raw_pct = progress.get('percentage', 0)
+        parsed_pct = self._to_progress_fraction(raw_pct)
+        position_ms = progress.get('positionMs')
+        try:
+            position_ms = int(position_ms) if position_ms is not None else None
+        except (TypeError, ValueError):
+            position_ms = None
+        return {
+            'pct': parsed_pct,
+            'position_ms': position_ms,
+            'track_index': progress.get('trackIndex'),
+            'track_position_ms': progress.get('trackPositionMs'),
+        }
+
     def get_progress(self, ebook_filename):
         book = self.find_book_by_filename(ebook_filename)
         if not book:
             return None, None
         return self._get_progress_by_book_id(book['id'])
+
+    def get_audiobook_cover_bytes(self, book_id):
+        response = self._make_request("GET", f"/api/v1/audiobook/{book_id}/cover")
+        if not response or response.status_code != 200:
+            return None, None
+        return response.content, response.headers.get('Content-Type', 'image/jpeg')
+
+    def download_audiobook_track(self, book_id, track_index, output_path):
+        token = self._get_fresh_token()
+        if not token:
+            return False
+        headers = {"Authorization": f"Bearer {token}"}
+        url = f"{self.base_url}/api/v1/audiobook/{book_id}/track/{track_index}/stream"
+        try:
+            with self.session.get(url, headers=headers, stream=True, timeout=120) as response:
+                if response.status_code != 200:
+                    logger.error(
+                        f"❌ Booklore audiobook track download failed: book_id={book_id} "
+                        f"track_index={track_index} status={response.status_code}"
+                    )
+                    return False
+                output_path = Path(output_path)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(output_path, "wb") as handle:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            handle.write(chunk)
+                return True
+        except Exception as e:
+            logger.error(f"❌ Booklore audiobook track download error: {e}")
+            return False
+
+    def update_audiobook_progress(
+        self,
+        book_id,
+        book_file_id,
+        position_ms,
+        percentage,
+        track_index=None,
+        track_position_ms=None,
+    ):
+        pct_display = max(0.0, min(float(percentage), 1.0)) * 100.0
+        position_ms = max(int(position_ms or 0), 0)
+        progress_payload = {
+            "positionMs": position_ms,
+            "percentage": pct_display,
+        }
+        if track_index is not None:
+            progress_payload["trackIndex"] = int(track_index)
+        if track_position_ms is not None:
+            progress_payload["trackPositionMs"] = max(int(track_position_ms), 0)
+
+        payloads = [("audiobookProgress", {"bookId": book_id, "audiobookProgress": progress_payload})]
+        if book_file_id is not None:
+            file_progress = {
+                "bookFileId": book_file_id,
+                "progressPercent": pct_display,
+                "positionData": json.dumps(progress_payload),
+            }
+            payloads.append(("fileProgress", {"bookId": book_id, "fileProgress": file_progress}))
+
+        last_status = "No response"
+        for variant_name, payload in payloads:
+            response = self._make_request("POST", "/api/v1/books/progress", payload)
+            if not response or response.status_code not in [200, 201, 204]:
+                last_status = response.status_code if response else "No response"
+                continue
+            verified = self.get_audiobook_progress(book_id)
+            if verified:
+                observed_pct = verified.get('pct')
+                observed_position_ms = verified.get('position_ms')
+                pct_delta = abs((observed_pct or 0.0) - float(percentage))
+                position_verifiable = observed_position_ms is not None
+                ts_delta_ms = (
+                    abs(int(observed_position_ms) - int(position_ms))
+                    if position_verifiable
+                    else None
+                )
+                logger.debug(
+                    f"Booklore audiobook verify comparison: book_id={book_id} variant={variant_name} "
+                    f"expected_pct={pct_display:.2f}% observed_pct={(observed_pct or 0.0) * 100:.2f}% "
+                    f"expected_position_ms={position_ms} observed_position_ms={observed_position_ms} "
+                    f"pct_delta={pct_delta:.4f} ts_delta_ms={ts_delta_ms} "
+                    f"position_verifiable={position_verifiable}"
+                )
+                if pct_delta > 0.005:
+                    last_status = f"verify_mismatch:{(observed_pct or 0.0) * 100:.2f}%"
+                    continue
+                if position_verifiable and ts_delta_ms is not None and ts_delta_ms > 5000:
+                    last_status = f"verify_mismatch:{(observed_pct or 0.0) * 100:.2f}%"
+                    continue
+            with self._cache_lock:
+                cached = self._book_id_cache.get(book_id)
+                if cached is not None:
+                    cached['audiobookProgress'] = dict(progress_payload)
+            return True
+
+        logger.error(f"❌ Booklore audiobook update failed: {last_status}")
+        return False
 
     def update_progress(self, ebook_filename, percentage, rich_locator: Optional[LocatorResult] = None):
         book = self.find_book_by_filename(ebook_filename)

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -1169,7 +1169,7 @@ class BookloreClient:
                     all_books.append(book_info)
         return self._dedupe_book_results(all_books)
 
-    def search_audiobooks(self, search_term):
+    def search_audiobooks(self, search_term, include_info=True):
         """Search Booklore for audiobook-capable books."""
         results = []
         seen_ids = set()
@@ -1193,10 +1193,11 @@ class BookloreClient:
                 ) or book
             if not self._book_supports_audiobook(hydrated):
                 continue
-            info = self.get_audiobook_info(bid)
-            if info:
-                hydrated = dict(hydrated)
-                hydrated['audiobookInfo'] = info
+            if include_info:
+                info = self.get_audiobook_info(bid)
+                if info:
+                    hydrated = dict(hydrated)
+                    hydrated['audiobookInfo'] = info
             results.append(hydrated)
             seen_ids.add(bid)
         return results

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -1097,13 +1097,29 @@ class BookloreClient:
         ).upper()
         if book_type == 'EPUB':
             progress = data.get('epubProgress') or {}
-            return self._to_progress_fraction(progress.get('percentage', 0)), progress.get('cfi')
+            raw_pct = progress.get('percentage', 0)
+            parsed_pct = self._to_progress_fraction(raw_pct)
+            logger.debug(
+                f"Booklore verify read: book_id={book_id} type=EPUB "
+                f"raw_pct={raw_pct!r} parsed_pct={parsed_pct if parsed_pct is not None else 'None'} "
+                f"has_cfi={bool(progress.get('cfi'))}"
+            )
+            return parsed_pct, progress.get('cfi')
         if book_type == 'PDF':
             progress = data.get('pdfProgress') or {}
+            logger.debug(
+                f"Booklore verify read: book_id={book_id} type=PDF "
+                f"raw_pct={progress.get('percentage', 0)!r}"
+            )
             return self._to_progress_fraction(progress.get('percentage', 0)), None
         if book_type == 'CBX':
             progress = data.get('cbxProgress') or {}
+            logger.debug(
+                f"Booklore verify read: book_id={book_id} type=CBX "
+                f"raw_pct={progress.get('percentage', 0)!r}"
+            )
             return self._to_progress_fraction(progress.get('percentage', 0)), None
+        logger.debug(f"Booklore verify read: book_id={book_id} unknown book_type={book_type!r}")
         return None, None
 
     def get_progress(self, ebook_filename):
@@ -1118,13 +1134,14 @@ class BookloreClient:
             logger.debug(f"Booklore: Book not found: {ebook_filename}")
             return False
 
+        safe_filename = sanitize_log_data(ebook_filename)
         book_id = book['id']
         if book.get('_needs_detail') or not self._get_book_type(book):
             hydrated = self._fetch_and_cache_detail(book_id)
             if hydrated:
                 book = hydrated
             elif book.get('_needs_detail'):
-                logger.debug(f"Booklore: Could not hydrate lightweight entry for {sanitize_log_data(ebook_filename)}")
+                logger.debug(f"Booklore: Could not hydrate lightweight entry for {safe_filename}")
         book_type = self._get_book_type(book)
         pct_display = percentage * 100
 
@@ -1154,15 +1171,35 @@ class BookloreClient:
         elif book_type == 'CBX':
             payload_variants = [("standard", {"bookId": book_id, "cbxProgress": {"page": 1, "percentage": pct_display}})]
         else:
-            logger.warning(f"Booklore: Unknown book type {book_type} for {sanitize_log_data(ebook_filename)}")
+            logger.warning(f"Booklore: Unknown book type {book_type} for {safe_filename}")
             return False
 
+        logger.debug(
+            f"Booklore progress write start: file={safe_filename} book_id={book_id} type={book_type} "
+            f"target_pct={pct_display:.2f}% clear_reset={clear_reset} has_locator={bool(rich_locator)} "
+            f"has_cfi={cfi is not None} variants={[name for name, _ in payload_variants]}"
+        )
+
         last_status = "No response"
-        for variant_name, payload in payload_variants:
+        for variant_idx, (variant_name, payload) in enumerate(payload_variants, start=1):
             if clear_reset:
                 logger.debug(f"Booklore: Clearing CFI for 0% reset (variant={variant_name})")
 
+            progress_payload = payload.get('epubProgress') or payload.get('pdfProgress') or payload.get('cbxProgress') or {}
+            has_payload_cfi = isinstance(payload.get('epubProgress'), dict) and ('cfi' in payload.get('epubProgress', {}))
+            payload_cfi_value = payload.get('epubProgress', {}).get('cfi') if has_payload_cfi else None
+            logger.debug(
+                f"Booklore progress write attempt {variant_idx}/{len(payload_variants)}: "
+                f"file={safe_filename} book_id={book_id} variant={variant_name} "
+                f"payload_pct={progress_payload.get('percentage', 'n/a')} has_cfi={has_payload_cfi} "
+                f"cfi_len={len(str(payload_cfi_value)) if payload_cfi_value is not None else 0}"
+            )
+
             response = self._make_request("POST", "/api/v1/books/progress", payload)
+            logger.debug(
+                f"Booklore progress write response: file={safe_filename} book_id={book_id} "
+                f"variant={variant_name} status={response.status_code if response else 'no_response'}"
+            )
             if response and response.status_code == 404:
                 self._evict_cached_book(
                     book_id=book_id,
@@ -1172,16 +1209,33 @@ class BookloreClient:
                 last_status = 404
                 break
             if not response or response.status_code not in [200, 201, 204]:
+                logger.debug(
+                    f"Booklore progress write non-success: file={safe_filename} book_id={book_id} "
+                    f"variant={variant_name} status={response.status_code if response else 'no_response'} "
+                    f"body_preview={self._response_text_preview(response)!r}"
+                )
                 last_status = response.status_code if response else "No response"
                 continue
 
             # Verify EPUB writes to ensure the server actually persisted the target.
             if book_type == 'EPUB':
-                verified_pct, _ = self._get_progress_by_book_id(book_id)
+                verified_pct, verified_cfi = self._get_progress_by_book_id(book_id)
+                if verified_pct is not None:
+                    logger.debug(
+                        f"Booklore progress verify comparison: file={safe_filename} book_id={book_id} "
+                        f"variant={variant_name} expected={pct_display:.2f}% observed={verified_pct * 100:.2f}% "
+                        f"delta={abs(verified_pct - percentage) * 100:.2f}% clear_reset={clear_reset} "
+                        f"verified_has_cfi={bool(verified_cfi)}"
+                    )
+                else:
+                    logger.debug(
+                        f"Booklore progress verify unavailable: file={safe_filename} book_id={book_id} "
+                        f"variant={variant_name} expected={pct_display:.2f}%"
+                    )
                 if clear_reset:
                     if verified_pct is not None and verified_pct > 0.001:
                         logger.warning(
-                            f"Booklore clear did not persist for {sanitize_log_data(ebook_filename)} "
+                            f"Booklore clear did not persist for {safe_filename} "
                             f"(variant={variant_name}, observed={verified_pct * 100:.2f}%). Retrying..."
                         )
                         last_status = f"verify_failed:{verified_pct * 100:.2f}%"
@@ -1189,13 +1243,13 @@ class BookloreClient:
                 elif verified_pct is not None:
                     if abs(verified_pct - percentage) > 0.005:
                         logger.warning(
-                            f"Booklore progress write mismatch for {sanitize_log_data(ebook_filename)} "
+                            f"Booklore progress write mismatch for {safe_filename} "
                             f"(variant={variant_name}, expected={pct_display:.2f}%, observed={verified_pct * 100:.2f}%). Retrying..."
                         )
                         last_status = f"verify_mismatch:{verified_pct * 100:.2f}%"
                         continue
 
-            logger.info(f"Booklore: {sanitize_log_data(ebook_filename)} -> {pct_display:.1f}%")
+            logger.info(f"Booklore: {safe_filename} -> {pct_display:.1f}%")
 
             # Update cache in-place instead of full library refresh
             try:
@@ -1223,6 +1277,10 @@ class BookloreClient:
                 logger.debug("Booklore: In-place cache update failed, will refresh on next read")
             return True
 
+        logger.debug(
+            f"Booklore progress write exhausted variants: file={safe_filename} book_id={book_id} "
+            f"type={book_type} target_pct={pct_display:.2f}% last_status={last_status}"
+        )
         logger.error(f"Booklore update failed: {last_status}")
         return False
 

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -46,6 +46,10 @@ class BookloreClient:
             os.getenv("BOOKLORE_SEARCH_HIT_REFRESH_COOLDOWN", "600")
         )
         self._last_search_hit_refresh_attempt = 0
+        self._audiobook_search_miss_refresh_cooldown = int(
+            os.getenv("BOOKLORE_AUDIOBOOK_SEARCH_MISS_REFRESH_COOLDOWN", "30")
+        )
+        self._last_audiobook_search_miss_refresh_attempt = 0
         self._refresh_lock = threading.Lock()
         self._cache_lock = threading.RLock()
 
@@ -1171,35 +1175,71 @@ class BookloreClient:
 
     def search_audiobooks(self, search_term, include_info=True):
         """Search Booklore for audiobook-capable books."""
-        results = []
-        seen_ids = set()
-        books = self.search_books(search_term) if search_term else self.get_all_books()
-        for book in books or []:
-            if not isinstance(book, dict):
-                continue
-            bid = book.get('id')
-            if bid in seen_ids:
-                continue
-            hydrated = book
-            requires_audio_refresh = (
-                not book.get('_needs_detail')
-                and not self._book_supports_audiobook(book)
-                and not self._has_audio_shape_fields(book)
+        safe_term = str(search_term or "").strip()
+
+        def collect_results(books):
+            collected = []
+            seen_ids = set()
+            for book in books or []:
+                if not isinstance(book, dict):
+                    continue
+                bid = book.get('id')
+                if bid in seen_ids:
+                    continue
+                hydrated = book
+                requires_audio_refresh = (
+                    not book.get('_needs_detail')
+                    and not self._book_supports_audiobook(book)
+                    and not self._has_audio_shape_fields(book)
+                )
+                if book.get('_needs_detail') or not self._book_supports_audiobook(book):
+                    hydrated = self._fetch_and_cache_detail(
+                        bid,
+                        force_refresh=requires_audio_refresh,
+                    ) or book
+                if not self._book_supports_audiobook(hydrated):
+                    continue
+                if include_info:
+                    info = self.get_audiobook_info(bid)
+                    if info:
+                        hydrated = dict(hydrated)
+                        hydrated['audiobookInfo'] = info
+                collected.append(hydrated)
+                seen_ids.add(bid)
+            return collected
+
+        books = self.search_books(safe_term) if safe_term else self.get_all_books()
+        results = collect_results(books)
+        if results or not safe_term:
+            return results
+
+        if self._is_refresh_on_cooldown():
+            logger.debug(
+                "Booklore audiobook search miss: refresh skipped due to cooldown "
+                f"(term='{sanitize_log_data(safe_term)}')"
             )
-            if book.get('_needs_detail') or not self._book_supports_audiobook(book):
-                hydrated = self._fetch_and_cache_detail(
-                    bid,
-                    force_refresh=requires_audio_refresh,
-                ) or book
-            if not self._book_supports_audiobook(hydrated):
-                continue
-            if include_info:
-                info = self.get_audiobook_info(bid)
-                if info:
-                    hydrated = dict(hydrated)
-                    hydrated['audiobookInfo'] = info
-            results.append(hydrated)
-            seen_ids.add(bid)
+            return results
+
+        now = time.time()
+        if (
+            now - self._last_audiobook_search_miss_refresh_attempt
+            < self._audiobook_search_miss_refresh_cooldown
+        ):
+            logger.debug(
+                "Booklore audiobook search miss: refresh throttled "
+                f"(term='{sanitize_log_data(safe_term)}', cooldown={self._audiobook_search_miss_refresh_cooldown}s)"
+            )
+            return results
+
+        self._last_audiobook_search_miss_refresh_attempt = now
+        logger.debug(
+            "Booklore audiobook search miss: forcing cache refresh once "
+            f"(term='{sanitize_log_data(safe_term)}')"
+        )
+        if self._refresh_book_cache(refresh_stale_details=False):
+            refreshed_books = self.search_books(safe_term)
+            return collect_results(refreshed_books)
+
         return results
 
     def clear_and_refresh(self):

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -1450,6 +1450,18 @@ class BookloreClient:
         except (TypeError, ValueError):
             return 0.0
 
+    @staticmethod
+    def _to_optional_int(raw_value):
+        if raw_value in (None, ""):
+            return None
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError):
+            try:
+                return int(float(raw_value))
+            except (TypeError, ValueError):
+                return None
+
     def _get_progress_by_book_id(self, book_id):
         """
         Get progress tuple for a specific Booklore book id.
@@ -1500,7 +1512,7 @@ class BookloreClient:
         return None, None
 
     def get_audiobook_info(self, book_id):
-        response = self._make_request("GET", f"/api/v1/audiobook/{book_id}/info")
+        response = self._make_request("GET", f"/api/v1/audiobooks/{book_id}/info")
         if not response or response.status_code != 200:
             return None
         data = self._parse_json_response(response, f"Booklore audiobook info for book {book_id}")
@@ -1523,16 +1535,12 @@ class BookloreClient:
             return None
         raw_pct = progress.get('percentage', 0)
         parsed_pct = self._to_progress_fraction(raw_pct)
-        position_ms = progress.get('positionMs')
-        try:
-            position_ms = int(position_ms) if position_ms is not None else None
-        except (TypeError, ValueError):
-            position_ms = None
+        position_ms = self._to_optional_int(progress.get('positionMs'))
         return {
             'pct': parsed_pct,
             'position_ms': position_ms,
-            'track_index': progress.get('trackIndex'),
-            'track_position_ms': progress.get('trackPositionMs'),
+            'track_index': self._to_optional_int(progress.get('trackIndex')),
+            'track_position_ms': self._to_optional_int(progress.get('trackPositionMs')),
         }
 
     def get_progress(self, ebook_filename):
@@ -1542,7 +1550,7 @@ class BookloreClient:
         return self._get_progress_by_book_id(book['id'])
 
     def get_audiobook_cover_bytes(self, book_id):
-        response = self._make_request("GET", f"/api/v1/audiobook/{book_id}/cover")
+        response = self._make_request("GET", f"/api/v1/audiobooks/{book_id}/cover")
         if not response or response.status_code != 200:
             return None, None
         return response.content, response.headers.get('Content-Type', 'image/jpeg')
@@ -1552,7 +1560,7 @@ class BookloreClient:
         if not token:
             return False
         headers = {"Authorization": f"Bearer {token}"}
-        url = f"{self.base_url}/api/v1/audiobook/{book_id}/track/{track_index}/stream"
+        url = f"{self.base_url}/api/v1/audiobooks/{book_id}/track/{track_index}/stream"
         try:
             with self.session.get(url, headers=headers, stream=True, timeout=120) as response:
                 if response.status_code != 200:
@@ -1583,36 +1591,83 @@ class BookloreClient:
     ):
         pct_display = max(0.0, min(float(percentage), 1.0)) * 100.0
         position_ms = max(int(position_ms or 0), 0)
+        track_index = self._to_optional_int(track_index)
+        if track_index is not None:
+            track_index = max(track_index, 0)
+        track_position_ms = self._to_optional_int(track_position_ms)
+        if track_position_ms is not None:
+            track_position_ms = max(track_position_ms, 0)
+
         progress_payload = {
             "positionMs": position_ms,
             "percentage": pct_display,
         }
         if track_index is not None:
-            progress_payload["trackIndex"] = int(track_index)
+            progress_payload["trackIndex"] = track_index
         if track_position_ms is not None:
-            progress_payload["trackPositionMs"] = max(int(track_position_ms), 0)
+            progress_payload["trackPositionMs"] = track_position_ms
 
-        payloads = [("audiobookProgress", {"bookId": book_id, "audiobookProgress": progress_payload})]
-        if book_file_id is not None:
+        payloads = []
+        book_file_id_value = None
+        if book_file_id not in (None, ""):
+            book_file_id_value = self._to_optional_int(book_file_id)
+            if book_file_id_value is None:
+                book_file_id_value = book_file_id
             file_progress = {
-                "bookFileId": book_file_id,
+                "bookFileId": book_file_id_value,
                 "progressPercent": pct_display,
-                "positionData": json.dumps(progress_payload),
+                "positionData": str(position_ms),
             }
-            payloads.append(("fileProgress", {"bookId": book_id, "fileProgress": file_progress}))
+            if track_index is not None:
+                file_progress["positionHref"] = str(track_index)
+            payloads.append(("fileProgress", {"bookId": book_id, "fileProgress": file_progress}, True))
+        payloads.append(("audiobookProgress", {"bookId": book_id, "audiobookProgress": progress_payload}, False))
 
         last_status = "No response"
-        for variant_name, payload in payloads:
+        file_progress_http_failed = False
+        for variant_name, payload, allow_http_fallback in payloads:
+            if variant_name == "audiobookProgress" and book_file_id_value is not None and not file_progress_http_failed:
+                # Skip the compatibility fallback until fileProgress actually fails at the HTTP layer.
+                continue
+            logger.debug(
+                "Booklore audiobook write attempt: book_id=%s variant=%s expected_pct=%.2f%% "
+                "stored_position_ms=%s track_index=%s track_position_ms=%s has_book_file_id=%s",
+                book_id,
+                variant_name,
+                pct_display,
+                position_ms,
+                track_index,
+                track_position_ms,
+                book_file_id_value is not None,
+            )
             response = self._make_request("POST", "/api/v1/books/progress", payload)
             if not response or response.status_code not in [200, 201, 204]:
                 last_status = response.status_code if response else "No response"
-                continue
+                logger.debug(
+                    "Booklore audiobook write non-success: book_id=%s variant=%s status=%s body_preview=%r",
+                    book_id,
+                    variant_name,
+                    response.status_code if response else "no_response",
+                    self._response_text_preview(response),
+                )
+                if allow_http_fallback:
+                    file_progress_http_failed = True
+                    logger.debug(
+                        "Booklore audiobook write falling back after HTTP failure: book_id=%s "
+                        "variant=%s fallback=audiobookProgress",
+                        book_id,
+                        variant_name,
+                    )
+                    continue
+                break
             time.sleep(0.25)
             verified = self.get_audiobook_progress(book_id)
             if verified:
                 observed_pct = verified.get('pct')
                 observed_position_ms = verified.get('position_ms')
+                observed_track_index = self._to_optional_int(verified.get('track_index'))
                 pct_delta = abs((observed_pct or 0.0) - float(percentage))
+                position_required = position_ms > 0
                 position_verifiable = observed_position_ms is not None
                 ts_delta_ms = (
                     abs(int(observed_position_ms) - int(position_ms))
@@ -1623,15 +1678,25 @@ class BookloreClient:
                     f"Booklore audiobook verify comparison: book_id={book_id} variant={variant_name} "
                     f"expected_pct={pct_display:.2f}% observed_pct={(observed_pct or 0.0) * 100:.2f}% "
                     f"expected_position_ms={position_ms} observed_position_ms={observed_position_ms} "
+                    f"expected_track_index={track_index} observed_track_index={observed_track_index} "
                     f"pct_delta={pct_delta:.4f} ts_delta_ms={ts_delta_ms} "
-                    f"position_verifiable={position_verifiable}"
+                    f"position_verifiable={position_verifiable} position_required={position_required}"
                 )
                 if pct_delta > 0.01:
                     last_status = f"verify_mismatch:{(observed_pct or 0.0) * 100:.2f}%"
-                    continue
+                    break
+                if position_required and not position_verifiable:
+                    last_status = "verify_missing_position"
+                    break
                 if position_verifiable and ts_delta_ms is not None and ts_delta_ms > 5000:
-                    last_status = f"verify_mismatch:{(observed_pct or 0.0) * 100:.2f}%"
-                    continue
+                    last_status = f"verify_position_mismatch:{observed_position_ms}"
+                    break
+                if track_index is not None and observed_track_index != track_index:
+                    last_status = f"verify_track_mismatch:{observed_track_index}"
+                    break
+            elif position_ms > 0:
+                last_status = "verify_unavailable"
+                break
             with self._cache_lock:
                 cached = self._book_id_cache.get(book_id)
                 if cached is not None:

--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -52,6 +52,14 @@ class BookloreClient:
         self._token = None
         self._token_timestamp = 0
         self._token_max_age = 300
+        self._token_lock = threading.Lock()
+        self._token_login_retry_delay = float(
+            os.getenv("BOOKLORE_LOGIN_RETRY_DELAY_SECONDS", "1.1")
+        )
+        self._token_login_max_attempts = max(
+            1,
+            int(os.getenv("BOOKLORE_LOGIN_MAX_ATTEMPTS", "2"))
+        )
         self.session = requests.Session()
 
         # Legacy Cache file path (for migration only)
@@ -145,29 +153,68 @@ class BookloreClient:
         """
         pass # Database persistence is handled atomically per book elsewhere
 
-    def _get_fresh_token(self):
-        if self._token and (time.time() - self._token_timestamp) < self._token_max_age:
-            return self._token
-        if not all([self.base_url, self.username, self.password]): return None
+    @staticmethod
+    def _is_duplicate_refresh_token_failure(response) -> bool:
+        if response is None:
+            return False
+        if getattr(response, "status_code", None) not in (400, 409):
+            return False
         try:
-            # Use session for login to handle cookies if needed
-            response = self.session.post(
-                f"{self.base_url}/api/v1/auth/login",
-                json={"username": self.username, "password": self.password},
-                timeout=10
-            )
-            if response.status_code == 200:
-                data = self._parse_json_response(response, "Booklore login")
-                if not isinstance(data, dict):
-                    return None
-                # Booklore v1.17+ uses accessToken instead of token
-                self._token = data.get("accessToken") or data.get("token")
-                self._token_timestamp = time.time()
+            text = (response.text or "").lower()
+        except Exception:
+            text = ""
+        return (
+            "uq_refresh_token" in text
+            or ("duplicate entry" in text and "refresh_token" in text)
+        )
+
+    def _current_token_is_fresh(self) -> bool:
+        return bool(self._token) and (time.time() - self._token_timestamp) < self._token_max_age
+
+    def _get_fresh_token(self):
+        if self._current_token_is_fresh():
+            return self._token
+        if not all([self.base_url, self.username, self.password]):
+            return None
+        with self._token_lock:
+            if self._current_token_is_fresh():
                 return self._token
-            else:
-                logger.error(f"❌ Booklore login failed: {response.status_code} - {response.text}")
-        except Exception as e:
-            logger.error(f"❌ Booklore login error: {e}")
+            try:
+                for attempt in range(1, self._token_login_max_attempts + 1):
+                    # Use session for login to handle cookies if needed
+                    response = self.session.post(
+                        f"{self.base_url}/api/v1/auth/login",
+                        json={"username": self.username, "password": self.password},
+                        timeout=10
+                    )
+                    if response.status_code == 200:
+                        data = self._parse_json_response(response, "Booklore login")
+                        if not isinstance(data, dict):
+                            return None
+                        # Booklore v1.17+ uses accessToken instead of token
+                        self._token = data.get("accessToken") or data.get("token")
+                        self._token_timestamp = time.time()
+                        return self._token
+
+                    duplicate_conflict = self._is_duplicate_refresh_token_failure(response)
+                    if duplicate_conflict and attempt < self._token_login_max_attempts:
+                        logger.warning(
+                            "Booklore login conflict (duplicate refresh token). "
+                            "Retrying in %.1fs (attempt %d/%d).",
+                            self._token_login_retry_delay,
+                            attempt,
+                            self._token_login_max_attempts,
+                        )
+                        time.sleep(self._token_login_retry_delay)
+                        continue
+
+                    logger.error(
+                        f"❌ Booklore login failed: {response.status_code} - "
+                        f"{self._response_text_preview(response, limit=300)}"
+                    )
+                    return None
+            except Exception as e:
+                logger.error(f"❌ Booklore login error: {e}")
         return None
 
     def _make_request(self, method, endpoint, json_data=None):
@@ -183,7 +230,9 @@ class BookloreClient:
             else: return None
 
             if response.status_code == 401:
-                self._token = None
+                with self._token_lock:
+                    self._token = None
+                    self._token_timestamp = 0
                 token = self._get_fresh_token()
                 if not token: return None
                 headers["Authorization"] = f"Bearer {token}"

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -653,7 +653,7 @@ class DatabaseService:
             ).first()
 
             if existing:
-                for attr in ['title', 'author', 'cover_url', 'matches_json', 'status']:
+                for attr in ['source', 'title', 'author', 'cover_url', 'matches_json', 'status']:
                     if hasattr(suggestion, attr):
                         setattr(existing, attr, getattr(suggestion, attr))
                 session.flush()

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -171,6 +171,19 @@ class DatabaseService:
                 session.expunge(book)  # Detach from session
             return book
 
+    def get_book_by_audio_source(self, audio_source: str, audio_source_id: str) -> Optional[Book]:
+        """Get a book by its primary audio source identity."""
+        if not audio_source or not audio_source_id:
+            return None
+        with self.get_session() as session:
+            book = session.query(Book).filter(
+                Book.audio_source == audio_source,
+                Book.audio_source_id == audio_source_id,
+            ).first()
+            if book:
+                session.expunge(book)
+            return book
+
     def get_book_by_kosync_id(self, kosync_id: str) -> Optional[Book]:
         """Get a book by its KoSync document ID."""
         with self.get_session() as session:
@@ -203,9 +216,12 @@ class DatabaseService:
 
             if existing:
                 # Update existing book
-                for attr in ['abs_title', 'ebook_filename', 'original_ebook_filename', 'kosync_doc_id',
-                           'transcript_file', 'status', 'duration', 'sync_mode', 'transcript_source', 'storyteller_uuid',
-                           'abs_ebook_item_id']:
+                for attr in ['abs_title', 'audio_source', 'audio_source_id', 'audio_title',
+                           'audio_cover_url', 'audio_duration', 'audio_provider_book_id',
+                           'audio_provider_file_id', 'ebook_filename', 'ebook_source',
+                           'ebook_source_id', 'original_ebook_filename', 'kosync_doc_id',
+                           'transcript_file', 'status', 'duration', 'sync_mode',
+                           'transcript_source', 'storyteller_uuid', 'abs_ebook_item_id']:
                     if hasattr(book, attr):
                         setattr(existing, attr, getattr(book, attr))
                 session.flush()

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -248,8 +248,10 @@ class PendingSuggestion(Base):
     status = Column(String(20), default='pending')
     created_at = Column(DateTime, default=datetime.utcnow)
 
-    def __init__(self, source_id: str, title: str, author: str = None, 
-                 cover_url: str = None, matches_json: str = "[]", status: str = 'pending'):
+    def __init__(self, source_id: str, title: str, author: str = None,
+                 cover_url: str = None, matches_json: str = "[]", status: str = 'pending',
+                 source: str = None):
+        self.source = source or 'abs'
         self.source_id = source_id
         self.title = title
         self.author = author

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -69,7 +69,16 @@ class Book(Base):
 
     abs_id = Column(String(255), primary_key=True)
     abs_title = Column(String(500))
+    audio_source = Column(String(32), nullable=True, index=True)
+    audio_source_id = Column(String(255), nullable=True, index=True)
+    audio_title = Column(String(500), nullable=True)
+    audio_cover_url = Column(String(1000), nullable=True)
+    audio_duration = Column(Float, nullable=True)
+    audio_provider_book_id = Column(String(255), nullable=True)
+    audio_provider_file_id = Column(String(255), nullable=True)
     ebook_filename = Column(String(500))
+    ebook_source = Column(String(32), nullable=True)
+    ebook_source_id = Column(String(255), nullable=True)
     original_ebook_filename = Column(String(500))  # NEW COLUMN
     kosync_doc_id = Column(String(255), index=True)
     transcript_file = Column(String(500))
@@ -87,6 +96,11 @@ class Book(Base):
     alignment = relationship("BookAlignment", back_populates="book", uselist=False, cascade="all, delete-orphan")
 
     def __init__(self, abs_id: str, abs_title: str = None, ebook_filename: str = None,
+                 audio_source: str = None, audio_source_id: str = None,
+                 audio_title: str = None, audio_cover_url: str = None,
+                 audio_duration: float = None, audio_provider_book_id: str = None,
+                 audio_provider_file_id: str = None,
+                 ebook_source: str = None, ebook_source_id: str = None,
                  original_ebook_filename: str = None,  # NEW ARGUMENT
                  kosync_doc_id: str = None, transcript_file: str = None,
                  status: str = 'active', duration: float = None, sync_mode: str = 'audiobook',
@@ -94,7 +108,16 @@ class Book(Base):
                  storyteller_uuid: str = None, abs_ebook_item_id: str = None):
         self.abs_id = abs_id
         self.abs_title = abs_title
+        self.audio_source = audio_source
+        self.audio_source_id = audio_source_id
+        self.audio_title = audio_title
+        self.audio_cover_url = audio_cover_url
+        self.audio_duration = audio_duration
+        self.audio_provider_book_id = audio_provider_book_id
+        self.audio_provider_file_id = audio_provider_file_id
         self.ebook_filename = ebook_filename
+        self.ebook_source = ebook_source
+        self.ebook_source_id = ebook_source_id
         self.original_ebook_filename = original_ebook_filename  # NEW FIELD
         self.kosync_doc_id = kosync_doc_id
         self.transcript_file = transcript_file

--- a/src/services/alignment_service.py
+++ b/src/services/alignment_service.py
@@ -719,6 +719,44 @@ def _validate_storyteller_chapters(
     return False, [], []
 
 
+def _read_storyteller_chapter_metrics(chapter_file_path: Path) -> tuple[int, int, float]:
+    """Return transcript lengths and chapter-local duration for a storyteller chapter file."""
+    text_len = 0
+    text_len_utf16 = 0
+    local_duration = 0.0
+
+    if not chapter_file_path.exists():
+        return text_len, text_len_utf16, local_duration
+
+    try:
+        with open(chapter_file_path, "r", encoding="utf-8") as chapter_file:
+            chapter_data = json.load(chapter_file)
+        if not isinstance(chapter_data, dict):
+            return text_len, text_len_utf16, local_duration
+
+        chapter_text = chapter_data.get("transcript", "")
+        text_len = len(chapter_text)
+        text_len_utf16 = len(chapter_text.encode("utf-16-le")) // 2
+
+        timeline = chapter_data.get("wordTimeline")
+        if not isinstance(timeline, list):
+            timeline = chapter_data.get("timeline")
+        if isinstance(timeline, list):
+            for row in timeline:
+                if not isinstance(row, dict):
+                    continue
+                try:
+                    end_time = float(row.get("endTime", 0.0) or 0.0)
+                except (TypeError, ValueError):
+                    end_time = 0.0
+                if end_time > local_duration:
+                    local_duration = end_time
+    except Exception:
+        return 0, 0, 0.0
+
+    return text_len, text_len_utf16, local_duration
+
+
 def ingest_storyteller_transcripts(abs_id: str, abs_title: str, chapters: list) -> Optional[str]:
     """
     Copy Storyteller chapter JSON files into bridge-managed data storage and write a manifest.
@@ -729,10 +767,6 @@ def ingest_storyteller_transcripts(abs_id: str, abs_title: str, chapters: list) 
         return None
 
     chapter_list = chapters if isinstance(chapters, list) else []
-    expected_count = len(chapter_list)
-    if expected_count <= 0:
-        logger.info(f"Storyteller ingest skipped for '{abs_id}': no ABS chapters available")
-        return None
 
     assets_root = Path(assets_dir_raw)
     title_dir = _resolve_storyteller_title_dir(assets_root, abs_title or "")
@@ -744,6 +778,23 @@ def ingest_storyteller_transcripts(abs_id: str, abs_title: str, chapters: list) 
     if not transcriptions_dir.exists() or not transcriptions_dir.is_dir():
         logger.info(f"Storyteller transcriptions directory missing for '{abs_id}' at '{transcriptions_dir}'")
         return None
+
+    expected_count = len(chapter_list)
+    chapterless_mode = expected_count <= 0
+    if chapterless_mode:
+        numeric_pattern = re.compile(r"^\d{5}-\d{5}\.json$")
+        numeric_files = [p.name for p in transcriptions_dir.glob("*.json") if numeric_pattern.match(p.name)]
+        expected_count = len(numeric_files)
+        if expected_count <= 0:
+            logger.info(
+                f"Storyteller ingest skipped for '{abs_id}': no ABS chapters and no storyteller chapter files at "
+                f"'{transcriptions_dir}'"
+            )
+            return None
+        logger.info(
+            f"Storyteller ingest chapterless mode for '{abs_id}': deriving {expected_count} chapters from "
+            f"'{transcriptions_dir}'"
+        )
 
     is_valid, source_files, expected_files = _validate_storyteller_chapters(transcriptions_dir, expected_count)
     if not is_valid:
@@ -789,31 +840,37 @@ def ingest_storyteller_transcripts(abs_id: str, abs_title: str, chapters: list) 
         )
 
     chapter_entries = []
-    for idx, chapter in enumerate(chapter_list):
-        start = float(chapter.get("start", 0.0) or 0.0)
-        end = float(chapter.get("end", 0.0) or 0.0)
-        chapter_file_name = _storyteller_filename_for_abs_chapter(idx)
-        text_len = 0
-        text_len_utf16 = 0
-        chapter_file_path = target_dir / chapter_file_name
-        if chapter_file_path.exists():
-            try:
-                with open(chapter_file_path, "r", encoding="utf-8") as chapter_file:
-                    chapter_data = json.load(chapter_file)
-                chapter_text = chapter_data.get("transcript", "") if isinstance(chapter_data, dict) else ""
-                text_len = len(chapter_text)
-                text_len_utf16 = len(chapter_text.encode("utf-16-le")) // 2
-            except Exception:
-                text_len = 0
-                text_len_utf16 = 0
-        chapter_entries.append({
-            "index": idx,
-            "file": chapter_file_name,
-            "start": start,
-            "end": end,
-            "text_len": text_len,
-            "text_len_utf16": text_len_utf16,
-        })
+    if chapterless_mode:
+        cumulative_start = 0.0
+        for idx, chapter_file_name in enumerate(expected_files):
+            chapter_file_path = target_dir / chapter_file_name
+            text_len, text_len_utf16, local_duration = _read_storyteller_chapter_metrics(chapter_file_path)
+            start = cumulative_start
+            end = cumulative_start + max(0.0, float(local_duration))
+            cumulative_start = end
+            chapter_entries.append({
+                "index": idx,
+                "file": chapter_file_name,
+                "start": start,
+                "end": end,
+                "text_len": text_len,
+                "text_len_utf16": text_len_utf16,
+            })
+    else:
+        for idx, chapter in enumerate(chapter_list):
+            start = float(chapter.get("start", 0.0) or 0.0)
+            end = float(chapter.get("end", 0.0) or 0.0)
+            chapter_file_name = _storyteller_filename_for_abs_chapter(idx)
+            chapter_file_path = target_dir / chapter_file_name
+            text_len, text_len_utf16, _local_duration = _read_storyteller_chapter_metrics(chapter_file_path)
+            chapter_entries.append({
+                "index": idx,
+                "file": chapter_file_name,
+                "start": start,
+                "end": end,
+                "text_len": text_len,
+                "text_len_utf16": text_len_utf16,
+            })
 
     duration = 0.0
     if chapter_entries:

--- a/src/services/audio_source_adapters.py
+++ b/src/services/audio_source_adapters.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from src.api.api_clients import ABSClient
+from src.api.booklore_client import BookloreClient
+from src.utils.logging_utils import sanitize_log_data
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AudioResult:
+    source: str
+    source_id: str
+    title: str
+    subtitle: str = ""
+    authors: str = ""
+    cover_url: str = ""
+    duration: Optional[float] = None
+    display_name: str = ""
+    provider_book_id: Optional[str] = None
+    provider_file_id: Optional[str] = None
+
+
+class AudioSourceAdapter:
+    source_name = ""
+
+    def search(self, query: str) -> list[AudioResult]:
+        raise NotImplementedError
+
+    def get_metadata(self, source_id: str) -> Optional[dict]:
+        raise NotImplementedError
+
+    def get_cover_url(self, source_id: str) -> Optional[str]:
+        raise NotImplementedError
+
+    def get_audio_files(self, source_id: str, bridge_key: str | None = None) -> list[dict]:
+        raise NotImplementedError
+
+    def get_chapters(self, source_id: str) -> list[dict]:
+        raise NotImplementedError
+
+
+class ABSAudioSourceAdapter(AudioSourceAdapter):
+    source_name = "ABS"
+
+    def __init__(self, abs_client: ABSClient):
+        self.abs_client = abs_client
+
+    @staticmethod
+    def _parse_library_scope() -> str | None:
+        """
+        Support both legacy and newer env shapes:
+        - ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID=<library_id>
+        - ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID=true + ABS_LIBRARY_ID=<library_id>
+        """
+        raw = (os.environ.get("ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID") or "").strip()
+        if not raw:
+            return None
+        lowered = raw.lower()
+        if lowered in {"false", "0", "off", "no", "none"}:
+            return None
+        if lowered in {"true", "1", "on", "yes"}:
+            lib_id = (os.environ.get("ABS_LIBRARY_ID") or "").strip()
+            return lib_id or None
+        return raw
+
+    def _get_search_pool(self) -> list[dict]:
+        library_id = self._parse_library_scope()
+        if library_id:
+            return self.abs_client.get_audiobooks_for_lib(library_id)
+        return self.abs_client.get_all_audiobooks()
+
+    @staticmethod
+    def _matches_query(item: dict, query: str) -> bool:
+        if not query:
+            return True
+        media = item.get("media", {}) or {}
+        metadata = media.get("metadata", {}) or item.get("metadata", {}) or {}
+        haystack = " ".join(
+            [
+                str(metadata.get("title") or item.get("name") or ""),
+                str(metadata.get("subtitle") or ""),
+                str(metadata.get("authorName") or ""),
+                str(metadata.get("seriesName") or ""),
+            ]
+        ).lower()
+        return query.lower() in haystack
+
+    @staticmethod
+    def _get_title(item: dict) -> str:
+        media = item.get("media", {}) or {}
+        metadata = media.get("metadata", {}) or item.get("metadata", {}) or {}
+        return metadata.get("title") or item.get("name") or "Unknown"
+
+    @staticmethod
+    def _get_authors(item: dict) -> str:
+        media = item.get("media", {}) or {}
+        metadata = media.get("metadata", {}) or item.get("metadata", {}) or {}
+        return metadata.get("authorName") or ""
+
+    def search(self, query: str) -> list[AudioResult]:
+        library_scope = self._parse_library_scope()
+        query_mode = bool(query)
+        pool = (
+            self.abs_client.search_audiobooks(query, library_id=library_scope)
+            if query_mode
+            else self._get_search_pool()
+        )
+        results: list[AudioResult] = []
+        for item in pool:
+            if not query_mode and not self._matches_query(item, query):
+                continue
+            item_id = str(item.get("id") or "")
+            if not item_id:
+                continue
+            media = item.get("media", {}) or {}
+            metadata = media.get("metadata", {}) or {}
+            title = self._get_title(item)
+            if title == "Unknown":
+                details = self.get_metadata(item_id) or {}
+                if details:
+                    item = details
+                    media = item.get("media", {}) or {}
+                    metadata = media.get("metadata", {}) or item.get("metadata", {}) or {}
+                    title = self._get_title(item)
+            authors = self._get_authors(item)
+            subtitle = metadata.get("subtitle") or ""
+            cover_url = self.get_cover_url(item_id) or ""
+            duration = media.get("duration")
+            results.append(
+                AudioResult(
+                    source="ABS",
+                    source_id=item_id,
+                    title=title,
+                    subtitle=subtitle,
+                    authors=authors,
+                    cover_url=cover_url,
+                    duration=float(duration) if duration is not None else None,
+                    display_name=title,
+                    provider_book_id=item_id,
+                )
+            )
+        return results
+
+    def get_metadata(self, source_id: str) -> Optional[dict]:
+        return self.abs_client.get_item_details(source_id)
+
+    def get_cover_url(self, source_id: str) -> Optional[str]:
+        if not self.abs_client.is_configured():
+            return None
+        return f"{self.abs_client.base_url}/api/items/{source_id}/cover?token={self.abs_client.token}"
+
+    def get_audio_files(self, source_id: str, bridge_key: str | None = None) -> list[dict]:
+        return self.abs_client.get_audio_files(source_id)
+
+    def get_chapters(self, source_id: str) -> list[dict]:
+        details = self.get_metadata(source_id) or {}
+        return details.get("media", {}).get("chapters", []) or []
+
+
+class BookLoreAudioSourceAdapter(AudioSourceAdapter):
+    source_name = "BookLore"
+
+    def __init__(self, booklore_client: BookloreClient, data_dir: Path):
+        self.booklore_client = booklore_client
+        self.data_dir = Path(data_dir)
+
+    @staticmethod
+    def _format_authors(book: dict) -> str:
+        authors = book.get("authors")
+        if isinstance(authors, str):
+            return authors
+        if isinstance(authors, list):
+            cleaned = [str(a).strip() for a in authors if a]
+            return ", ".join(cleaned)
+        return ""
+
+    @staticmethod
+    def _safe_ext(track: dict) -> str:
+        raw_ext = str(track.get("extension") or track.get("ext") or "mp3").lower().strip()
+        return raw_ext.lstrip(".") or "mp3"
+
+    @staticmethod
+    def _to_seconds(raw_value) -> float | None:
+        if raw_value is None or raw_value == "":
+            return None
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            return None
+        if value < 0:
+            return None
+        return value
+
+    @staticmethod
+    def _normalize_time_value(raw_value: float | None, key_name: str | None, use_ms_scale: bool | None = None) -> float | None:
+        if raw_value is None:
+            return None
+        if use_ms_scale is not None:
+            return raw_value / 1000.0 if use_ms_scale else raw_value
+        key = (key_name or "").lower()
+        hinted_ms = ("ms" in key) or ("millis" in key)
+        if not hinted_ms:
+            return raw_value / 1000.0 if raw_value >= 100000 else raw_value
+        # Some BookLore builds expose ms-suffixed keys with second values.
+        # Only scale down when values look like true milliseconds.
+        return raw_value / 1000.0 if raw_value >= 100000 else raw_value
+
+    @staticmethod
+    def _infer_ms_scale(raw_values: list[float], hinted_ms: bool, total_hint_raw: float | None = None) -> bool:
+        if not hinted_ms or not raw_values:
+            return False
+        max_raw = max(raw_values)
+        if max_raw >= 100000:
+            return True
+        if total_hint_raw is not None and total_hint_raw >= 100000:
+            if max_raw >= 10000:
+                return True
+            # Many short chapter values can still be milliseconds if total is large.
+            if len(raw_values) >= 8 and (total_hint_raw / max(max_raw, 1.0)) > 20:
+                return True
+        return False
+
+    def _extract_duration_seconds(self, info: dict) -> float | None:
+        for key in ("durationMs", "duration_ms", "duration", "totalDurationMs", "totalDuration"):
+            raw_value = self._to_seconds(info.get(key))
+            if raw_value and raw_value > 0:
+                seconds = self._normalize_time_value(raw_value, key)
+                if seconds and seconds > 0:
+                    return seconds
+        return None
+
+    def search(self, query: str) -> list[AudioResult]:
+        results: list[AudioResult] = []
+        for book in self.booklore_client.search_audiobooks(query):
+            book_id = book.get("id")
+            if book_id is None:
+                continue
+            info = book.get("audiobookInfo") or {}
+            duration = self._extract_duration_seconds(info)
+            title = book.get("title") or book.get("fileName") or f"BookLore {book_id}"
+            provider_file_id = info.get("bookFileId") or book.get("bookFileId")
+            results.append(
+                AudioResult(
+                    source="BookLore",
+                    source_id=str(book_id),
+                    title=title,
+                    subtitle=book.get("subtitle") or "",
+                    authors=self._format_authors(book),
+                    cover_url=self.get_cover_url(str(book_id)) or "",
+                    duration=duration,
+                    display_name=title,
+                    provider_book_id=str(book_id),
+                    provider_file_id=str(provider_file_id) if provider_file_id is not None else None,
+                )
+            )
+        return results
+
+    def get_metadata(self, source_id: str) -> Optional[dict]:
+        book_info = self.booklore_client.get_audiobook_info(source_id)
+        if not book_info:
+            return None
+        progress = self.booklore_client.get_audiobook_progress(source_id)
+        if progress:
+            book_info["audiobookProgress"] = progress
+        return book_info
+
+    def get_cover_url(self, source_id: str) -> Optional[str]:
+        return f"/api/booklore/audiobook-cover/{source_id}"
+
+    def get_audio_files(self, source_id: str, bridge_key: str | None = None) -> list[dict]:
+        info = self.booklore_client.get_audiobook_info(source_id) or {}
+        tracks = info.get("tracks") or []
+        if not tracks:
+            return []
+
+        cache_key = bridge_key or f"booklore-{source_id}"
+        source_cache_dir = self.data_dir / "audio_cache" / str(cache_key) / "source_tracks"
+        source_cache_dir.mkdir(parents=True, exist_ok=True)
+
+        files = []
+        for idx, track in enumerate(tracks):
+            ext = self._safe_ext(track)
+            local_path = source_cache_dir / f"track_{idx:03d}.{ext}"
+            if not local_path.exists() or local_path.stat().st_size == 0:
+                ok = self.booklore_client.download_audiobook_track(source_id, idx, local_path)
+                if not ok:
+                    raise RuntimeError(
+                        f"BookLore track download failed for book_id={source_id} track_index={idx}"
+                    )
+            files.append(
+                {
+                    "local_path": str(local_path),
+                    "ext": ext,
+                    "track_index": idx,
+                    "duration_ms": track.get("durationMs"),
+                }
+            )
+        return files
+
+    def get_chapters(self, source_id: str) -> list[dict]:
+        info = self.booklore_client.get_audiobook_info(source_id) or {}
+        chapters = info.get("chapters") or []
+        if chapters:
+            raw_total_duration = None
+            for key in ("durationMs", "duration_ms", "duration", "totalDurationMs", "totalDuration"):
+                raw_total_duration = self._to_seconds(info.get(key))
+                if raw_total_duration is not None:
+                    break
+
+            raw_rows = []
+            for idx, chapter in enumerate(chapters):
+                start_raw = None
+                start_key = None
+                for key in (
+                    "startTimeMs", "start_time_ms", "startTimeMillis", "startMillis",
+                    "startMs", "start_ms", "startTime", "start_time", "start",
+                    "offsetMs", "offset_ms", "offset",
+                ):
+                    start_raw = self._to_seconds(chapter.get(key))
+                    if start_raw is not None:
+                        start_key = key
+                        break
+
+                end_raw = None
+                end_key = None
+                for key in (
+                    "endTimeMs", "end_time_ms", "endTimeMillis", "endMillis",
+                    "endMs", "end_ms", "endTime", "end_time", "end",
+                ):
+                    end_raw = self._to_seconds(chapter.get(key))
+                    if end_raw is not None:
+                        end_key = key
+                        break
+
+                duration_raw = None
+                duration_key = None
+                for key in (
+                    "durationMs", "duration_ms", "durationTimeMs", "durationTime",
+                    "lengthMs", "length_ms", "length", "duration",
+                ):
+                    duration_raw = self._to_seconds(chapter.get(key))
+                    if duration_raw is not None:
+                        duration_key = key
+                        break
+
+                raw_rows.append(
+                    {
+                        "id": idx,
+                        "title": chapter.get("title") or f"Chapter {idx + 1}",
+                        "start_raw": start_raw,
+                        "start_key": start_key,
+                        "end_raw": end_raw,
+                        "end_key": end_key,
+                        "duration_raw": duration_raw,
+                        "duration_key": duration_key,
+                    }
+                )
+
+            start_values_raw = [float(row["start_raw"]) for row in raw_rows if row["start_raw"] is not None]
+            end_values_raw = [float(row["end_raw"]) for row in raw_rows if row["end_raw"] is not None]
+            duration_values_raw = [float(row["duration_raw"]) for row in raw_rows if row["duration_raw"] is not None]
+            start_has_ms = any(
+                row["start_raw"] is not None and (("ms" in str(row["start_key"]).lower()) or ("millis" in str(row["start_key"]).lower()))
+                for row in raw_rows
+            )
+            end_has_ms = any(
+                row["end_raw"] is not None and (("ms" in str(row["end_key"]).lower()) or ("millis" in str(row["end_key"]).lower()))
+                for row in raw_rows
+            )
+            duration_has_ms = any(
+                row["duration_raw"] is not None and (("ms" in str(row["duration_key"]).lower()) or ("millis" in str(row["duration_key"]).lower()))
+                for row in raw_rows
+            )
+
+            use_ms_start = self._infer_ms_scale(start_values_raw, start_has_ms, raw_total_duration)
+            use_ms_end = self._infer_ms_scale(end_values_raw, end_has_ms, raw_total_duration)
+            use_ms_duration = self._infer_ms_scale(duration_values_raw, duration_has_ms, raw_total_duration)
+
+            logger.debug(
+                "BookLore audio chapter unit inference: source_id=%s start_ms=%s end_ms=%s duration_ms=%s raw_total=%s",
+                source_id,
+                use_ms_start,
+                use_ms_end,
+                use_ms_duration,
+                raw_total_duration,
+            )
+
+            converted_rows = []
+            for row in raw_rows:
+                start = self._normalize_time_value(row["start_raw"], row["start_key"], use_ms_start)
+                end = self._normalize_time_value(row["end_raw"], row["end_key"], use_ms_end)
+                duration = self._normalize_time_value(row["duration_raw"], row["duration_key"], use_ms_duration)
+                converted_rows.append(
+                    {
+                        "id": row["id"],
+                        "title": row["title"],
+                        "start": float(start) if start is not None else None,
+                        "end": float(end) if end is not None else None,
+                        "duration": max(0.0, float(duration or 0.0)),
+                        "explicit_start": row["start_raw"] is not None,
+                        "explicit_end": row["end_raw"] is not None,
+                    }
+                )
+
+            # Decide whether chapter rows are absolute ranges or duration-only rows.
+            # Some BookLore payloads expose per-chapter durations as end/duration fields.
+            explicit_start_count = sum(1 for row in converted_rows if row["explicit_start"])
+            end_values = [row["end"] for row in converted_rows if row["end"] is not None]
+            ends_monotonic = (
+                len(end_values) >= 2
+                and all(end_values[i] >= end_values[i - 1] for i in range(1, len(end_values)))
+            )
+            explicit_starts = [row["start"] for row in converted_rows if row["explicit_start"] and row["start"] is not None]
+            explicit_starts_all_zero = bool(explicit_starts) and all(abs(float(v)) < 0.001 for v in explicit_starts)
+
+            mode = "absolute"
+            if explicit_start_count == 0:
+                mode = "duration_only"
+                if ends_monotonic:
+                    # If no explicit starts but ends are monotonic and look like timeline offsets,
+                    # treat rows as absolute-end mode.
+                    mode = "absolute_end_only"
+            elif explicit_starts_all_zero and any(row["duration"] > 0 for row in converted_rows):
+                # Guardrail for malformed payloads where every chapter "start" is reported as 0.
+                mode = "duration_only"
+
+            normalized = []
+            cursor = 0.0
+            for row in converted_rows:
+                title = row["title"]
+                if mode == "absolute":
+                    start = row["start"] if row["start"] is not None else cursor
+                    if row["end"] is not None and row["end"] > start:
+                        end = row["end"]
+                    else:
+                        end = start + max(0.0, row["duration"])
+                    if end <= start:
+                        end = start
+                    cursor = max(cursor, end)
+                elif mode == "absolute_end_only":
+                    start = cursor
+                    end = row["end"] if row["end"] is not None else (start + max(0.0, row["duration"]))
+                    if end < start:
+                        end = start
+                    cursor = end
+                else:
+                    # duration_only
+                    start = cursor
+                    duration = row["duration"]
+                    if duration <= 0 and row["end"] is not None:
+                        duration = max(0.0, row["end"])
+                    end = start + duration
+                    cursor = end
+
+                normalized.append(
+                    {
+                        "id": row["id"],
+                        "title": title,
+                        "start": float(start),
+                        "end": float(end),
+                    }
+                )
+
+            valid = [c for c in normalized if c.get("end", 0) > c.get("start", 0)]
+            if valid:
+                logger.debug(
+                    "BookLore audio chapters: source_id=%s mode=%s count=%s end=%.1fs",
+                    source_id,
+                    mode,
+                    len(valid),
+                    float(valid[-1]["end"]),
+                )
+                return valid
+
+        tracks = info.get("tracks") or []
+        if tracks:
+            synthetic = []
+            cursor = 0.0
+            for idx, track in enumerate(tracks):
+                duration = None
+                for key in ("durationMs", "duration_ms", "duration", "lengthMs", "length"):
+                    duration = self._to_seconds(track.get(key))
+                    if duration is not None:
+                        if str(key).lower().endswith("ms"):
+                            duration = duration / 1000.0
+                        break
+                duration = max(0.0, float(duration or 0.0))
+                synthetic.append(
+                    {
+                        "id": idx,
+                        "title": track.get("title") or f"Track {idx + 1}",
+                        "start": cursor,
+                        "end": cursor + duration,
+                    }
+                )
+                cursor += duration
+            logger.debug(
+                "BookLore audio chapters: source_id=%s mode=tracks count=%s end=%.1fs",
+                source_id,
+                len(synthetic),
+                float(synthetic[-1]["end"]) if synthetic else 0.0,
+            )
+            return synthetic
+
+        total_duration = self._extract_duration_seconds(info) or 0.0
+        if total_duration <= 0:
+            return []
+        logger.debug(
+            "BookLore audio chapters: source_id=%s mode=duration_only count=1 end=%.1fs",
+            source_id,
+            float(total_duration),
+        )
+        return [{"id": 0, "title": "Audiobook", "start": 0.0, "end": total_duration}]

--- a/src/services/audio_source_adapters.py
+++ b/src/services/audio_source_adapters.py
@@ -183,8 +183,26 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
 
     @staticmethod
     def _safe_ext(track: dict) -> str:
-        raw_ext = str(track.get("extension") or track.get("ext") or "mp3").lower().strip()
-        return raw_ext.lstrip(".") or "mp3"
+        allowed = {"mp3", "m4a", "m4b", "flac", "ogg", "opus", "aac", "wav"}
+
+        raw_ext = str(track.get("extension") or track.get("ext") or "").lower().strip().lstrip(".")
+        if raw_ext in allowed:
+            return raw_ext
+
+        file_name = str(track.get("fileName") or track.get("filename") or "").strip()
+        if "." in file_name:
+            from_name = file_name.rsplit(".", 1)[-1].lower().lstrip(".")
+            if from_name in allowed:
+                return from_name
+
+        mime = str(track.get("mimeType") or track.get("mime") or "").lower()
+        codec = str(track.get("codec") or "").lower()
+        descriptor = f"{mime} {codec}"
+        if any(token in descriptor for token in ("mp3", "mpeg")):
+            return "mp3"
+        if any(token in descriptor for token in ("mp4", "m4a", "m4b", "aac", "mp4a")):
+            return "m4b"
+        return "mp3"
 
     @staticmethod
     def _to_seconds(raw_value) -> float | None:
@@ -277,8 +295,42 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
     def get_audio_files(self, source_id: str, bridge_key: str | None = None) -> list[dict]:
         info = self.booklore_client.get_audiobook_info(source_id) or {}
         tracks = info.get("tracks") or []
+        track_mode = "tracks"
         if not tracks:
+            # Some BookLore payloads expose chapter markers but no per-file tracks.
+            # In this shape, stream endpoint often serves a single full-book file.
+            chapters = info.get("chapters") or []
+            if chapters:
+                track_mode = "chapter_markers_single_stream"
+                fallback_ext = self._safe_ext(
+                    {
+                        "extension": info.get("extension"),
+                        "mimeType": info.get("mimeType"),
+                        "codec": info.get("codec"),
+                    }
+                )
+                tracks = [
+                    {
+                        "index": 0,
+                        "durationMs": info.get("durationMs"),
+                        "codec": info.get("codec"),
+                        "mimeType": info.get("mimeType") or info.get("contentType"),
+                        "extension": fallback_ext,
+                    }
+                ]
+        if not tracks:
+            logger.warning(
+                "BookLore audio files unavailable: source_id=%s info_keys=%s",
+                source_id,
+                sorted(info.keys()) if isinstance(info, dict) else [],
+            )
             return []
+        logger.debug(
+            "BookLore audio files: source_id=%s mode=%s count=%s",
+            source_id,
+            track_mode,
+            len(tracks),
+        )
 
         cache_key = bridge_key or f"booklore-{source_id}"
         source_cache_dir = self.data_dir / "audio_cache" / str(cache_key) / "source_tracks"
@@ -286,19 +338,22 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
 
         files = []
         for idx, track in enumerate(tracks):
+            download_index = track.get("index")
+            if not isinstance(download_index, int):
+                download_index = idx
             ext = self._safe_ext(track)
             local_path = source_cache_dir / f"track_{idx:03d}.{ext}"
             if not local_path.exists() or local_path.stat().st_size == 0:
-                ok = self.booklore_client.download_audiobook_track(source_id, idx, local_path)
+                ok = self.booklore_client.download_audiobook_track(source_id, download_index, local_path)
                 if not ok:
                     raise RuntimeError(
-                        f"BookLore track download failed for book_id={source_id} track_index={idx}"
+                        f"BookLore track download failed for book_id={source_id} track_index={download_index}"
                     )
             files.append(
                 {
                     "local_path": str(local_path),
                     "ext": ext,
-                    "track_index": idx,
+                    "track_index": download_index,
                     "duration_ms": track.get("durationMs"),
                 }
             )

--- a/src/services/audio_source_adapters.py
+++ b/src/services/audio_source_adapters.py
@@ -256,7 +256,8 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
 
     def search(self, query: str) -> list[AudioResult]:
         results: list[AudioResult] = []
-        for book in self.booklore_client.search_audiobooks(query):
+        include_info = bool(query and query.strip())
+        for book in self.booklore_client.search_audiobooks(query, include_info=include_info):
             book_id = book.get("id")
             if book_id is None:
                 continue

--- a/src/services/client_poller.py
+++ b/src/services/client_poller.py
@@ -22,6 +22,7 @@ class ClientPoller:
     _POLLABLE = [
         ('Storyteller', 'STORYTELLER'),
         ('BookLore', 'BOOKLORE'),
+        ('BookLoreAudio', 'BOOKLORE_AUDIO'),
     ]
 
     def __init__(self, database_service, sync_manager, sync_clients_dict: dict):
@@ -108,6 +109,8 @@ class ClientPoller:
         checked = 0
         for book in active_books:
             try:
+                if hasattr(sync_client, "supports_book") and not sync_client.supports_book(book):
+                    continue
                 current_state = sync_client.get_service_state(book, prev_state=None)
                 if current_state is None:
                     continue

--- a/src/services/forge_service.py
+++ b/src/services/forge_service.py
@@ -390,6 +390,90 @@ class ForgeService:
             logger.error(f"❌ Failed to copy ABS '{abs_id}': {e}", exc_info=True)
             return False
 
+    def _copy_booklore_audio_files(self, book_id: str, dest_folder: Path) -> bool:
+        """Download audiobook tracks from Booklore into dest_folder."""
+        def infer_ext(track: dict, info: dict) -> str:
+            allowed = {"mp3", "m4a", "m4b", "flac", "ogg", "opus", "aac", "wav"}
+            raw_ext = str(track.get("extension") or track.get("ext") or "").lower().strip().lstrip(".")
+            if raw_ext in allowed:
+                return raw_ext
+            file_name = str(track.get("fileName") or "").strip()
+            if "." in file_name:
+                from_name = file_name.rsplit(".", 1)[-1].lower().lstrip(".")
+                if from_name in allowed:
+                    return from_name
+            mime = str(track.get("mimeType") or info.get("mimeType") or info.get("contentType") or "").lower()
+            codec = str(track.get("codec") or info.get("codec") or "").lower()
+            descriptor = f"{mime} {codec}"
+            if "mp3" in descriptor or "mpeg" in descriptor:
+                return "mp3"
+            if any(token in descriptor for token in ("mp4", "m4a", "m4b", "aac", "mp4a")):
+                return "m4b"
+            return "mp3"
+
+        try:
+            info = self.booklore_client.get_audiobook_info(book_id)
+            if not info:
+                logger.warning(f"No audiobook info found for Booklore book '{book_id}'")
+                return False
+
+            logger.debug(f"Booklore audiobook info keys for '{book_id}': {list(info.keys())}")
+            tracks = info.get("tracks") or []
+            track_mode = "tracks"
+            if not tracks:
+                chapters = info.get("chapters") or []
+                if chapters:
+                    # Chapter markers are not guaranteed to map 1:1 to stream indexes.
+                    # Use a single-stream fallback when tracks are missing.
+                    tracks = [
+                        {
+                            "index": 0,
+                            "title": "Audiobook",
+                            "codec": info.get("codec"),
+                            "mimeType": info.get("mimeType") or info.get("contentType"),
+                            "extension": infer_ext({}, info),
+                        }
+                    ]
+                    track_mode = "chapter_markers_single_stream"
+            if not tracks:
+                logger.warning(
+                    f"No audio tracks found for Booklore book '{book_id}' "
+                    f"(info keys: {list(info.keys())})"
+                )
+                return False
+            logger.info(
+                f"Booklore audio mode for '{book_id}': {track_mode} ({len(tracks)} stream item(s))"
+            )
+
+            dest_folder.mkdir(parents=True, exist_ok=True)
+            downloaded = 0
+
+            for idx, track in enumerate(tracks):
+                download_index = track.get("index") if isinstance(track.get("index"), int) else idx
+                ext = infer_ext(track, info)
+                dest_path = dest_folder / f"track_{idx:03d}.{ext}"
+                logger.info(
+                    f"Booklore audio: downloading stream index {download_index} -> '{dest_path.name}'"
+                )
+                if self.booklore_client.download_audiobook_track(book_id, download_index, dest_path):
+                    downloaded += 1
+                else:
+                    logger.error(
+                        f"Failed to download Booklore track index {download_index} for book '{book_id}'"
+                    )
+
+            if downloaded == len(tracks):
+                logger.info(f"Booklore audio: downloaded all {downloaded} tracks for book '{book_id}'")
+                return True
+            else:
+                logger.error(
+                    f"Booklore audio: expected {len(tracks)} tracks, downloaded {downloaded} — Aborting"
+                )
+                return False
+        except Exception as e:
+            logger.error(f"Failed to copy Booklore audio for book '{book_id}': {e}", exc_info=True)
+            return False
+
     def start_manual_forge(self, abs_id, text_item, title, author):
         """
         Start manual forge process in background thread.
@@ -683,19 +767,22 @@ class ForgeService:
             with self.lock:
                 self.active_tasks.discard(title)
 
-    def start_auto_forge_match(self, abs_id, text_item, title, author, original_filename, original_hash):
+    def start_auto_forge_match(self, abs_id, text_item, title, author, original_filename, original_hash,
+                               audio_source: str = None, audio_source_id: str = None):
         """
         Start Auto-Forge & Match pipeline in background thread.
         Links forged artifact to DB after completion.
         """
         thread = threading.Thread(
             target=self._auto_forge_background_task,
-            args=(abs_id, text_item, title, author, original_filename, original_hash),
+            args=(abs_id, text_item, title, author, original_filename, original_hash,
+                  audio_source, audio_source_id),
             daemon=True
         )
         thread.start()
 
-    def _auto_forge_background_task(self, abs_id, text_item, title, author, original_filename, original_hash):
+    def _auto_forge_background_task(self, abs_id, text_item, title, author, original_filename, original_hash,
+                                    audio_source: str = None, audio_source_id: str = None):
         """
         Background task for Auto-Forge & Match pipeline.
         Staging -> Trigger -> Wait -> Download -> Sanitize -> Recalc Hash -> Update DB -> Cleanup
@@ -731,8 +818,12 @@ class ForgeService:
                 course_dir.mkdir(parents=True, exist_ok=True)
             
             # Copy Audio
-            if not self._copy_audio_files(abs_id, course_dir):
-                raise Exception("Failed to copy audio files")
+            if audio_source == 'BookLore' and audio_source_id:
+                if not self._copy_booklore_audio_files(audio_source_id, course_dir):
+                    raise Exception("Failed to copy Booklore audio files")
+            else:
+                if not self._copy_audio_files(abs_id, course_dir):
+                    raise Exception("Failed to copy audio files")
                 
             # Copy Text
             epub_dest = course_dir / f"{safe_title}.epub"

--- a/src/services/suggestions_service.py
+++ b/src/services/suggestions_service.py
@@ -62,6 +62,7 @@ class SuggestionsService:
                 "title": candidate_title,
                 "author": candidate_author,
                 "source": candidate_source,
+                "source_id": getattr(candidate, 'source_id', None) or getattr(candidate, 'booklore_id', None),
                 "search_text": f"{candidate_title} {candidate_author}".strip(),
                 "name": getattr(candidate, 'name', ''),
                 "display_name": getattr(candidate, 'display_name', None) or getattr(candidate, 'name', ''),
@@ -69,8 +70,117 @@ class SuggestionsService:
 
         return prepared
 
+    @staticmethod
+    def _build_bridge_key(audio_source: str, audio_source_id: str) -> str:
+        if not audio_source_id:
+            return ""
+        source_id = str(audio_source_id).strip()
+        if not source_id:
+            return ""
+        if source_id.lower().startswith("booklore:"):
+            return f"booklore:{source_id.split(':', 1)[1].strip()}"
+
+        source_name = str(audio_source or "").strip().lower()
+        if source_name == "booklore":
+            return f"booklore:{source_id}"
+        return source_id
+
+    def _audio_source(self, ab: dict) -> str:
+        source = (ab.get("audio_source") or ab.get("source") or "ABS")
+        source_text = str(source).strip()
+        return source_text or "ABS"
+
+    def _audio_source_id(self, ab: dict) -> str:
+        raw_id = ab.get("audio_source_id") or ab.get("source_id") or ab.get("id")
+        if raw_id is None:
+            return ""
+        value = str(raw_id).strip()
+        if not value:
+            return ""
+        if value.lower().startswith("booklore:"):
+            return value.split(":", 1)[1].strip()
+        return value
+
+    def _audio_bridge_key(self, ab: dict) -> str:
+        explicit = (ab.get("bridge_key") or "").strip()
+        if explicit:
+            return explicit
+
+        source = self._audio_source(ab)
+        source_id = self._audio_source_id(ab)
+        return self._build_bridge_key(source, source_id)
+
+    def _audio_title(self, ab: dict) -> str:
+        title = (ab.get("audio_title") or ab.get("title") or "").strip()
+        if title:
+            return title
+        try:
+            return (self.manager.get_abs_title(ab) or "").strip()
+        except Exception:
+            return ""
+
+    def _audio_author(self, ab: dict) -> str:
+        author = (
+            ab.get("audio_author")
+            or ab.get("authors")
+            or ab.get("author")
+            or ""
+        )
+        author_text = str(author).strip()
+        if author_text:
+            return author_text
+        try:
+            return (self.get_abs_author(ab) or "").strip()
+        except Exception:
+            return ""
+
+    def _audio_duration(self, ab: dict):
+        raw_duration = ab.get("audio_duration")
+        if raw_duration is None:
+            raw_duration = ab.get("duration")
+        if raw_duration is None:
+            try:
+                raw_duration = self.manager.get_duration(ab)
+            except Exception:
+                raw_duration = None
+        try:
+            return float(raw_duration) if raw_duration is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _audio_cover_url(self, ab: dict, audio_source: str, audio_source_id: str) -> str:
+        cover_url = (ab.get("audio_cover_url") or ab.get("cover_url") or "").strip()
+        if cover_url:
+            return cover_url
+        if audio_source == "ABS" and audio_source_id:
+            abs_client = self.container.abs_client()
+            return f"{abs_client.base_url}/api/items/{audio_source_id}/cover?token={abs_client.token}"
+        return ""
+
+    def _audiobook_matches_candidate(
+        self,
+        ab: dict,
+        candidate_search_text: str,
+        audio_title: str,
+        audio_author: str,
+    ) -> bool:
+        if not candidate_search_text:
+            return False
+
+        if ab.get("media") is not None:
+            try:
+                return bool(self.audiobook_matches_search(ab, candidate_search_text))
+            except Exception:
+                return False
+
+        audio_text = f"{audio_title} {audio_author}".strip().lower()
+        candidate_text = candidate_search_text.lower()
+        if not audio_text:
+            return False
+        return candidate_text in audio_text or audio_text in candidate_text
+
     def get_ignored_suggestion_source_ids(self) -> Set[str]:
-        """Return ABS source IDs that are marked as ignored."""
+        """Return source IDs (bridge keys) that are marked as ignored."""
         if hasattr(self.database_service, 'get_ignored_suggestion_source_ids'):
             try:
                 return set(self.database_service.get_ignored_suggestion_source_ids() or [])
@@ -98,19 +208,22 @@ class SuggestionsService:
         """Scan one unmatched audiobook and return a suggestion dict or None."""
         from rapidfuzz import fuzz
 
-        abs_id = ab.get('id')
-        abs_title = (self.manager.get_abs_title(ab) or '').strip()
-        abs_author = (self.get_abs_author(ab) or '').strip()
-        if not abs_id or not abs_title:
+        audio_source = self._audio_source(ab)
+        audio_source_id = self._audio_source_id(ab)
+        bridge_key = self._audio_bridge_key(ab)
+        audio_title = self._audio_title(ab)
+        audio_author = self._audio_author(ab)
+
+        if not bridge_key or not audio_title:
             return None
 
         per_book_pool = candidate_pool
         if not per_book_pool:
             # Fallback keeps prior behavior in source setups where no shared pool is available.
             try:
-                per_book_pool = self._prepare_candidate_pool(self.get_searchable_ebooks(abs_title))
+                per_book_pool = self._prepare_candidate_pool(self.get_searchable_ebooks(audio_title))
             except Exception as e:
-                self.logger.warning(f"Suggestion scan failed to search ebooks for '{abs_title}': {e}")
+                self.logger.warning(f"Suggestion scan failed to search ebooks for '{audio_title}': {e}")
                 return None
 
         matches = []
@@ -119,9 +232,9 @@ class SuggestionsService:
             candidate_author = candidate_info["author"]
             candidate_source = candidate_info.get("source", "")
 
-            title_score = float(fuzz.token_sort_ratio(abs_title, candidate_title))
-            if abs_author:
-                author_score = float(fuzz.token_sort_ratio(abs_author, candidate_author)) if candidate_author else 0.0
+            title_score = float(fuzz.token_sort_ratio(audio_title, candidate_title))
+            if audio_author:
+                author_score = float(fuzz.token_sort_ratio(audio_author, candidate_author)) if candidate_author else 0.0
                 score = (title_score * 0.7) + (author_score * 0.3)
             else:
                 score = title_score
@@ -130,13 +243,19 @@ class SuggestionsService:
                 continue
 
             candidate_search_text = candidate_info["search_text"]
-            direct_match = self.audiobook_matches_search(ab, candidate_search_text) if candidate_search_text else False
+            direct_match = self._audiobook_matches_candidate(
+                ab,
+                candidate_search_text,
+                audio_title,
+                audio_author,
+            )
 
             matches.append({
                 "ebook_filename": candidate_info["name"],
                 "display_name": candidate_info["display_name"],
                 "author": candidate_author,
                 "source": candidate_source,
+                "source_id": candidate_info.get("source_id"),
                 "score": round(score, 1),
                 "_direct_match": direct_match
             })
@@ -148,14 +267,25 @@ class SuggestionsService:
         for m in matches:
             m.pop('_direct_match', None)
 
-        abs_client = self.container.abs_client()
+        audio_cover_url = self._audio_cover_url(ab, audio_source, audio_source_id)
+        audio_duration = self._audio_duration(ab)
         return {
-            "abs_id": abs_id,
-            "abs_title": abs_title,
-            "abs_author": abs_author,
-            "duration": self.manager.get_duration(ab),
-            "cover_url": f"{abs_client.base_url}/api/items/{abs_id}/cover?token={abs_client.token}",
-            "matches": matches
+            "bridge_key": bridge_key,
+            "audio_source": audio_source,
+            "audio_source_id": audio_source_id,
+            "audio_title": audio_title,
+            "audio_author": audio_author,
+            "audio_duration": audio_duration,
+            "audio_cover_url": audio_cover_url,
+            "audio_provider_book_id": str(ab.get("audio_provider_book_id") or audio_source_id or ""),
+            "audio_provider_file_id": str(ab.get("audio_provider_file_id") or ""),
+            # Legacy aliases kept for template/session compatibility.
+            "abs_id": bridge_key,
+            "abs_title": audio_title,
+            "abs_author": audio_author,
+            "duration": audio_duration,
+            "cover_url": audio_cover_url,
+            "matches": matches,
         }
 
     def scan_library_suggestions(
@@ -203,24 +333,32 @@ class SuggestionsService:
                 "stats": {"scanned_new": 0, "reused_cached": 0, "total_unmatched": 0}
             }
 
-        matched_abs_ids = {
-            book.abs_id for book in self.database_service.get_all_books()
-            if getattr(book, 'abs_id', None)
-        }
+        matched_bridge_keys = set()
+        for book in self.database_service.get_all_books():
+            abs_id = getattr(book, "abs_id", None)
+            if abs_id:
+                matched_bridge_keys.add(str(abs_id))
+            mapped_audio_source = getattr(book, "audio_source", None) or "ABS"
+            mapped_audio_source_id = getattr(book, "audio_source_id", None)
+            if mapped_audio_source_id:
+                mapped_key = self._build_bridge_key(str(mapped_audio_source), str(mapped_audio_source_id))
+                if mapped_key:
+                    matched_bridge_keys.add(mapped_key)
+
         ignored_source_ids = self.get_ignored_suggestion_source_ids()
 
         unmatched_audiobooks = []
         for ab in all_audiobooks:
-            abs_id = ab.get('id')
-            if not abs_id:
+            bridge_key = self._audio_bridge_key(ab)
+            if not bridge_key:
                 continue
-            if abs_id in matched_abs_ids:
+            if bridge_key in matched_bridge_keys:
                 continue
-            if abs_id in ignored_source_ids:
+            if bridge_key in ignored_source_ids:
                 continue
-            unmatched_audiobooks.append(ab)
+            unmatched_audiobooks.append((bridge_key, ab))
 
-        unmatched_abs_ids = {ab.get('id') for ab in unmatched_audiobooks if ab.get('id')}
+        unmatched_abs_ids = {bridge_key for bridge_key, _ab in unmatched_audiobooks}
 
         # Keep only cache entries still relevant to current unmatched universe.
         cache_by_abs = {
@@ -235,8 +373,8 @@ class SuggestionsService:
         reused_cached_count = len(cache_by_abs) + len(no_match_abs_ids_set)
 
         new_scan_candidates = [
-            ab for ab in unmatched_audiobooks
-            if ab.get('id') not in cache_by_abs and ab.get('id') not in no_match_abs_ids_set
+            (bridge_key, ab) for bridge_key, ab in unmatched_audiobooks
+            if bridge_key not in cache_by_abs and bridge_key not in no_match_abs_ids_set
         ]
 
         total_unmatched = len(unmatched_abs_ids)
@@ -287,14 +425,13 @@ class SuggestionsService:
                 scanned_new_total,
             )
 
-        for idx, ab in enumerate(new_scan_candidates, start=1):
-            abs_id = ab.get('id')
+        for idx, (bridge_key, ab) in enumerate(new_scan_candidates, start=1):
             suggestion = self._scan_single_audiobook(ab, candidate_pool)
             if suggestion:
-                cache_by_abs[abs_id] = suggestion
-                no_match_abs_ids_set.discard(abs_id)
+                cache_by_abs[bridge_key] = suggestion
+                no_match_abs_ids_set.discard(bridge_key)
             else:
-                no_match_abs_ids_set.add(abs_id)
+                no_match_abs_ids_set.add(bridge_key)
             scanned_new_done = idx
             processed_total = reused_cached_count + scanned_new_done
             percent = (processed_total / total_unmatched) * 100 if total_unmatched else 100

--- a/src/sync_clients/abs_ebook_sync_client.py
+++ b/src/sync_clients/abs_ebook_sync_client.py
@@ -59,7 +59,7 @@ class ABSEbookSyncClient(SyncClient):
     def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
         cfi = state.current.get('cfi')
         pct = state.current.get('pct')
-        epub = book.ebook_filename
+        epub = getattr(book, "original_ebook_filename", None) or book.ebook_filename
         if cfi and epub:
             txt = self.ebook_parser.get_text_around_cfi(epub, cfi)
             if txt:

--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -37,6 +37,9 @@ class ABSSyncClient(SyncClient):
         """ABS audiobook client only syncs audiobooks."""
         return {'audiobook'}
 
+    def supports_book(self, book: Book) -> bool:
+        return getattr(book, "audio_source", "ABS") == "ABS"
+
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         abs_id = book.abs_id
 

--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -38,7 +38,7 @@ class ABSSyncClient(SyncClient):
         return {'audiobook'}
 
     def supports_book(self, book: Book) -> bool:
-        return getattr(book, "audio_source", "ABS") == "ABS"
+        return (getattr(book, "audio_source", None) or "ABS") == "ABS"
 
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         abs_id = book.abs_id

--- a/src/sync_clients/booklore_audio_sync_client.py
+++ b/src/sync_clients/booklore_audio_sync_client.py
@@ -1,0 +1,167 @@
+import logging
+import os
+from typing import Optional
+
+from src.api.booklore_client import BookloreClient
+from src.db.models import Book, State
+from src.sync_clients.sync_client_interface import SyncClient, SyncResult, UpdateProgressRequest, ServiceState
+from src.utils.ebook_utils import EbookParser
+
+logger = logging.getLogger(__name__)
+
+
+class BookLoreAudioSyncClient(SyncClient):
+    def __init__(self, booklore_client: BookloreClient, ebook_parser: EbookParser, alignment_service=None):
+        super().__init__(ebook_parser)
+        self.booklore_client = booklore_client
+        self.alignment_service = alignment_service
+        self.delta_abs_thresh = float(os.getenv("SYNC_DELTA_ABS_SECONDS", 60))
+
+    def is_configured(self) -> bool:
+        return self.booklore_client.is_configured()
+
+    def check_connection(self):
+        return self.booklore_client.check_connection()
+
+    def get_supported_sync_types(self) -> set:
+        return {"audiobook"}
+
+    def supports_book(self, book: Book) -> bool:
+        return getattr(book, "audio_source", None) == "BookLore"
+
+    def _resolve_booklore_book_id(self, book: Book) -> Optional[str]:
+        return (
+            getattr(book, "audio_provider_book_id", None)
+            or getattr(book, "audio_source_id", None)
+        )
+
+    def _resolve_booklore_file_id(self, book: Book) -> Optional[str]:
+        file_id = getattr(book, "audio_provider_file_id", None)
+        if file_id:
+            return str(file_id)
+        book_id = self._resolve_booklore_book_id(book)
+        if not book_id:
+            return None
+        info = self.booklore_client.get_audiobook_info(book_id) or {}
+        fetched = info.get("bookFileId")
+        return str(fetched) if fetched is not None else None
+
+    def _get_duration_seconds(self, book: Book) -> Optional[float]:
+        for attr in ("audio_duration", "duration"):
+            value = getattr(book, attr, None)
+            try:
+                if value is not None and float(value) > 0:
+                    return float(value)
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    def get_service_state(
+        self,
+        book: Book,
+        prev_state: Optional[State],
+        title_snip: str = "",
+        bulk_context: dict = None,
+    ) -> Optional[ServiceState]:
+        book_id = self._resolve_booklore_book_id(book)
+        if not book_id:
+            return None
+
+        progress = self.booklore_client.get_audiobook_progress(book_id)
+        if progress is None:
+            return None
+
+        current_pct = progress.get("pct")
+        position_ms = progress.get("position_ms")
+        current_ts = float(position_ms) / 1000.0 if position_ms is not None else None
+        duration = self._get_duration_seconds(book)
+        if current_pct is None and current_ts is not None and duration:
+            current_pct = min(max(current_ts / duration, 0.0), 1.0)
+        if current_pct is None:
+            current_pct = 0.0
+        if current_ts is None and duration is not None:
+            current_ts = current_pct * duration
+
+        prev_ts = prev_state.timestamp if prev_state and prev_state.timestamp is not None else 0.0
+        prev_pct = prev_state.percentage if prev_state and prev_state.percentage is not None else 0.0
+        delta = abs((current_ts or 0.0) - prev_ts)
+
+        return ServiceState(
+            current={"pct": current_pct, "ts": current_ts},
+            previous_pct=prev_pct,
+            delta=delta,
+            threshold=self.delta_abs_thresh,
+            is_configured=self.booklore_client.is_configured(),
+            display=("BookLoreAudio", "{prev:.4%} -> {curr:.4%}"),
+            value_seconds_formatter=lambda v: f"{v:.2f}s",
+            value_formatter=lambda v: f"{v:.4%}",
+        )
+
+    def get_text_from_current_state(self, book: Book, state: ServiceState):
+        return None
+
+    def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
+        book_id = self._resolve_booklore_book_id(book)
+        if not book_id:
+            return SyncResult(None, False)
+
+        if request.locator_result.percentage == 0.0:
+            success = self.booklore_client.update_audiobook_progress(
+                book_id=book_id,
+                book_file_id=self._resolve_booklore_file_id(book),
+                position_ms=0,
+                percentage=0.0,
+            )
+            updated_state = {"pct": 0.0, "ts": 0.0}
+            if success:
+                try:
+                    from src.services.write_tracker import record_write
+
+                    record_write("BookLoreAudio", book.abs_id, 0.0)
+                except ImportError:
+                    pass
+            return SyncResult(0.0, success, updated_state)
+
+        target_ts = None
+        if book.transcript_file == "DB_MANAGED" and self.alignment_service and request.txt:
+            target_ts = self.alignment_service.get_time_for_text(
+                book.abs_id,
+                request.txt,
+                char_offset_hint=request.locator_result.match_index,
+            )
+
+        if target_ts is None:
+            duration = self._get_duration_seconds(book)
+            if duration:
+                target_ts = max(0.0, min(duration, request.locator_result.percentage * duration))
+
+        if target_ts is None:
+            logger.warning(
+                "BookLoreAudio: cannot update '%s' because no target timestamp could be resolved",
+                getattr(book, "abs_title", book.abs_id),
+            )
+            return SyncResult(None, False)
+
+        position_ms = int(round(target_ts * 1000.0))
+        percentage = request.locator_result.percentage
+        success = self.booklore_client.update_audiobook_progress(
+            book_id=book_id,
+            book_file_id=self._resolve_booklore_file_id(book),
+            position_ms=position_ms,
+            percentage=percentage,
+        )
+        if success:
+            try:
+                from src.services.write_tracker import record_write
+
+                record_write("BookLoreAudio", book.abs_id, percentage)
+            except ImportError:
+                pass
+        return SyncResult(
+            target_ts,
+            success,
+            {
+                "pct": percentage,
+                "ts": target_ts,
+            },
+        )

--- a/src/sync_clients/booklore_audio_sync_client.py
+++ b/src/sync_clients/booklore_audio_sync_client.py
@@ -111,6 +111,8 @@ class BookLoreAudioSyncClient(SyncClient):
                 book_file_id=self._resolve_booklore_file_id(book),
                 position_ms=0,
                 percentage=0.0,
+                track_index=0,
+                track_position_ms=0,
             )
             updated_state = {"pct": 0.0, "ts": 0.0}
             if success:
@@ -149,6 +151,8 @@ class BookLoreAudioSyncClient(SyncClient):
             book_file_id=self._resolve_booklore_file_id(book),
             position_ms=position_ms,
             percentage=percentage,
+            track_index=0,
+            track_position_ms=position_ms,
         )
         if success:
             try:

--- a/src/sync_clients/booklore_audio_sync_client.py
+++ b/src/sync_clients/booklore_audio_sync_client.py
@@ -35,16 +35,170 @@ class BookLoreAudioSyncClient(SyncClient):
             or getattr(book, "audio_source_id", None)
         )
 
-    def _resolve_booklore_file_id(self, book: Book) -> Optional[str]:
+    def _resolve_booklore_file_id(self, book: Book, info: Optional[dict] = None) -> Optional[str]:
         file_id = getattr(book, "audio_provider_file_id", None)
         if file_id:
             return str(file_id)
-        book_id = self._resolve_booklore_book_id(book)
-        if not book_id:
-            return None
-        info = self.booklore_client.get_audiobook_info(book_id) or {}
+        if not isinstance(info, dict):
+            book_id = self._resolve_booklore_book_id(book)
+            if not book_id:
+                return None
+            info = self.booklore_client.get_audiobook_info(book_id) or {}
         fetched = info.get("bookFileId")
         return str(fetched) if fetched is not None else None
+
+    @staticmethod
+    def _coerce_int(value) -> Optional[int]:
+        if value is None or value == "":
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            try:
+                return int(float(value))
+            except (TypeError, ValueError):
+                return None
+
+    def _get_track_ranges(self, info: Optional[dict]) -> list[dict]:
+        if not isinstance(info, dict):
+            return []
+        tracks = info.get("tracks")
+        if not isinstance(tracks, list):
+            return []
+
+        ranges = []
+        cursor_ms = 0
+        for idx, track in enumerate(tracks):
+            if not isinstance(track, dict):
+                continue
+
+            track_index = self._coerce_int(track.get("index"))
+            if track_index is None:
+                track_index = idx
+
+            start_ms = self._coerce_int(track.get("cumulativeStartMs"))
+            if start_ms is None:
+                start_ms = cursor_ms
+
+            duration_ms = self._coerce_int(track.get("durationMs"))
+            if duration_ms is None or duration_ms < 0:
+                continue
+
+            end_ms = start_ms + duration_ms
+            cursor_ms = max(cursor_ms, end_ms)
+            ranges.append(
+                {
+                    "index": track_index,
+                    "start_ms": max(start_ms, 0),
+                    "duration_ms": max(duration_ms, 0),
+                    "end_ms": max(end_ms, start_ms),
+                }
+            )
+
+        return ranges
+
+    def _resolve_absolute_timestamp_from_progress(
+        self,
+        book_id: str,
+        progress: dict,
+        duration: Optional[float],
+        info: Optional[dict] = None,
+    ) -> Optional[float]:
+        current_pct = progress.get("pct")
+        position_ms = self._coerce_int(progress.get("position_ms"))
+        track_index = self._coerce_int(progress.get("track_index"))
+
+        if position_ms is None:
+            if current_pct is not None and duration is not None:
+                logger.debug(
+                    "BookLoreAudio read fallback: book_id=%s mode=percentage_only pct=%.4f duration=%.2fs",
+                    book_id,
+                    float(current_pct),
+                    float(duration),
+                )
+                return max(0.0, min(float(duration), float(current_pct) * float(duration)))
+            return None
+
+        if track_index is None:
+            logger.debug(
+                "BookLoreAudio read resolved: book_id=%s mode=single_stream stored_position_ms=%s",
+                book_id,
+                position_ms,
+            )
+            return float(position_ms) / 1000.0
+
+        track_ranges = self._get_track_ranges(info if info is not None else self.booklore_client.get_audiobook_info(book_id))
+        for track in track_ranges:
+            if track["index"] != track_index:
+                continue
+            absolute_ms = track["start_ms"] + max(position_ms, 0)
+            logger.debug(
+                "BookLoreAudio read resolved: book_id=%s mode=track_reconstructed track_index=%s "
+                "stored_position_ms=%s absolute_position_ms=%s",
+                book_id,
+                track_index,
+                position_ms,
+                absolute_ms,
+            )
+            return float(absolute_ms) / 1000.0
+
+        if current_pct is not None and duration is not None:
+            logger.debug(
+                "BookLoreAudio read fallback: book_id=%s mode=percentage_fallback track_index=%s "
+                "stored_position_ms=%s pct=%.4f duration=%.2fs",
+                book_id,
+                track_index,
+                position_ms,
+                float(current_pct),
+                float(duration),
+            )
+            return max(0.0, min(float(duration), float(current_pct) * float(duration)))
+
+        logger.debug(
+            "BookLoreAudio read unresolved: book_id=%s mode=missing_track_metadata track_index=%s stored_position_ms=%s",
+            book_id,
+            track_index,
+            position_ms,
+        )
+        return None
+
+    def _resolve_resume_fields(
+        self,
+        book_id: str,
+        target_ts: float,
+        info: Optional[dict] = None,
+    ) -> dict:
+        info = info if isinstance(info, dict) else (self.booklore_client.get_audiobook_info(book_id) or {})
+        absolute_target_ms = max(int(round(float(target_ts) * 1000.0)), 0)
+        track_ranges = self._get_track_ranges(info)
+        folder_based = bool(info.get("folderBased")) if isinstance(info, dict) else False
+
+        if folder_based and track_ranges:
+            chosen = track_ranges[-1]
+            for track in track_ranges:
+                if absolute_target_ms < track["end_ms"] or track is track_ranges[-1]:
+                    chosen = track
+                    break
+
+            resume_position_ms = max(absolute_target_ms - chosen["start_ms"], 0)
+            if chosen["duration_ms"] > 0:
+                resume_position_ms = min(resume_position_ms, chosen["duration_ms"])
+
+            return {
+                "absolute_target_ms": absolute_target_ms,
+                "position_ms": resume_position_ms,
+                "track_index": chosen["index"],
+                "track_position_ms": resume_position_ms,
+                "mode": "folder_track",
+            }
+
+        return {
+            "absolute_target_ms": absolute_target_ms,
+            "position_ms": absolute_target_ms,
+            "track_index": None,
+            "track_position_ms": None,
+            "mode": "single_stream",
+        }
 
     def _get_duration_seconds(self, book: Book) -> Optional[float]:
         for attr in ("audio_duration", "duration"):
@@ -72,9 +226,9 @@ class BookLoreAudioSyncClient(SyncClient):
             return None
 
         current_pct = progress.get("pct")
-        position_ms = progress.get("position_ms")
-        current_ts = float(position_ms) / 1000.0 if position_ms is not None else None
         duration = self._get_duration_seconds(book)
+        info = self.booklore_client.get_audiobook_info(book_id) or {}
+        current_ts = self._resolve_absolute_timestamp_from_progress(book_id, progress, duration, info=info)
         if current_pct is None and current_ts is not None and duration:
             current_pct = min(max(current_ts / duration, 0.0), 1.0)
         if current_pct is None:
@@ -105,27 +259,10 @@ class BookLoreAudioSyncClient(SyncClient):
         if not book_id:
             return SyncResult(None, False)
 
-        if request.locator_result.percentage == 0.0:
-            success = self.booklore_client.update_audiobook_progress(
-                book_id=book_id,
-                book_file_id=self._resolve_booklore_file_id(book),
-                position_ms=0,
-                percentage=0.0,
-                track_index=0,
-                track_position_ms=0,
-            )
-            updated_state = {"pct": 0.0, "ts": 0.0}
-            if success:
-                try:
-                    from src.services.write_tracker import record_write
-
-                    record_write("BookLoreAudio", book.abs_id, 0.0)
-                except ImportError:
-                    pass
-            return SyncResult(0.0, success, updated_state)
-
         target_ts = None
-        if book.transcript_file == "DB_MANAGED" and self.alignment_service and request.txt:
+        if request.locator_result.percentage == 0.0:
+            target_ts = 0.0
+        elif book.transcript_file == "DB_MANAGED" and self.alignment_service and request.txt:
             target_ts = self.alignment_service.get_time_for_text(
                 book.abs_id,
                 request.txt,
@@ -144,15 +281,25 @@ class BookLoreAudioSyncClient(SyncClient):
             )
             return SyncResult(None, False)
 
-        position_ms = int(round(target_ts * 1000.0))
         percentage = request.locator_result.percentage
+        info = self.booklore_client.get_audiobook_info(book_id) or {}
+        resume_fields = self._resolve_resume_fields(book_id, target_ts, info=info)
+        logger.debug(
+            "BookLoreAudio write resolved: book_id=%s mode=%s absolute_target_ms=%s "
+            "resume_position_ms=%s track_index=%s",
+            book_id,
+            resume_fields["mode"],
+            resume_fields["absolute_target_ms"],
+            resume_fields["position_ms"],
+            resume_fields["track_index"],
+        )
         success = self.booklore_client.update_audiobook_progress(
             book_id=book_id,
-            book_file_id=self._resolve_booklore_file_id(book),
-            position_ms=position_ms,
+            book_file_id=self._resolve_booklore_file_id(book, info=info),
+            position_ms=resume_fields["position_ms"],
             percentage=percentage,
-            track_index=0,
-            track_position_ms=position_ms,
+            track_index=resume_fields["track_index"],
+            track_position_ms=resume_fields["track_position_ms"],
         )
         if success:
             try:

--- a/src/sync_clients/booklore_sync_client.py
+++ b/src/sync_clients/booklore_sync_client.py
@@ -25,9 +25,28 @@ class BookloreSyncClient(SyncClient):
         """Booklore participates in both audiobook and ebook sync modes."""
         return {'audiobook', 'ebook'}
 
+    @staticmethod
+    def _resolve_epub_filename(book: Book) -> Optional[str]:
+        return getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
+
+    def supports_book(self, book: Book) -> bool:
+        epub = self._resolve_epub_filename(book)
+        if not epub:
+            return False
+
+        # If the selected ebook source is explicitly BookLore, always include
+        # the BookLore ebook client even when the audio source is also BookLore.
+        if getattr(book, "ebook_source", None) == "BookLore":
+            return True
+
+        # Otherwise only participate when the ebook can actually be resolved
+        # against the BookLore library cache.
+        target = self.booklore_client.find_book_by_filename(epub, allow_refresh=False)
+        return bool(target)
+
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         # FIX: Use original filename if available (Tri-Link), otherwise standard filename
-        epub = book.original_ebook_filename or book.ebook_filename
+        epub = self._resolve_epub_filename(book)
         bl_pct, bl_cfi = self.booklore_client.get_progress(epub)
 
         if bl_pct is None:
@@ -52,7 +71,7 @@ class BookloreSyncClient(SyncClient):
     def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
         bl_pct = state.current.get('pct')
         bl_cfi = state.current.get('cfi')
-        epub = getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
+        epub = self._resolve_epub_filename(book)
         if bl_cfi and epub and self.ebook_parser:
             txt = self.ebook_parser.get_text_around_cfi(epub, bl_cfi)
             if txt:
@@ -63,7 +82,7 @@ class BookloreSyncClient(SyncClient):
 
     def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
         # FIX: Use original filename for updates too
-        epub = book.original_ebook_filename or book.ebook_filename
+        epub = self._resolve_epub_filename(book)
         pct = request.locator_result.percentage
         success = self.booklore_client.update_progress(epub, pct, request.locator_result)
         if success:

--- a/src/sync_clients/booklore_sync_client.py
+++ b/src/sync_clients/booklore_sync_client.py
@@ -52,7 +52,7 @@ class BookloreSyncClient(SyncClient):
     def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
         bl_pct = state.current.get('pct')
         bl_cfi = state.current.get('cfi')
-        epub = getattr(book, "ebook_filename", None)
+        epub = getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
         if bl_cfi and epub and self.ebook_parser:
             txt = self.ebook_parser.get_text_around_cfi(epub, bl_cfi)
             if txt:

--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -63,7 +63,7 @@ class KoSyncSyncClient(SyncClient):
     def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
         ko_xpath = state.current.get('xpath')
         ko_pct = state.current.get('pct')
-        epub = getattr(book, "ebook_filename", None)
+        epub = getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
         if ko_xpath and epub:
             txt = self.ebook_parser.resolve_xpath(epub, ko_xpath)
             if txt:
@@ -112,8 +112,13 @@ class KoSyncSyncClient(SyncClient):
         xpath = locator.perfect_ko_xpath if locator and locator.perfect_ko_xpath else locator.xpath
         safe_xpath = self._sanitize_kosync_xpath(xpath, pct)
 
-        if safe_xpath is None and book and book.ebook_filename and pct is not None and pct > 0:
-            regenerated_xpath = self.ebook_parser.get_sentence_level_ko_xpath(book.ebook_filename, pct)
+        epub = (
+            (getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None))
+            if book
+            else None
+        )
+        if safe_xpath is None and epub and pct is not None and pct > 0:
+            regenerated_xpath = self.ebook_parser.get_sentence_level_ko_xpath(epub, pct)
             safe_xpath = self._sanitize_kosync_xpath(regenerated_xpath, pct)
             if safe_xpath:
                 logger.info(f"Recovered malformed KoSync XPath using sentence-level fallback for '{book.abs_title}'")

--- a/src/sync_clients/storyteller_sync_client.py
+++ b/src/sync_clients/storyteller_sync_client.py
@@ -32,6 +32,24 @@ class StorytellerSyncClient(SyncClient):
         """Storyteller participates in both audiobook and ebook sync modes."""
         return {"audiobook", "ebook"}
 
+    def _resolve_storyteller_epub_filename(self, book: Book) -> Optional[str]:
+        """Resolve the best EPUB context for Storyteller href/fragment operations."""
+        current = getattr(book, "ebook_filename", None)
+        if current and str(current).startswith("storyteller_"):
+            return current
+
+        storyteller_uuid = getattr(book, "storyteller_uuid", None)
+        if storyteller_uuid:
+            candidate = f"storyteller_{storyteller_uuid}.epub"
+            try:
+                # Verify the candidate can be resolved by configured EPUB paths.
+                self.ebook_parser.resolve_book_path(candidate)
+                return candidate
+            except Exception:
+                pass
+
+        return current
+
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         # [Tri-Link Fix] Strict UUID Sync Only
         uuid = book.storyteller_uuid
@@ -93,7 +111,9 @@ class StorytellerSyncClient(SyncClient):
 
     def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
         # This needs to be updated to work with the new interface
-        epub = book.ebook_filename
+        epub = self._resolve_storyteller_epub_filename(book)
+        if not epub:
+            return None
         st_pct, href, frag = state.current.get("pct"), state.current.get("href"), state.current.get("frag")
         txt = None
         if href and frag:
@@ -105,36 +125,69 @@ class StorytellerSyncClient(SyncClient):
         return txt
 
     def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
-        epub = book.ebook_filename
+        epub = self._resolve_storyteller_epub_filename(book)
+        if not epub:
+            logger.warning(f"Skipping Storyteller update for {book.abs_title}: missing storyteller EPUB context")
+            return SyncResult(request.locator_result.percentage, False)
+
         pct = request.locator_result.percentage
         locator = request.locator_result
 
-        if not locator.href:
-            # Try to enrich using the matched text if available
-            if request.txt:
-                enriched = self.ebook_parser.find_text_location(
-                    epub, request.txt, hint_percentage=pct
-                )
-                if enriched and enriched.href:
-                    logger.debug(f"Enriched Storyteller locator with href={enriched.href}")
-                    locator = enriched
-
-            # Fallback: if we still don't have href, try to resolve from percentage
-            if not locator.href:
-                fallback_href = self._resolve_href_from_percentage(epub, pct)
-                if fallback_href:
-                    # Merge: keep the percentage but add the href
+        # Always prefer remapping with matched text in Storyteller EPUB context.
+        if request.txt:
+            enriched = self.ebook_parser.find_text_location(
+                epub, request.txt, hint_percentage=pct
+            )
+            if isinstance(enriched, LocatorResult) and enriched.href:
+                logger.debug(f"Enriched Storyteller locator with href={enriched.href}")
+                locator = enriched
+        elif locator.href:
+            try:
+                if not self.ebook_parser.resolve_locator_id(epub, locator.href, locator.fragment):
                     locator = LocatorResult(
                         percentage=pct,
-                        href=fallback_href,
-                        css_selector=None,
                         xpath=locator.xpath,
                         match_index=locator.match_index,
                         cfi=locator.cfi,
-                        fragment=locator.fragment,
+                        href=None,
+                        fragment=None,
                         perfect_ko_xpath=locator.perfect_ko_xpath,
+                        css_selector=locator.css_selector,
+                        chapter_progress=locator.chapter_progress,
+                        fragments=locator.fragments,
                     )
-                    logger.debug(f"Resolved Storyteller href from percentage: {locator.href}")
+            except Exception:
+                locator = LocatorResult(
+                    percentage=pct,
+                    xpath=locator.xpath,
+                    match_index=locator.match_index,
+                    cfi=locator.cfi,
+                    href=None,
+                    fragment=None,
+                    perfect_ko_xpath=locator.perfect_ko_xpath,
+                    css_selector=locator.css_selector,
+                    chapter_progress=locator.chapter_progress,
+                    fragments=locator.fragments,
+                )
+
+        if not locator.href:
+            # Fallback: if we still don't have href, try to resolve from percentage
+            fallback_href = self._resolve_href_from_percentage(epub, pct)
+            if fallback_href:
+                # Merge: keep the percentage but add the href
+                locator = LocatorResult(
+                    percentage=pct,
+                    href=fallback_href,
+                    css_selector=locator.css_selector,
+                    xpath=locator.xpath,
+                    match_index=locator.match_index,
+                    cfi=locator.cfi,
+                    fragment=locator.fragment,
+                    perfect_ko_xpath=locator.perfect_ko_xpath,
+                    chapter_progress=locator.chapter_progress,
+                    fragments=locator.fragments,
+                )
+                logger.debug(f"Resolved Storyteller href from percentage: {locator.href}")
 
         if book.storyteller_uuid:
             success = self.storyteller_client.update_position(book.storyteller_uuid, pct, locator)

--- a/src/sync_clients/sync_client_interface.py
+++ b/src/sync_clients/sync_client_interface.py
@@ -90,6 +90,10 @@ class SyncClient:
         """
         return {'audiobook', 'ebook'}  # Default: supports both
 
+    def supports_book(self, book: Book) -> bool:
+        """Return True when this client is applicable to the provided book."""
+        return True
+
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         """
         Args:

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -248,8 +248,35 @@ class SyncManager:
         cfi_offset = self.ebook_parser.resolve_cfi_to_index(target_epub, safe_locator.cfi) if safe_locator.cfi else None
         cfi_error = abs(int(cfi_offset) - int(target_offset)) if cfi_offset is not None else None
         if cfi_offset is None or cfi_error > tolerance:
-            safe_locator.cfi = None
-            fallback.append("booklore=percent_only")
+            regenerated_cfi = None
+            regenerated_offset = None
+            regenerated_error = None
+
+            # Prefer a fresh CFI derived from the canonical target offset instead of
+            # dropping to percent-only BookLore writes.
+            try:
+                regenerated_locator = self.ebook_parser.get_locator_from_char_offset(target_epub, int(target_offset))
+                candidate_cfi = getattr(regenerated_locator, "cfi", None)
+                if isinstance(candidate_cfi, str) and candidate_cfi:
+                    regenerated_cfi = candidate_cfi
+                    regenerated_offset = self.ebook_parser.resolve_cfi_to_index(target_epub, regenerated_cfi)
+                    if regenerated_offset is not None:
+                        regenerated_error = abs(int(regenerated_offset) - int(target_offset))
+            except Exception as regen_err:
+                logger.debug(f"'{book.abs_id}' Failed to regenerate CFI for BookLore fallback: {regen_err}")
+
+            if regenerated_cfi:
+                safe_locator.cfi = regenerated_cfi
+                cfi_offset = regenerated_offset
+                cfi_error = regenerated_error
+                if regenerated_error is not None and regenerated_error <= tolerance:
+                    fallback.append("booklore=regenerated_cfi")
+                else:
+                    fallback.append("booklore=regenerated_cfi_unverified")
+            elif safe_locator.cfi:
+                fallback.append("booklore=keep_unstable_cfi")
+            else:
+                fallback.append("booklore=no_cfi_available")
 
         logger.debug(
             f"'{book.abs_id}' time->ebook locator roundtrip: ts_target_offset={int(target_offset)} "

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -113,6 +113,48 @@ class SyncManager:
         self._sync_cycle_ebook_cache[ebook_filename] = result
         return result
 
+    def _get_non_story_ebook_filename(self, book: Book | None) -> str | None:
+        """Preferred EPUB for KoSync/Booklore/ABS ebook operations."""
+        if not book:
+            return None
+        original = getattr(book, "original_ebook_filename", None)
+        current = getattr(book, "ebook_filename", None)
+        return original or current
+
+    def _get_storyteller_ebook_filename(self, book: Book | None) -> str | None:
+        """Preferred EPUB for Storyteller href/fragment operations."""
+        if not book:
+            return None
+
+        current = getattr(book, "ebook_filename", None)
+        if current and str(current).startswith("storyteller_"):
+            return current
+
+        storyteller_uuid = getattr(book, "storyteller_uuid", None)
+        if storyteller_uuid:
+            candidate = f"storyteller_{storyteller_uuid}.epub"
+            try:
+                candidate_path = self.ebook_parser.resolve_book_path(candidate)
+                if candidate_path and Path(candidate_path).exists():
+                    return candidate
+            except Exception:
+                pass
+
+        return current
+
+    def _get_epub_for_client(self, book: Book | None, client_name: str | None) -> str | None:
+        if client_name == "Storyteller":
+            return self._get_storyteller_ebook_filename(book)
+        return self._get_non_story_ebook_filename(book)
+
+    def _get_locator_target_epub(self, book: Book | None, leader_name: str | None) -> str | None:
+        """
+        Locator generation target EPUB used for cross-client updates.
+        Prefer non-Storyteller EPUB so KoSync/Booklore/ABS locators stay stable,
+        but fall back to Storyteller artifact when that's all we have.
+        """
+        return self._get_non_story_ebook_filename(book) or self._get_storyteller_ebook_filename(book)
+
     def _build_text_anchors(self, full_text: str, char_offset: int):
         if not full_text:
             return "", "", ""
@@ -165,9 +207,16 @@ class SyncManager:
         except Exception:
             return None, None
 
-    def _validate_and_stabilize_locator(self, book: Book, target_offset: int, locator: LocatorResult):
+    def _validate_and_stabilize_locator(
+        self,
+        book: Book,
+        target_offset: int,
+        locator: LocatorResult,
+        ebook_filename: str | None = None,
+    ):
         """Round-trip validate locator fields and deterministically degrade to safer fields."""
-        if not locator or not getattr(book, "ebook_filename", None):
+        target_epub = ebook_filename or self._get_non_story_ebook_filename(book) or getattr(book, "ebook_filename", None)
+        if not locator or not target_epub:
             return locator
 
         tolerance = int(os.getenv("CROSSFORMAT_ROUNDTRIP_TOLERANCE_CHARS", self.ebook_parser.locator_roundtrip_tolerance))
@@ -176,16 +225,16 @@ class SyncManager:
 
         ko_offset = None
         if safe_locator.perfect_ko_xpath:
-            ko_offset = self.ebook_parser.resolve_xpath_to_index(book.ebook_filename, safe_locator.perfect_ko_xpath)
+            ko_offset = self.ebook_parser.resolve_xpath_to_index(target_epub, safe_locator.perfect_ko_xpath)
         if ko_offset is None and safe_locator.xpath:
-            ko_offset = self.ebook_parser.resolve_xpath_to_index(book.ebook_filename, safe_locator.xpath)
+            ko_offset = self.ebook_parser.resolve_xpath_to_index(target_epub, safe_locator.xpath)
         if ko_offset is None:
             ko_offset = target_offset
 
         ko_error = abs(int(ko_offset) - int(target_offset))
         if ko_error > tolerance:
-            sentence_xpath = self.ebook_parser.get_sentence_level_ko_xpath(book.ebook_filename, safe_locator.percentage)
-            sentence_offset = self.ebook_parser.resolve_xpath_to_index(book.ebook_filename, sentence_xpath) if sentence_xpath else None
+            sentence_xpath = self.ebook_parser.get_sentence_level_ko_xpath(target_epub, safe_locator.percentage)
+            sentence_offset = self.ebook_parser.resolve_xpath_to_index(target_epub, sentence_xpath) if sentence_xpath else None
             sentence_error = abs(int(sentence_offset) - int(target_offset)) if sentence_offset is not None else None
             if sentence_xpath and sentence_offset is not None and sentence_error <= tolerance:
                 safe_locator.xpath = sentence_xpath
@@ -196,7 +245,7 @@ class SyncManager:
                 safe_locator.perfect_ko_xpath = None
                 fallback.append("ko=percent_only")
 
-        cfi_offset = self.ebook_parser.resolve_cfi_to_index(book.ebook_filename, safe_locator.cfi) if safe_locator.cfi else None
+        cfi_offset = self.ebook_parser.resolve_cfi_to_index(target_epub, safe_locator.cfi) if safe_locator.cfi else None
         cfi_error = abs(int(cfi_offset) - int(target_offset)) if cfi_offset is not None else None
         if cfi_offset is None or cfi_error > tolerance:
             safe_locator.cfi = None
@@ -385,17 +434,28 @@ class SyncManager:
         abs_ts = config['ABS'].current.get('ts', 0)
         normalized['ABS'] = abs_ts
 
-        try:
-            full_text, total_text_len = self._get_cached_ebook_text(book.ebook_filename)
-            if total_text_len <= 0:
-                logger.debug(f"'{book.abs_id}' Empty ebook text during cross-format normalization")
-                return None
-        except Exception as e:
-            logger.warning(f"⚠️ '{book.abs_id}' Failed to load ebook text for normalization: {e}")
-            return None
-
         for client_name in ebook_clients:
             if client_name not in self.sync_clients:
+                continue
+
+            client_epub = self._get_epub_for_client(book, client_name)
+            if not client_epub:
+                logger.debug(f"'{book.abs_id}' Missing epub filename for normalization client '{client_name}'")
+                continue
+
+            try:
+                full_text, total_text_len = self._get_cached_ebook_text(client_epub)
+                if total_text_len <= 0:
+                    logger.debug(
+                        f"'{book.abs_id}' Empty ebook text during normalization "
+                        f"for '{client_name}' epub='{sanitize_log_data(client_epub)}'"
+                    )
+                    continue
+            except Exception as e:
+                logger.warning(
+                    f"⚠️ '{book.abs_id}' Failed to load ebook text for normalization "
+                    f"client '{client_name}' epub='{sanitize_log_data(client_epub)}': {e}"
+                )
                 continue
 
             client_state = config[client_name]
@@ -410,17 +470,17 @@ class SyncManager:
             try:
                 char_offset = None
                 if client_xpath:
-                    char_offset = self.ebook_parser.resolve_xpath_to_index(book.ebook_filename, client_xpath)
+                    char_offset = self.ebook_parser.resolve_xpath_to_index(client_epub, client_xpath)
                     if char_offset is not None:
                         normalization_source = "xpath"
 
                 if char_offset is None and client_cfi:
-                    char_offset = self.ebook_parser.resolve_cfi_to_index(book.ebook_filename, client_cfi)
+                    char_offset = self.ebook_parser.resolve_cfi_to_index(client_epub, client_cfi)
                     if char_offset is not None:
                         normalization_source = "cfi"
 
                 if char_offset is None and client_href and client_frag:
-                    txt_at_loc = self.ebook_parser.resolve_locator_id(book.ebook_filename, client_href, client_frag)
+                    txt_at_loc = self.ebook_parser.resolve_locator_id(client_epub, client_href, client_frag)
                     if txt_at_loc:
                         idx = full_text.find(txt_at_loc[:120])
                         if idx >= 0:
@@ -434,7 +494,7 @@ class SyncManager:
 
                 if char_offset is None and client_href:
                     char_offset, href_source = self._resolve_href_to_char_offset(
-                        book.ebook_filename, client_href, client_chapter_progress
+                        client_epub, client_href, client_chapter_progress
                     )
                     if char_offset is not None:
                         normalization_source = href_source
@@ -466,6 +526,7 @@ class SyncManager:
                     continue
 
                 normalized[client_name] = ts_for_text
+                client_state.current["_normalized_ts"] = ts_for_text
                 high_conf_sources = {"xpath", "cfi", "href_frag", "href_progression"}
                 client_state.current["_normalization_confidence"] = (
                     "high" if normalization_source in high_conf_sources else "low"
@@ -580,8 +641,11 @@ class SyncManager:
             not book
             or getattr(book, "transcript_source", None) != "storyteller"
             or abs_timestamp is None
-            or not getattr(book, "ebook_filename", None)
         ):
+            return None, None
+
+        story_epub = self._get_storyteller_ebook_filename(book)
+        if not story_epub:
             return None, None
 
         manifest_path = self._get_storyteller_manifest_path(book)
@@ -595,7 +659,7 @@ class SyncManager:
                 return None, None
 
             global_offset_py = int(story_pos["global_offset_py"])
-            locator = self.ebook_parser.get_locator_from_char_offset(book.ebook_filename, global_offset_py)
+            locator = self.ebook_parser.get_locator_from_char_offset(story_epub, global_offset_py)
             if not locator:
                 return None, None
 
@@ -604,7 +668,7 @@ class SyncManager:
             ) or ""
             logger.debug(
                 f"'{book.abs_id}' Storyteller direct locator resolved via chapter={story_pos['chapter']} "
-                f"offset_utf16={story_pos['offset_utf16']} epub='{sanitize_log_data(book.ebook_filename)}'"
+                f"offset_utf16={story_pos['offset_utf16']} epub='{sanitize_log_data(story_epub)}'"
             )
             return locator, context_txt
         except Exception as e:
@@ -616,10 +680,13 @@ class SyncManager:
         if (
             not book
             or abs_timestamp is None
-            or not getattr(book, "ebook_filename", None)
             or not self.alignment_service
             or getattr(book, "transcript_file", None) != "DB_MANAGED"
         ):
+            return None, None
+
+        target_epub = self._get_non_story_ebook_filename(book) or self._get_storyteller_ebook_filename(book)
+        if not target_epub:
             return None, None
 
         try:
@@ -627,12 +694,12 @@ class SyncManager:
             if char_offset is None:
                 return None, None
 
-            locator = self.ebook_parser.get_locator_from_char_offset(book.ebook_filename, int(char_offset))
+            locator = self.ebook_parser.get_locator_from_char_offset(target_epub, int(char_offset))
             if not locator:
                 return None, None
-            locator = self._validate_and_stabilize_locator(book, int(char_offset), locator)
+            locator = self._validate_and_stabilize_locator(book, int(char_offset), locator, ebook_filename=target_epub)
 
-            full_text, _ = self._get_cached_ebook_text(book.ebook_filename)
+            full_text, _ = self._get_cached_ebook_text(target_epub)
             context_txt = ""
             if full_text:
                 start = max(0, int(char_offset) - 400)
@@ -642,7 +709,7 @@ class SyncManager:
             logger.debug(
                 f"'{book.abs_id}' time->ebook mapping ts={float(abs_timestamp):.2f}s offset0={int(char_offset)} "
                 f"locator_xpath={'yes' if locator.xpath else 'no'} locator_cfi={'yes' if locator.cfi else 'no'} "
-                f"epub='{sanitize_log_data(book.ebook_filename)}'"
+                f"epub='{sanitize_log_data(target_epub)}'"
             )
             return locator, context_txt
         except Exception as e:
@@ -968,6 +1035,10 @@ class SyncManager:
         logger.info(f"⚡ [{job_idx}/{job_total}] Processing '{sanitize_log_data(abs_title)}'")
 
         try:
+            ebook_only_mode = bool(
+                hasattr(book, "sync_mode") and getattr(book, "sync_mode", "audiobook") == "ebook_only"
+            )
+
             def update_progress(local_pct, phase):
                 """
                 Map local phase progress to global 0-100% progress.
@@ -991,7 +1062,13 @@ class SyncManager:
             update_progress(0.0, 1)
 
             # Fetch item details for acquisition context
-            item_details = self.abs_client.get_item_details(abs_id)
+            item_details = None
+            if not ebook_only_mode:
+                item_details = self.abs_client.get_item_details(abs_id)
+            else:
+                logger.info(
+                    f"Ebook-only background prep: skipping ABS item lookup for '{sanitize_log_data(abs_title)}'"
+                )
             
             epub_path = None
             if self.library_service and item_details:
@@ -1030,6 +1107,26 @@ class SyncManager:
                             logger.info(f"✅ Locked KOSync ID: {computed_hash}")
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to eager-lock KOSync ID: {e}")
+
+            if ebook_only_mode:
+                logger.info(
+                    f"Ebook-only background prep: skipping Storyteller/SMIL/Whisper transcript generation for '{sanitize_log_data(abs_title)}'"
+                )
+                # Warm parser caches for subsequent locator-based sync cycles.
+                self.ebook_parser.extract_text_and_map(epub_path)
+                update_progress(1.0, 3)
+                book.status = 'active'
+                self.database_service.save_book(book)
+
+                job = self.database_service.get_latest_job(abs_id)
+                if job:
+                    job.retry_count = 0
+                    job.last_error = None
+                    job.progress = 1.0
+                    self.database_service.save_job(job)
+
+                logger.info(f"✅ Completed (ebook-only): {sanitize_log_data(abs_title)}")
+                return
 
             raw_transcript = None
             transcript_source = None
@@ -1677,7 +1774,7 @@ class SyncManager:
                 leader_client = self.sync_clients[leader]
                 leader_state = config[leader]
 
-                epub = book.ebook_filename
+                epub = self._get_locator_target_epub(book, leader)
                 txt = None
                 locator = None
                 locator_source = None
@@ -1696,8 +1793,23 @@ class SyncManager:
                         if locator:
                             locator_source = "storyteller_direct"
                             logger.debug(f"'{abs_id}' '{title_snip}' Using storyteller direct timestamp->locator path")
+                else:
+                    normalized_ts = leader_state.current.get("_normalized_ts")
+                    if normalized_ts is not None:
+                        locator, txt = self._resolve_alignment_locator_from_abs_timestamp(book, normalized_ts)
+                        if locator:
+                            locator_source = "alignment_from_normalized_ts"
+                            logger.debug(
+                                f"'{abs_id}' '{title_snip}' Using normalized timestamp->locator path "
+                                f"for leader '{leader}' (ts={float(normalized_ts):.2f}s)"
+                            )
 
                 if not locator:
+                    if not epub:
+                        logger.warning(
+                            f"⚠️ '{abs_id}' '{title_snip}' Missing locator target EPUB; cannot derive cross-client locator"
+                        )
+                        continue
                     txt = leader_client.get_text_from_current_state(book, leader_state)
                     if not txt:
                         logger.warning(f"⚠️ '{abs_id}' '{title_snip}' Could not get text from leader '{leader}'")
@@ -1725,7 +1837,7 @@ class SyncManager:
 
                 logger.debug(
                     f"'{abs_id}' '{title_snip}' Locator resolved via source={locator_source or 'unknown'} "
-                    f"epub='{sanitize_log_data(book.ebook_filename)}' "
+                    f"epub='{sanitize_log_data(epub)}' "
                     f"original_epub='{sanitize_log_data(getattr(book, 'original_ebook_filename', None))}'"
                 )
 

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -51,6 +51,7 @@ class SyncManager:
                  alignment_service: AlignmentService = None,
                  library_service: LibraryService = None,
                  migration_service: MigrationService = None,
+                 audio_source_adapters: dict | None = None,
                  epub_cache_dir=None,
                  data_dir=None,
                  books_dir=None):
@@ -69,6 +70,7 @@ class SyncManager:
         self.alignment_service = alignment_service
         self.library_service = library_service
         self.migration_service = migration_service
+        self.audio_source_adapters = audio_source_adapters or {}
         
         self.data_dir = data_dir
         self.books_dir = books_dir
@@ -154,6 +156,30 @@ class SyncManager:
         but fall back to Storyteller artifact when that's all we have.
         """
         return self._get_non_story_ebook_filename(book) or self._get_storyteller_ebook_filename(book)
+
+    def _get_audio_source_name(self, book: Book | None) -> str | None:
+        if not book:
+            return None
+        source = getattr(book, "audio_source", None)
+        if source:
+            return source
+        if getattr(book, "sync_mode", "audiobook") == "ebook_only":
+            return None
+        return "ABS"
+
+    def _get_primary_audio_client_name(self, book: Book | None) -> str | None:
+        source = self._get_audio_source_name(book)
+        if source == "BookLore":
+            return "BookLoreAudio"
+        if source == "ABS":
+            return "ABS"
+        return None
+
+    def _get_audio_source_adapter(self, book: Book | None):
+        source = self._get_audio_source_name(book)
+        if not source:
+            return None
+        return self.audio_source_adapters.get(source)
 
     def _build_text_anchors(self, full_text: str, char_offset: int):
         if not full_text:
@@ -447,10 +473,15 @@ class SyncManager:
 
     def _normalize_for_cross_format_comparison(self, book, config):
         """Normalize ebook locators to audiobook timeline with deterministic anchors."""
-        has_abs = 'ABS' in config
-        ebook_clients = [k for k in config.keys() if k != 'ABS']
+        primary_audio_client = self._get_primary_audio_client_name(book)
+        has_primary_audio = bool(primary_audio_client and primary_audio_client in config)
+        ebook_clients = [
+            k for k in config.keys()
+            if k != primary_audio_client
+            and 'ebook' in self.sync_clients.get(k).get_supported_sync_types()
+        ]
 
-        if not has_abs or not ebook_clients:
+        if not has_primary_audio or not ebook_clients:
             return None
 
         if not book.transcript_file:
@@ -458,8 +489,8 @@ class SyncManager:
             return None
 
         normalized = {}
-        abs_ts = config['ABS'].current.get('ts', 0)
-        normalized['ABS'] = abs_ts
+        abs_ts = config[primary_audio_client].current.get('ts', 0)
+        normalized[primary_audio_client] = abs_ts
 
         for client_name in ebook_clients:
             if client_name not in self.sync_clients:
@@ -575,6 +606,9 @@ class SyncManager:
         clients_to_use = clients_to_use or self.sync_clients
         config = {}
         bulk_states_per_client = bulk_states_per_client or {}
+
+        if not clients_to_use:
+            return config
 
         with ThreadPoolExecutor(max_workers=len(clients_to_use)) as executor:
             futures = {}
@@ -1065,6 +1099,9 @@ class SyncManager:
             ebook_only_mode = bool(
                 hasattr(book, "sync_mode") and getattr(book, "sync_mode", "audiobook") == "ebook_only"
             )
+            audio_adapter = self._get_audio_source_adapter(book)
+            audio_source = self._get_audio_source_name(book)
+            audio_source_id = getattr(book, "audio_source_id", None) or abs_id
 
             def update_progress(local_pct, phase):
                 """
@@ -1090,8 +1127,12 @@ class SyncManager:
 
             # Fetch item details for acquisition context
             item_details = None
-            if not ebook_only_mode:
+            if not ebook_only_mode and audio_source == "ABS":
                 item_details = self.abs_client.get_item_details(abs_id)
+            elif not ebook_only_mode:
+                logger.info(
+                    f"Background prep: skipping ABS item lookup for non-ABS audio source '{sanitize_log_data(audio_source or 'unknown')}'"
+                )
             else:
                 logger.info(
                     f"Ebook-only background prep: skipping ABS item lookup for '{sanitize_log_data(abs_title)}'"
@@ -1161,7 +1202,10 @@ class SyncManager:
 
             # [MOVED UP] Fetch item details to get chapters (for time alignment) and for Ebook Acquisition
             # item_details = self.abs_client.get_item_details(abs_id) # Already fetched above
-            chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
+            if audio_adapter and not ebook_only_mode:
+                chapters = audio_adapter.get_chapters(audio_source_id)
+            else:
+                chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
             
             # [NEW] Pre-fetch book text for validation/alignment
             # We need this for Validating SMIL OR for Aligning Whisper
@@ -1212,7 +1256,9 @@ class SyncManager:
             if not storyteller_aligned and not raw_transcript:
                 logger.info("🔄 SMIL extraction skipped/failed, falling back to Whisper transcription")
                 
-                audio_files = self.abs_client.get_audio_files(abs_id)
+                if not audio_adapter:
+                    raise RuntimeError(f"No audio source adapter configured for '{audio_source}'")
+                audio_files = audio_adapter.get_audio_files(audio_source_id, bridge_key=abs_id)
                 raw_transcript = self.transcriber.process_audio(
                     abs_id, audio_files,
                     full_book_text=book_text, # Passed for context/alignment inside transcriber if old logic used
@@ -1391,6 +1437,7 @@ class SyncManager:
         # "Most recent change wins" - if only one client changed, it becomes the leader
         # Use hybrid time/percentage logic to filter out phantom API noise
         normalized_positions = self._normalize_for_cross_format_comparison(book, config)
+        primary_audio_client = self._get_primary_audio_client_name(book)
         clients_with_delta = {k: v for k, v in vals.items() if self._has_significant_delta(k, config, book)}
 
         # Suppress raw pct delta when locator-derived position shows no movement from previous state.
@@ -1416,13 +1463,15 @@ class SyncManager:
         leader_pct = None
 
         single_delta_low_conf = False
+        low_conf_single_delta_client = None
         if len(clients_with_delta) == 1:
             changed_client = list(clients_with_delta.keys())[0]
             changed_source = config[changed_client].current.get("_normalization_source")
+
             if (
                 normalized_positions
                 and len(normalized_positions) > 1
-                and changed_client != "ABS"
+                and changed_client != primary_audio_client
             ):
                 changed_ts = normalized_positions.get(changed_client)
                 other_ts = [
@@ -1430,8 +1479,9 @@ class SyncManager:
                     if name != changed_client and name in vals
                 ]
 
-                if changed_source == "percent_fallback" and "ABS" in vals:
+                if changed_source == "percent_fallback" and primary_audio_client in vals:
                     single_delta_low_conf = True
+                    low_conf_single_delta_client = changed_client
                     logger.info(
                         f"🔄 '{abs_id}' '{title_snip}' Ignoring single-client delta from "
                         f"'{changed_client}' (low-confidence source=percent_fallback); evaluating all candidates"
@@ -1474,7 +1524,7 @@ class SyncManager:
                     high_conf_normalized_candidates = {}
                     for candidate_name, candidate_ts in normalized_candidates.items():
                         candidate_source = config[candidate_name].current.get("_normalization_source")
-                        if candidate_name == "ABS" or candidate_source != "percent_fallback":
+                        if candidate_name == primary_audio_client or candidate_source != "percent_fallback":
                             high_conf_normalized_candidates[candidate_name] = candidate_ts
                     selected_normalized_candidates = (
                         high_conf_normalized_candidates
@@ -1491,16 +1541,39 @@ class SyncManager:
 
                     leader = max(selected_normalized_candidates, key=selected_normalized_candidates.get)
                     leader_ts = selected_normalized_candidates[leader]
-                    if leader != "ABS" and "ABS" in selected_normalized_candidates:
-                        abs_ts = selected_normalized_candidates["ABS"]
+                    if leader != primary_audio_client and primary_audio_client in selected_normalized_candidates:
+                        abs_ts = selected_normalized_candidates[primary_audio_client]
                         ts_delta = leader_ts - abs_ts
                         if ts_delta <= getattr(self, "cross_format_deadband_seconds", 2.0):
                             logger.debug(
                                 f"'{abs_id}' '{title_snip}' Deadband prevents cross-format switch: "
                                 f"candidate={leader} ts={leader_ts:.1f}s abs_ts={abs_ts:.1f}s delta={ts_delta:.2f}s"
                             )
-                            leader = "ABS"
+                            leader = primary_audio_client
                             leader_ts = abs_ts
+
+                    # Guardrail: avoid destructive 0% resets on first-progress bootstrap.
+                    # If primary audio is still at/near 0 but we have a non-zero single-client
+                    # low-confidence update, prefer that non-zero candidate over forcing a reset.
+                    if (
+                        low_conf_single_delta_client
+                        and leader == primary_audio_client
+                        and primary_audio_client in vals
+                    ):
+                        primary_pct = float(vals.get(primary_audio_client) or 0.0)
+                        candidate_pct = float(vals.get(low_conf_single_delta_client) or 0.0)
+                        candidate_ts = normalized_positions.get(low_conf_single_delta_client)
+                        if primary_pct <= 0.001 and candidate_pct >= 0.005:
+                            deadband_s = getattr(self, "cross_format_deadband_seconds", 2.0)
+                            if candidate_ts is None or candidate_ts > deadband_s:
+                                leader = low_conf_single_delta_client
+                                leader_ts = normalized_positions.get(leader, leader_ts)
+                                logger.warning(
+                                    f"⚠️ '{abs_id}' '{title_snip}' Guardrail: promoting "
+                                    f"'{low_conf_single_delta_client}' ({candidate_pct:.2%}, source=percent_fallback) "
+                                    f"over primary audio 0% to prevent destructive reset"
+                                )
+
                     leader_pct = vals[leader]
                     locator_pct = config[leader].current.get("_locator_pct")
                     if locator_pct is not None and abs(locator_pct - leader_pct) > 0.01:
@@ -1510,7 +1583,10 @@ class SyncManager:
                         )
                         leader_pct = locator_pct
                         config[leader].current['pct'] = leader_pct
-                    leader_source = config[leader].current.get("_normalization_source", "abs")
+                    leader_source = config[leader].current.get(
+                        "_normalization_source",
+                        primary_audio_client.lower() if primary_audio_client else "audio",
+                    )
                     logger.info(
                         f"🔄 '{abs_id}' '{title_snip}' {leader} leads at "
                         f"{config[leader].value_formatter(leader_pct)} "
@@ -1640,7 +1716,7 @@ class SyncManager:
                 sync_type = 'ebook' if (hasattr(book, 'sync_mode') and book.sync_mode == 'ebook_only') else 'audiobook'
                 active_clients = {
                     name: client for name, client in self.sync_clients.items()
-                    if sync_type in client.get_supported_sync_types()
+                    if sync_type in client.get_supported_sync_types() and client.supports_book(book)
                 }
                 if sync_type == 'ebook':
                     logger.debug(f"'{abs_id}' '{title_snip}' Ebook-only mode - using clients: {list(active_clients.keys())}")
@@ -1655,15 +1731,16 @@ class SyncManager:
                 # Check for ABS offline condition (only for audiobook mode)
                 # Check for ABS offline condition (only for audiobook mode)
                 if not (hasattr(book, 'sync_mode') and book.sync_mode == 'ebook_only'):
-                    abs_state = config.get('ABS')
-                    if abs_state is None:
+                    primary_audio_client = self._get_primary_audio_client_name(book)
+                    audio_state = config.get(primary_audio_client) if primary_audio_client else None
+                    if audio_state is None:
                         # Fallback logic: If ABS is missing but we have ebook clients, try to sync them as ebook-only
-                        ebook_clients_active = [k for k in config.keys() if k != 'ABS']
+                        ebook_clients_active = [k for k in config.keys() if k != primary_audio_client]
                         if ebook_clients_active:
-                             logger.info(f"'{abs_id}' '{title_snip}' ABS audiobook not found/offline, falling back to ebook-only sync between {ebook_clients_active}")
+                             logger.info(f"'{abs_id}' '{title_snip}' Primary audio source not found/offline, falling back to ebook-only sync between {ebook_clients_active}")
                         else:
-                             logger.debug(f"'{abs_id}' '{title_snip}' ABS audiobook offline and no other clients, skipping")
-                             continue  # ABS offline and no fallback possible
+                             logger.debug(f"'{abs_id}' '{title_snip}' Primary audio source offline and no other clients, skipping")
+                             continue
 
 
 
@@ -1806,7 +1883,8 @@ class SyncManager:
                 locator = None
                 locator_source = None
 
-                if leader == 'ABS':
+                primary_audio_client = self._get_primary_audio_client_name(book)
+                if leader == primary_audio_client:
                     abs_timestamp = leader_state.current.get('ts')
                     locator, txt = self._resolve_alignment_locator_from_abs_timestamp(book, abs_timestamp)
                     if locator:
@@ -1870,13 +1948,10 @@ class SyncManager:
 
                 # Update all other clients and store results
                 results: dict[str, SyncResult] = {}
-                for client_name, client in self.sync_clients.items():
+                for client_name, client in active_clients.items():
                     if client_name == leader:
                         continue
 
-                    # Skip ABS update if in ebook-only mode
-                    if client_name == 'ABS' and hasattr(book, 'sync_mode') and book.sync_mode == 'ebook_only':
-                        continue
                     try:
                         request = UpdateProgressRequest(locator, txt, previous_location=config.get(client_name).previous_pct if config.get(client_name) else None)
                         result = client.update_progress(book, request)
@@ -1971,7 +2046,15 @@ class SyncManager:
                 locator = LocatorResult(percentage=0.0)
                 request = UpdateProgressRequest(locator_result=locator, txt="", previous_location=None)
 
-                for client_name, client in self.sync_clients.items():
+                applicable_clients = {
+                    name: client for name, client in self.sync_clients.items()
+                    if (
+                        ('ebook' if getattr(book, 'sync_mode', 'audiobook') == 'ebook_only' else 'audiobook') in client.get_supported_sync_types()
+                        and client.supports_book(book)
+                    )
+                }
+
+                for client_name, client in applicable_clients.items():
                     if client_name == 'ABS' and book.sync_mode == 'ebook_only':
                         logger.debug(f"'{book.abs_title}' Ebook-only mode - skipping ABS progress reset")
                         continue

--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -25,10 +25,12 @@ from src.services.alignment_service import AlignmentService # [NEW]
 from src.services.library_service import LibraryService # [NEW]
 from src.services.migration_service import MigrationService # [NEW]
 from src.services.forge_service import ForgeService
+from src.services.audio_source_adapters import ABSAudioSourceAdapter, BookLoreAudioSourceAdapter
 from src.sync_clients.abs_sync_client import ABSSyncClient
 from src.sync_clients.kosync_sync_client import KoSyncSyncClient
 from src.sync_clients.storyteller_sync_client import StorytellerSyncClient
 from src.sync_clients.booklore_sync_client import BookloreSyncClient
+from src.sync_clients.booklore_audio_sync_client import BookLoreAudioSyncClient
 from src.sync_clients.abs_ebook_sync_client import ABSEbookSyncClient
 from src.sync_clients.hardcover_sync_client import HardcoverSyncClient
 from src.sync_manager import SyncManager
@@ -186,6 +188,13 @@ class Container(containers.DeclarativeContainer):
         ebook_parser
     )
 
+    booklore_audio_sync_client = providers.Singleton(
+        BookLoreAudioSyncClient,
+        booklore_client,
+        ebook_parser,
+        alignment_service=alignment_service,
+    )
+
     abs_ebook_sync_client = providers.Singleton(
         ABSEbookSyncClient,
         abs_client,
@@ -200,6 +209,22 @@ class Container(containers.DeclarativeContainer):
         database_service
     )
 
+    abs_audio_source_adapter = providers.Singleton(
+        ABSAudioSourceAdapter,
+        abs_client=abs_client,
+    )
+
+    booklore_audio_source_adapter = providers.Singleton(
+        BookLoreAudioSourceAdapter,
+        booklore_client=booklore_client,
+        data_dir=data_dir,
+    )
+
+    audio_source_adapters = providers.Dict(
+        ABS=abs_audio_source_adapter,
+        BookLore=booklore_audio_source_adapter,
+    )
+
     # Sync clients dictionary for reuse
     sync_clients = providers.Dict(
         ABS=abs_sync_client,
@@ -207,6 +232,7 @@ class Container(containers.DeclarativeContainer):
         KoSync=kosync_sync_client,
         Storyteller=storyteller_sync_client,
         BookLore=booklore_sync_client,
+        BookLoreAudio=booklore_audio_sync_client,
         Hardcover=hardcover_sync_client
     )
 
@@ -226,6 +252,7 @@ class Container(containers.DeclarativeContainer):
         alignment_service=alignment_service,
         library_service=library_service,
         migration_service=migration_service,
+        audio_source_adapters=audio_source_adapters,
 
         epub_cache_dir=epub_cache_dir,
         data_dir=data_dir,

--- a/src/utils/smil_extractor.py
+++ b/src/utils/smil_extractor.py
@@ -90,7 +90,7 @@ class SmilExtractor:
                 
                 logger.info(f"📖 Found {len(smil_files)} SMIL files in EPUB")
                 if abs_chapters:
-                    logger.info(f"📖 ABS has {len(abs_chapters)} chapters")
+                    logger.info(f"📖 Audio source has {len(abs_chapters)} chapters")
                 
                 # Detect timestamp mode
                 timestamp_mode = self._detect_timestamp_mode(zf, smil_files)
@@ -111,7 +111,7 @@ class SmilExtractor:
                         logger.info(f"   Using Smart Duration Mapping (Files: {len(smil_files)}, Chapters: {len(abs_chapters)})")
                         transcript = self._process_relative_with_chapters(zf, smil_files, abs_chapters)
                     else:
-                        logger.info(f"   Using Sequential Stacking (No ABS chapters provided)")
+                        logger.info(f"   Using Sequential Stacking (No audio chapters provided)")
                         transcript = self._process_relative_sequential(zf, smil_files, audio_offset)
                 else:
                     # Auto/Smart mode
@@ -339,7 +339,7 @@ class SmilExtractor:
                 if last_matched_abs_idx != -1 and best_match_idx > last_matched_abs_idx + 1:
                     logger.info(f"   ⏭️ Skipped {best_match_idx - last_matched_abs_idx - 1} ABS tracks to find match.")
                 
-                logger.debug(f"   🔗 Matched SMIL {Path(smil_path).name} ({smil_duration:.1f}s) to ABS Ch {best_match_idx} ({abs_chapters[best_match_idx].get('start', 0):.1f}s) - diff: {smallest_diff:.1f}s")
+                logger.debug(f"   🔗 Matched SMIL {Path(smil_path).name} ({smil_duration:.1f}s) to Audio Ch {best_match_idx} ({abs_chapters[best_match_idx].get('start', 0):.1f}s) - diff: {smallest_diff:.1f}s")
                 last_matched_abs_idx = best_match_idx
                 offset = best_offset
                 current_sequential_offset = float(abs_chapters[best_match_idx].get('end', 0))

--- a/src/utils/transcriber.py
+++ b/src/utils/transcriber.py
@@ -494,17 +494,22 @@ class AudioTranscriber:
 
                     logger.info(f"📥 Phase 1: Downloading {len(audio_urls)} audio files...")
                     for idx, audio_data in enumerate(audio_urls):
-                        stream_url = audio_data['stream_url']
+                        stream_url = audio_data.get('stream_url')
+                        local_source_path = audio_data.get('local_path')
                         extension = audio_data.get('ext', '.mp3')
                         if not extension.startswith('.'): extension = f".{extension}"
                         local_path = book_cache_dir / f"part_{idx:03d}{extension}"
 
-                        logger.info(f"   Downloading Part {idx + 1}/{len(audio_urls)}...")
-                        with requests.get(stream_url, stream=True, timeout=300) as r:
-                            r.raise_for_status()
-                            with open(local_path, 'wb') as f:
-                                for chunk in r.iter_content(chunk_size=8192):
-                                    f.write(chunk)
+                        if local_source_path:
+                            logger.info(f"   Copying Part {idx + 1}/{len(audio_urls)} from local cache...")
+                            shutil.copy2(local_source_path, local_path)
+                        else:
+                            logger.info(f"   Downloading Part {idx + 1}/{len(audio_urls)}...")
+                            with requests.get(stream_url, stream=True, timeout=300) as r:
+                                r.raise_for_status()
+                                with open(local_path, 'wb') as f:
+                                    for chunk in r.iter_content(chunk_size=8192):
+                                        f.write(chunk)
 
                         if not local_path.exists() or local_path.stat().st_size == 0:
                             raise ValueError(f"File {local_path} is empty or missing.")

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1333,6 +1333,92 @@ def get_abs_author(ab):
     return metadata.get('authorName') or (metadata.get('authors') or [{}])[0].get("name", "")
 
 
+def _coerce_author_display(value):
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, dict):
+        return (value.get("name") or value.get("authorName") or "").strip()
+    if isinstance(value, list):
+        names = []
+        for item in value:
+            if isinstance(item, dict):
+                name = (item.get("name") or item.get("authorName") or "").strip()
+            else:
+                name = str(item).strip() if item is not None else ""
+            if name:
+                names.append(name)
+        return ", ".join(names)
+    return ""
+
+
+def _get_cached_ebook_display_metadata(book):
+    candidates = []
+    for filename in (
+        getattr(book, "original_ebook_filename", None),
+        getattr(book, "ebook_filename", None),
+    ):
+        if filename and filename not in candidates:
+            candidates.append(filename)
+
+    for filename in candidates:
+        cached = database_service.get_booklore_book(filename)
+        if not cached:
+            continue
+        raw = cached.raw_metadata_dict if hasattr(cached, "raw_metadata_dict") else {}
+        title = (raw.get("title") or getattr(cached, "title", "") or "").strip()
+        subtitle = (raw.get("subtitle") or "").strip()
+        author = _coerce_author_display(raw.get("authors")) or (getattr(cached, "authors", "") or "").strip()
+        if title or subtitle or author:
+            return {"title": title, "subtitle": subtitle, "author": author}
+    return {}
+
+
+def _get_storyteller_display_metadata(storyteller_uuid):
+    if not storyteller_uuid:
+        return {}
+    try:
+        st_client = container.storyteller_client()
+        if not st_client or not st_client.is_configured() or not hasattr(st_client, "get_book_details"):
+            return {}
+        details = st_client.get_book_details(storyteller_uuid) or {}
+        return {
+            "title": (details.get("title") or "").strip(),
+            "subtitle": (details.get("subtitle") or "").strip(),
+            "author": _coerce_author_display(details.get("authors")),
+        }
+    except Exception as exc:
+        logger.debug("Storyteller metadata lookup failed for '%s': %s", storyteller_uuid, exc)
+        return {}
+
+
+def _resolve_dashboard_display_metadata(book, base_title, base_subtitle, base_author):
+    title = (base_title or "").strip()
+    subtitle = (base_subtitle or "").strip()
+    author = (base_author or "").strip()
+    sync_mode = getattr(book, "sync_mode", "audiobook")
+    is_storyteller_placeholder = title.lower().startswith("storyteller_")
+
+    cached_meta = _get_cached_ebook_display_metadata(book)
+    if cached_meta:
+        if (sync_mode == "ebook_only" or is_storyteller_placeholder or not title) and cached_meta.get("title"):
+            title = cached_meta["title"]
+        if not subtitle and cached_meta.get("subtitle"):
+            subtitle = cached_meta["subtitle"]
+        if not author and cached_meta.get("author"):
+            author = cached_meta["author"]
+
+    storyteller_meta = _get_storyteller_display_metadata(getattr(book, "storyteller_uuid", None))
+    if storyteller_meta:
+        if (sync_mode == "ebook_only" or is_storyteller_placeholder or not title) and storyteller_meta.get("title"):
+            title = storyteller_meta["title"]
+        if not subtitle and storyteller_meta.get("subtitle"):
+            subtitle = storyteller_meta["subtitle"]
+        if not author and storyteller_meta.get("author"):
+            author = storyteller_meta["author"]
+
+    return title or (base_title or "").strip(), subtitle, author
+
+
 def _storyteller_transcript_source(storyteller_uuid, storyteller_manifest):
     return "storyteller" if storyteller_uuid or storyteller_manifest else None
 
@@ -1433,16 +1519,22 @@ def index():
         _abs_meta = abs_metadata_by_id.get(book.abs_id, {})
         abs_subtitle = _abs_meta.get('subtitle', '')
         abs_author = _abs_meta.get('author', '')
+        display_title, abs_subtitle, abs_author = _resolve_dashboard_display_metadata(
+            book,
+            book.abs_title,
+            abs_subtitle,
+            abs_author,
+        )
 
         # Create mapping dict for template compatibility
         mapping = {
             'abs_id': book.abs_id,
-            'abs_title': book.abs_title,
+            'abs_title': display_title,
             'abs_subtitle': abs_subtitle,
             'abs_author': abs_author,
             'audio_source': getattr(book, 'audio_source', None) or ('ABS' if getattr(book, 'sync_mode', 'audiobook') != 'ebook_only' else None),
             'audio_source_id': getattr(book, 'audio_source_id', None) or book.abs_id,
-            'audio_title': getattr(book, 'audio_title', None) or book.abs_title,
+            'audio_title': getattr(book, 'audio_title', None) or display_title,
             'audio_duration': getattr(book, 'audio_duration', None) or book.duration or 0,
             'audio_cover_url': getattr(book, 'audio_cover_url', None),
             'ebook_filename': book.ebook_filename,
@@ -1866,7 +1958,12 @@ def match():
             if not (storyteller_uuid or selected_filename):
                 return "Please select a text source (Storyteller or Standard Ebook)", 400
 
-            ebook_only_title = Path(selected_filename).stem if selected_filename else f"storyteller_{storyteller_uuid or 'book'}"
+            storyteller_meta = _get_storyteller_display_metadata(storyteller_uuid)
+            ebook_only_title = (
+                Path(selected_filename).stem
+                if selected_filename
+                else (storyteller_meta.get("title") or f"storyteller_{storyteller_uuid or 'book'}")
+            )
             logger.info(
                 "Match: entering ebook-only create path (storyteller_selected=%s, ebook_selected=%s)",
                 bool(storyteller_uuid),

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -919,6 +919,46 @@ def get_searchable_audiobooks(search_term):
     return results
 
 
+def get_suggestion_audiobooks():
+    """Return provider-normalized audiobook records for suggestions scan."""
+    records = []
+    for item in get_searchable_audiobooks(""):
+        if not isinstance(item, AudioResult):
+            continue
+
+        audio_source = (item.source or "").strip() or "ABS"
+        source_id = str(item.source_id or "").strip()
+        if not source_id:
+            continue
+        bridge_key = _build_bridge_key(audio_source, source_id)
+        if not bridge_key:
+            continue
+
+        title = (item.title or item.display_name or bridge_key).strip()
+        author = (item.authors or "").strip()
+        records.append(
+            {
+                "bridge_key": bridge_key,
+                "audio_source": audio_source,
+                "audio_source_id": source_id,
+                "audio_title": title,
+                "audio_author": author,
+                "audio_duration": item.duration,
+                "audio_cover_url": item.cover_url or "",
+                "audio_provider_book_id": str(item.provider_book_id or source_id),
+                "audio_provider_file_id": str(item.provider_file_id or ""),
+                # Legacy aliases maintained for compatibility with existing templates/session keys.
+                "id": bridge_key,
+                "title": title,
+                "authors": author,
+                "duration": item.duration,
+                "cover_url": item.cover_url or "",
+            }
+        )
+
+    return records
+
+
 def get_searchable_ebooks(search_term):
     """Get ebooks from Booklore API, filesystem, ABS, and CWA.
     Returns list of EbookResult objects for consistent interface."""
@@ -1035,9 +1075,19 @@ def get_searchable_ebooks(search_term):
 
 
 def _build_bridge_key(audio_source, audio_source_id):
-    if audio_source == "BookLore":
-        return f"booklore:{audio_source_id}"
-    return audio_source_id
+    if audio_source_id is None:
+        return None
+    source_id = str(audio_source_id).strip()
+    if not source_id:
+        return None
+
+    if source_id.lower().startswith("booklore:"):
+        return f"booklore:{source_id.split(':', 1)[1].strip()}"
+
+    source_name = str(audio_source or "").strip().lower()
+    if source_name == "booklore":
+        return f"booklore:{source_id}"
+    return source_id
 
 
 def _parse_audio_duration(raw_value):
@@ -2495,7 +2545,7 @@ def _get_suggestions_service():
         database_service=database_service,
         container=container,
         manager=manager,
-        get_audiobooks_conditionally=get_audiobooks_conditionally,
+        get_audiobooks_conditionally=get_suggestion_audiobooks,
         get_searchable_ebooks=get_searchable_ebooks,
         audiobook_matches_search=audiobook_matches_search,
         get_abs_author=get_abs_author,
@@ -2504,7 +2554,7 @@ def _get_suggestions_service():
 
 
 def _get_ignored_suggestion_source_ids():
-    """Return ABS source IDs that are marked as ignored."""
+    """Return suggestion source IDs (bridge keys) that are marked as ignored."""
     return _get_suggestions_service().get_ignored_suggestion_source_ids()
 
 
@@ -2782,32 +2832,64 @@ def suggestions_page():
             return redirect(url_for('suggestions'))
 
         elif action == 'never':
-            abs_id = request.form.get('abs_id')
-            if abs_id:
+            bridge_key = (request.form.get('bridge_key') or request.form.get('abs_id') or '').strip()
+            if bridge_key:
                 from src.db.models import PendingSuggestion
 
                 current_scan_results = suggestions_state.get('scan_results', [])
-                current_entry = next((s for s in current_scan_results if s.get('abs_id') == abs_id), None)
-                abs_title = request.form.get('abs_title') or (current_entry.get('abs_title') if current_entry else '') or ''
-                abs_author = request.form.get('abs_author') or (current_entry.get('abs_author') if current_entry else '') or ''
+                current_entry = next(
+                    (
+                        s for s in current_scan_results
+                        if (s.get('bridge_key') or s.get('abs_id')) == bridge_key
+                    ),
+                    None,
+                )
+                audio_source = (
+                    request.form.get('audio_source')
+                    or (current_entry.get('audio_source') if current_entry else '')
+                    or ('BookLore' if bridge_key.startswith('booklore:') else 'ABS')
+                ).strip() or 'ABS'
+                abs_title = (
+                    request.form.get('audio_title')
+                    or request.form.get('abs_title')
+                    or (current_entry.get('audio_title') if current_entry else '')
+                    or (current_entry.get('abs_title') if current_entry else '')
+                    or ''
+                )
+                abs_author = (
+                    request.form.get('audio_author')
+                    or request.form.get('abs_author')
+                    or (current_entry.get('audio_author') if current_entry else '')
+                    or (current_entry.get('abs_author') if current_entry else '')
+                    or ''
+                )
                 cover_url = request.form.get('cover_url') or (current_entry.get('cover_url') if current_entry else '') or ''
 
-                if not database_service.ignore_suggestion(abs_id):
-                    database_service.save_pending_suggestion(PendingSuggestion(
-                        source_id=abs_id,
+                if not database_service.ignore_suggestion(bridge_key):
+                    suggestion = PendingSuggestion(
+                        source_id=bridge_key,
                         title=abs_title,
                         author=abs_author,
                         cover_url=cover_url,
                         matches_json="[]",
                         status='ignored'
-                    ))
+                    )
+                    suggestion.source = audio_source
+                    database_service.save_pending_suggestion(suggestion)
 
-                suggestions_state['scan_results'] = [item for item in current_scan_results if item.get('abs_id') != abs_id]
+                suggestions_state['scan_results'] = [
+                    item
+                    for item in current_scan_results
+                    if (item.get('bridge_key') or item.get('abs_id')) != bridge_key
+                ]
                 cache_by_abs = suggestions_state.get('scan_cache_by_abs', {}) or {}
-                if abs_id in cache_by_abs:
-                    cache_by_abs.pop(abs_id, None)
+                if bridge_key in cache_by_abs:
+                    cache_by_abs.pop(bridge_key, None)
                     suggestions_state['scan_cache_by_abs'] = cache_by_abs
-                no_match_abs_ids = [x for x in (suggestions_state.get('scan_cache_no_match_abs_ids', []) or []) if x != abs_id]
+                no_match_abs_ids = [
+                    x for x in (suggestions_state.get('scan_cache_no_match_abs_ids', []) or [])
+                    if x != bridge_key
+                ]
                 suggestions_state['scan_cache_no_match_abs_ids'] = no_match_abs_ids
                 suggestions_state['updated_at'] = time.time()
 
@@ -2815,22 +2897,72 @@ def suggestions_page():
 
         elif action == 'add_to_queue':
             session.setdefault('queue', [])
-            abs_id = request.form.get('audiobook_id')
+            bridge_key = (request.form.get('audiobook_id') or '').strip()
+            audio_source = (
+                request.form.get('audio_source')
+                or ('BookLore' if bridge_key.startswith('booklore:') else ('ABS' if bridge_key else ''))
+            ).strip() or None
+            audio_source_id = (request.form.get('audio_source_id') or bridge_key).strip() or None
+            audio_title = (request.form.get('audio_title') or '').strip() or None
+            audio_cover_url = (request.form.get('audio_cover_url') or '').strip() or None
+            audio_provider_book_id = (request.form.get('audio_provider_book_id') or audio_source_id or '').strip() or None
+            audio_provider_file_id = (request.form.get('audio_provider_file_id') or '').strip() or None
+            audio_duration = _parse_audio_duration(request.form.get('audio_duration'))
             ebook_filename = request.form.get('ebook_filename', '')
             ebook_display_name = request.form.get('ebook_display_name', ebook_filename)
+            ebook_source = (request.form.get('ebook_source') or '').strip() or None
+            ebook_source_id = (request.form.get('ebook_source_id') or '').strip() or None
             storyteller_uuid = request.form.get('storyteller_uuid', '')
-            audiobooks = container.abs_client().get_all_audiobooks()
-            selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None)
-            if selected_ab and (ebook_filename or storyteller_uuid):
-                if not any(item['abs_id'] == abs_id for item in session['queue']):
+            selected_audio = None
+            if audio_source == 'ABS' and audio_source_id:
+                selected_ab = None
+                if not audio_title or audio_duration is None:
+                    abs_items = container.abs_client().get_all_audiobooks()
+                    selected_ab = next((ab for ab in abs_items if str(ab.get('id')) == audio_source_id), None)
+
+                resolved_title = audio_title or (manager.get_abs_title(selected_ab) if selected_ab else '') or audio_source_id
+                resolved_duration = audio_duration if audio_duration is not None else (
+                    manager.get_duration(selected_ab) if selected_ab else None
+                )
+                resolved_cover = (
+                    audio_cover_url
+                    or f"{container.abs_client().base_url}/api/items/{audio_source_id}/cover?token={container.abs_client().token}"
+                )
+                selected_audio = {
+                    'bridge_key': bridge_key or audio_source_id,
+                    'audio_source': 'ABS',
+                    'audio_source_id': audio_source_id,
+                    'audio_title': resolved_title,
+                    'audio_duration': resolved_duration,
+                    'audio_cover_url': resolved_cover,
+                    'audio_provider_book_id': audio_provider_book_id or audio_source_id,
+                    'audio_provider_file_id': audio_provider_file_id,
+                }
+            elif audio_source == 'BookLore' and audio_source_id:
+                selected_audio = {
+                    'bridge_key': bridge_key or _build_bridge_key('BookLore', audio_source_id),
+                    'audio_source': 'BookLore',
+                    'audio_source_id': audio_source_id,
+                    'audio_title': audio_title or f"BookLore {audio_source_id}",
+                    'audio_duration': audio_duration,
+                    'audio_cover_url': audio_cover_url,
+                    'audio_provider_book_id': audio_provider_book_id,
+                    'audio_provider_file_id': audio_provider_file_id,
+                }
+
+            if selected_audio and (ebook_filename or storyteller_uuid):
+                if not any(item.get('bridge_key') == selected_audio['bridge_key'] for item in session['queue']):
                     session['queue'].append({
-                        "abs_id": abs_id,
-                        "abs_title": manager.get_abs_title(selected_ab),
+                        **selected_audio,
+                        "abs_id": selected_audio['bridge_key'],
+                        "abs_title": selected_audio['audio_title'],
                         "ebook_filename": ebook_filename,
                         "ebook_display_name": ebook_display_name,
+                        "ebook_source": ebook_source,
+                        "ebook_source_id": ebook_source_id,
                         "storyteller_uuid": storyteller_uuid,
-                        "duration": manager.get_duration(selected_ab),
-                        "cover_url": f"{container.abs_client().base_url}/api/items/{abs_id}/cover?token={container.abs_client().token}"
+                        "duration": selected_audio['audio_duration'],
+                        "cover_url": selected_audio['audio_cover_url'],
                     })
                     session.modified = True
             return redirect(url_for('suggestions'))
@@ -2850,6 +2982,28 @@ def suggestions_page():
             from src.db.models import Book
 
             for item in session.get('queue', []):
+                audio_source = item.get('audio_source') or 'ABS'
+                if audio_source == 'BookLore':
+                    saved_book, err_msg, _err_code = _create_or_update_booklore_audio_mapping(
+                        audio_source_id=item.get('audio_source_id'),
+                        audio_title=item.get('audio_title'),
+                        audio_cover_url=item.get('audio_cover_url'),
+                        audio_duration=_parse_audio_duration(item.get('audio_duration')),
+                        audio_provider_book_id=item.get('audio_provider_book_id'),
+                        audio_provider_file_id=item.get('audio_provider_file_id'),
+                        ebook_filename=item.get('ebook_filename'),
+                        ebook_source=item.get('ebook_source'),
+                        ebook_source_id=item.get('ebook_source_id'),
+                        storyteller_uuid=item.get('storyteller_uuid'),
+                    )
+                    if err_msg:
+                        logger.warning(
+                            "Suggestions skipped BookLore audiobook '%s': %s",
+                            sanitize_log_data(item.get('audio_title') or item.get('audio_source_id')),
+                            err_msg,
+                        )
+                    continue
+
                 ebook_filename = item['ebook_filename']
                 storyteller_uuid = item.get('storyteller_uuid', '')
                 original_ebook_filename = item['ebook_filename']
@@ -2913,6 +3067,12 @@ def suggestions_page():
                 book = Book(
                     abs_id=item['abs_id'],
                     abs_title=item['abs_title'],
+                    audio_source="ABS",
+                    audio_source_id=item['abs_id'],
+                    audio_title=item['abs_title'],
+                    audio_cover_url=item.get('cover_url'),
+                    audio_duration=duration,
+                    audio_provider_book_id=item['abs_id'],
                     ebook_filename=ebook_filename,
                     kosync_doc_id=kosync_doc_id,
                     transcript_file=storyteller_manifest,
@@ -2920,7 +3080,9 @@ def suggestions_page():
                     duration=duration,
                     transcript_source=transcript_source,
                     storyteller_uuid=storyteller_uuid or None,
-                    original_ebook_filename=original_ebook_filename
+                    original_ebook_filename=original_ebook_filename,
+                    ebook_source=item.get('ebook_source'),
+                    ebook_source_id=item.get('ebook_source_id'),
                 )
 
                 database_service.save_book(book)
@@ -2992,7 +3154,10 @@ def suggestions_page():
     cache_by_abs = suggestions_state.get('scan_cache_by_abs', {}) or {}
     no_match_abs_ids = suggestions_state.get('scan_cache_no_match_abs_ids', []) or []
     if ignored_source_ids:
-        filtered_results = [item for item in scan_results if item.get('abs_id') not in ignored_source_ids]
+        filtered_results = [
+            item for item in scan_results
+            if (item.get('bridge_key') or item.get('abs_id')) not in ignored_source_ids
+        ]
         filtered_cache_by_abs = {
             abs_id: suggestion for abs_id, suggestion in cache_by_abs.items()
             if abs_id not in ignored_source_ids
@@ -3010,6 +3175,96 @@ def suggestions_page():
             suggestions_state['scan_cache_no_match_abs_ids'] = filtered_no_match_abs_ids
             no_match_abs_ids = filtered_no_match_abs_ids
             suggestions_state['updated_at'] = time.time()
+        _save_persisted_suggestions_cache({
+            "scan_cache_by_abs": suggestions_state.get('scan_cache_by_abs', {}),
+            "scan_cache_no_match_abs_ids": suggestions_state.get('scan_cache_no_match_abs_ids', []),
+            "scan_last_stats": suggestions_state.get('scan_last_stats', {}),
+        })
+
+    active_suggestion_keys = set()
+    for book in database_service.get_all_books():
+        abs_id = str(getattr(book, 'abs_id', '') or '').strip()
+        if abs_id:
+            active_suggestion_keys.add(abs_id)
+            if abs_id.lower().startswith("booklore_audio_"):
+                legacy_source_id = abs_id.split("_", 2)[-1].strip()
+                legacy_bridge = _build_bridge_key("BookLore", legacy_source_id)
+                if legacy_bridge:
+                    active_suggestion_keys.add(legacy_bridge)
+
+        mapped_bridge = _build_bridge_key(
+            getattr(book, 'audio_source', None),
+            getattr(book, 'audio_source_id', None),
+        )
+        if mapped_bridge:
+            active_suggestion_keys.add(mapped_bridge)
+
+    if active_suggestion_keys:
+        filtered_results = [
+            item for item in scan_results
+            if (item.get('bridge_key') or item.get('abs_id')) not in active_suggestion_keys
+        ]
+        filtered_cache_by_abs = {
+            key: suggestion for key, suggestion in cache_by_abs.items()
+            if key not in active_suggestion_keys
+        }
+        filtered_no_match_abs_ids = [
+            key for key in no_match_abs_ids if key not in active_suggestion_keys
+        ]
+        if len(filtered_results) != len(scan_results):
+            suggestions_state['scan_results'] = filtered_results
+            scan_results = filtered_results
+            suggestions_state['updated_at'] = time.time()
+        if len(filtered_cache_by_abs) != len(cache_by_abs):
+            suggestions_state['scan_cache_by_abs'] = filtered_cache_by_abs
+            cache_by_abs = filtered_cache_by_abs
+            suggestions_state['updated_at'] = time.time()
+        if len(filtered_no_match_abs_ids) != len(no_match_abs_ids):
+            suggestions_state['scan_cache_no_match_abs_ids'] = filtered_no_match_abs_ids
+            no_match_abs_ids = filtered_no_match_abs_ids
+            suggestions_state['updated_at'] = time.time()
+        _save_persisted_suggestions_cache({
+            "scan_cache_by_abs": suggestions_state.get('scan_cache_by_abs', {}),
+            "scan_cache_no_match_abs_ids": suggestions_state.get('scan_cache_no_match_abs_ids', []),
+            "scan_last_stats": suggestions_state.get('scan_last_stats', {}),
+        })
+
+    def _normalize_suggestion_identity_part(value):
+        normalized = re.sub(r'[\W_]+', ' ', str(value or '').lower()).strip()
+        return normalized
+
+    deduped_results = []
+    seen_identity = {}
+    removed_duplicate_keys = []
+    for item in scan_results:
+        suggestion_key = (item.get('bridge_key') or item.get('abs_id') or '').strip()
+        source = (item.get('audio_source') or ('BookLore' if suggestion_key.startswith('booklore:') else 'ABS')).strip().lower()
+        title = _normalize_suggestion_identity_part(item.get('audio_title') or item.get('abs_title'))
+        author = _normalize_suggestion_identity_part(item.get('audio_author') or item.get('abs_author'))
+        if not title:
+            dedupe_key = ('key', suggestion_key)
+        else:
+            dedupe_key = (source, title, author)
+
+        if dedupe_key in seen_identity:
+            removed_duplicate_keys.append(suggestion_key)
+            continue
+
+        seen_identity[dedupe_key] = suggestion_key
+        deduped_results.append(item)
+
+    if removed_duplicate_keys:
+        removed_set = set(removed_duplicate_keys)
+        scan_results = deduped_results
+        suggestions_state['scan_results'] = deduped_results
+        filtered_cache_by_abs = {
+            key: suggestion for key, suggestion in cache_by_abs.items()
+            if key not in removed_set
+        }
+        if len(filtered_cache_by_abs) != len(cache_by_abs):
+            cache_by_abs = filtered_cache_by_abs
+            suggestions_state['scan_cache_by_abs'] = filtered_cache_by_abs
+        suggestions_state['updated_at'] = time.time()
         _save_persisted_suggestions_cache({
             "scan_cache_by_abs": suggestions_state.get('scan_cache_by_abs', {}),
             "scan_cache_no_match_abs_ids": suggestions_state.get('scan_cache_no_match_abs_ids', []),

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1090,6 +1090,47 @@ def _build_bridge_key(audio_source, audio_source_id):
     return source_id
 
 
+def _normalize_text_source_type(raw_source):
+    source_text = str(raw_source or "").strip()
+    if not source_text:
+        return ""
+    source_map = {
+        "booklore": "Booklore",
+        "abs": "ABS",
+        "cwa": "CWA",
+        "local file": "Local File",
+    }
+    return source_map.get(source_text.lower(), source_text)
+
+
+def _build_forge_text_item(source_type, source_id, source_path, original_filename):
+    normalized_source = _normalize_text_source_type(source_type)
+    normalized_source_id = str(source_id or "").strip()
+    normalized_source_path = str(source_path or "").strip()
+
+    text_item = {
+        "source": normalized_source,
+        "path": normalized_source_path,
+        "booklore_id": normalized_source_id,
+        "cwa_id": normalized_source_id,
+        "abs_id": normalized_source_id,
+        "filename": original_filename,
+    }
+
+    if normalized_source == "ABS":
+        text_item["abs_id"] = normalized_source_id
+    if normalized_source == "Booklore":
+        text_item["booklore_id"] = normalized_source_id
+    if normalized_source == "CWA":
+        text_item["cwa_id"] = normalized_source_id
+        if normalized_source_path:
+            text_item["download_url"] = normalized_source_path
+    if normalized_source == "Local File":
+        text_item["path"] = normalized_source_path
+
+    return text_item
+
+
 def _parse_audio_duration(raw_value):
     try:
         if raw_value is None or raw_value == "":
@@ -2040,25 +2081,10 @@ def match():
             source_type = request.form.get('source_type')
             source_path = request.form.get('source_path')
             source_id = request.form.get('source_id')
+            text_item = _build_forge_text_item(source_type, source_id, source_path, original_filename)
+            normalized_source_type = text_item.get("source")
 
-            text_item = {
-                "source": source_type,
-                "path": source_path,
-                "booklore_id": source_id,
-                "cwa_id": source_id,
-                "abs_id": source_id,
-                "filename": original_filename
-            }
-
-            if source_type == 'ABS': text_item['abs_id'] = source_id
-            if source_type == 'Booklore': text_item['booklore_id'] = source_id
-            if source_type == 'CWA':
-                text_item['cwa_id'] = source_id
-                if source_path:
-                    text_item['download_url'] = source_path
-            if source_type == 'Local File': text_item['path'] = source_path
-
-            initial_booklore_id = source_id if source_type == 'Booklore' else None
+            initial_booklore_id = source_id if normalized_source_type == 'Booklore' else None
             kosync_doc_id = get_kosync_id_for_ebook(original_filename, initial_booklore_id)
 
             if not kosync_doc_id:
@@ -2068,7 +2094,7 @@ def match():
 
             if audio_source == 'BookLore':
                 forge_title = audio_title or Path(selected_filename or f"booklore_{audio_source_id}").stem
-                forge_id = f"booklore_audio_{audio_source_id}"
+                forge_id = _build_bridge_key('BookLore', audio_source_id)
                 book = Book(
                     abs_id=forge_id,
                     abs_title=forge_title,
@@ -2325,6 +2351,7 @@ def batch_match():
             ebook_display_name = request.form.get('ebook_display_name', ebook_filename)
             ebook_source = (request.form.get('ebook_source') or request.form.get('source_type') or '').strip() or None
             ebook_source_id = (request.form.get('ebook_source_id') or request.form.get('source_id') or '').strip() or None
+            ebook_source_path = (request.form.get('ebook_source_path') or request.form.get('source_path') or '').strip() or None
             storyteller_uuid = request.form.get('storyteller_uuid', '')
             audiobooks = container.abs_client().get_all_audiobooks()
             selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None)
@@ -2362,6 +2389,7 @@ def batch_match():
                         "ebook_display_name": ebook_display_name,
                         "ebook_source": ebook_source,
                         "ebook_source_id": ebook_source_id,
+                        "ebook_source_path": ebook_source_path,
                         "storyteller_uuid": storyteller_uuid,
                         "duration": selected_audio['audio_duration'],
                         "cover_url": selected_audio['audio_cover_url'],
@@ -2377,6 +2405,279 @@ def batch_match():
             session['queue'] = []
             session.modified = True
             return redirect(url_for('batch_match'))
+        elif action == 'forge_and_match_queue':
+            from src.db.models import Book
+
+            for item in session.get('queue', []):
+                audio_source = item.get('audio_source') or 'ABS'
+                storyteller_uuid = item.get('storyteller_uuid', '')
+
+                # If Storyteller is selected, keep the current direct-match path.
+                if storyteller_uuid:
+                    if audio_source == 'BookLore':
+                        saved_book, err_msg, _err_code = _create_or_update_booklore_audio_mapping(
+                            audio_source_id=item.get('audio_source_id'),
+                            audio_title=item.get('audio_title'),
+                            audio_cover_url=item.get('audio_cover_url'),
+                            audio_duration=_parse_audio_duration(item.get('audio_duration')),
+                            audio_provider_book_id=item.get('audio_provider_book_id'),
+                            audio_provider_file_id=item.get('audio_provider_file_id'),
+                            ebook_filename=item.get('ebook_filename'),
+                            ebook_source=item.get('ebook_source'),
+                            ebook_source_id=item.get('ebook_source_id'),
+                            storyteller_uuid=storyteller_uuid,
+                        )
+                        if err_msg:
+                            logger.warning(
+                                "Batch Forge skipped BookLore audiobook '%s': %s",
+                                sanitize_log_data(item.get('audio_title') or item.get('audio_source_id')),
+                                err_msg,
+                            )
+                        continue
+
+                    ebook_filename = item['ebook_filename']
+                    original_ebook_filename = item['ebook_filename']
+                    duration = item['duration']
+                    kosync_doc_id = None
+
+                    try:
+                        epub_cache = container.epub_cache_dir()
+                        if not epub_cache.exists():
+                            epub_cache.mkdir(parents=True, exist_ok=True)
+
+                        target_filename = f"storyteller_{storyteller_uuid}.epub"
+                        target_path = epub_cache / target_filename
+
+                        logger.info(
+                            "Batch Forge: Using Storyteller Artifact '%s' for '%s'",
+                            sanitize_log_data(storyteller_uuid),
+                            sanitize_log_data(item.get('abs_title')),
+                        )
+
+                        if container.storyteller_client().download_book(storyteller_uuid, target_path):
+                            original_ebook_filename = ebook_filename
+                            ebook_filename = target_filename
+
+                            kosync_doc_id = _compute_storyteller_trilink_kosync_id(
+                                original_ebook_filename,
+                                target_filename,
+                                "Batch Forge Tri-Link",
+                            )
+                        else:
+                            logger.warning(
+                                "Batch Forge: Failed to download Storyteller artifact '%s' for '%s', skipping",
+                                sanitize_log_data(storyteller_uuid),
+                                sanitize_log_data(item.get('abs_title')),
+                            )
+                            continue
+                    except Exception as e:
+                        logger.error(
+                            "Batch Forge: Storyteller Tri-Link failed for '%s': %s",
+                            sanitize_log_data(item.get('abs_title')),
+                            e,
+                        )
+                        continue
+
+                    if not kosync_doc_id:
+                        logger.warning(
+                            "Batch Forge: Could not compute KOSync ID for %s, skipping",
+                            sanitize_log_data(ebook_filename),
+                        )
+                        continue
+
+                    current_book_entry = database_service.get_book(item['abs_id'])
+                    if current_book_entry and current_book_entry.kosync_doc_id:
+                        kosync_doc_id = current_book_entry.kosync_doc_id
+
+                    item_details = container.abs_client().get_item_details(item['abs_id'])
+                    chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
+                    storyteller_manifest = ingest_storyteller_transcripts(
+                        item['abs_id'],
+                        item.get('abs_title', ''),
+                        chapters
+                    )
+                    transcript_source = _storyteller_transcript_source(storyteller_uuid, storyteller_manifest)
+
+                    book = Book(
+                        abs_id=item['abs_id'],
+                        abs_title=item['abs_title'],
+                        audio_source="ABS",
+                        audio_source_id=item['abs_id'],
+                        audio_title=item['abs_title'],
+                        audio_cover_url=item.get('cover_url'),
+                        audio_duration=duration,
+                        audio_provider_book_id=item['abs_id'],
+                        ebook_filename=ebook_filename,
+                        kosync_doc_id=kosync_doc_id,
+                        transcript_file=storyteller_manifest,
+                        status="pending",
+                        duration=duration,
+                        transcript_source=transcript_source,
+                        storyteller_uuid=storyteller_uuid or None,
+                        original_ebook_filename=original_ebook_filename,
+                        ebook_source=item.get('ebook_source'),
+                        ebook_source_id=item.get('ebook_source_id'),
+                    )
+
+                    database_service.save_book(book)
+
+                    hardcover_sync_client = container.sync_clients().get('Hardcover')
+                    if hardcover_sync_client and hardcover_sync_client.is_configured():
+                        hardcover_sync_client._automatch_hardcover(book)
+
+                    container.abs_client().add_to_collection(item['abs_id'], ABS_COLLECTION_NAME)
+                    if container.booklore_client().is_configured():
+                        shelf_filename = original_ebook_filename or ebook_filename
+                        container.booklore_client().add_to_shelf(shelf_filename, BOOKLORE_SHELF_NAME)
+                    if container.storyteller_client().is_configured() and book.storyteller_uuid:
+                        container.storyteller_client().add_to_collection_by_uuid(book.storyteller_uuid)
+
+                    database_service.dismiss_suggestion(item['abs_id'])
+                    database_service.dismiss_suggestion(kosync_doc_id)
+
+                    try:
+                        device_doc = database_service.get_kosync_doc_by_filename(ebook_filename)
+                        if device_doc and device_doc.document_hash != kosync_doc_id:
+                            database_service.dismiss_suggestion(device_doc.document_hash)
+                    except Exception:
+                        pass
+                    continue
+
+                original_filename = (item.get('ebook_filename') or '').strip()
+                if not original_filename:
+                    logger.warning(
+                        "Batch Forge skipped '%s': missing ebook filename",
+                        sanitize_log_data(item.get('audio_title') or item.get('abs_title') or item.get('abs_id')),
+                    )
+                    continue
+
+                source_type = _normalize_text_source_type(item.get('ebook_source'))
+                source_id = str(item.get('ebook_source_id') or '').strip()
+                source_path = str(item.get('ebook_source_path') or '').strip()
+
+                if not source_type:
+                    if source_id:
+                        source_type = 'Booklore'
+                    else:
+                        source_type = 'Local File'
+                if source_type == 'Local File' and not source_path:
+                    resolved_path = find_ebook_file(original_filename)
+                    source_path = str(resolved_path) if resolved_path else ''
+
+                if source_type in ('ABS', 'Booklore', 'CWA') and not source_id:
+                    logger.warning(
+                        "Batch Forge skipped '%s': missing source id for source type '%s'",
+                        sanitize_log_data(item.get('audio_title') or item.get('abs_title') or item.get('abs_id')),
+                        sanitize_log_data(source_type),
+                    )
+                    continue
+                if source_type == 'Local File' and not source_path:
+                    logger.warning(
+                        "Batch Forge skipped '%s': local file path unavailable",
+                        sanitize_log_data(item.get('audio_title') or item.get('abs_title') or item.get('abs_id')),
+                    )
+                    continue
+
+                text_item = _build_forge_text_item(source_type, source_id, source_path, original_filename)
+                initial_booklore_id = source_id if text_item.get('source') == 'Booklore' else None
+                kosync_doc_id = get_kosync_id_for_ebook(original_filename, initial_booklore_id)
+                if not kosync_doc_id:
+                    logger.warning(
+                        "Batch Forge: Could not compute KOSync ID for '%s', continuing with forge fallback hash",
+                        sanitize_log_data(original_filename),
+                    )
+
+                audio_duration = _parse_audio_duration(item.get('audio_duration'))
+                if audio_duration is None:
+                    audio_duration = _parse_audio_duration(item.get('duration'))
+
+                if audio_source == 'BookLore':
+                    audio_source_id = (item.get('audio_source_id') or '').strip()
+                    forge_id = _build_bridge_key('BookLore', audio_source_id)
+                    if not forge_id:
+                        logger.warning(
+                            "Batch Forge skipped '%s': missing BookLore source id",
+                            sanitize_log_data(item.get('audio_title') or item.get('abs_title') or item.get('abs_id')),
+                        )
+                        continue
+
+                    forge_title = item.get('audio_title') or item.get('abs_title') or Path(original_filename).stem
+                    book = Book(
+                        abs_id=forge_id,
+                        abs_title=forge_title,
+                        ebook_filename=original_filename,
+                        original_ebook_filename=original_filename,
+                        kosync_doc_id=kosync_doc_id or f"forging_{forge_id}",
+                        status="forging",
+                        duration=audio_duration or 0.0,
+                        audio_source='BookLore',
+                        audio_source_id=audio_source_id,
+                        audio_provider_book_id=item.get('audio_provider_book_id') or audio_source_id,
+                        audio_provider_file_id=item.get('audio_provider_file_id'),
+                        audio_title=forge_title,
+                        audio_cover_url=item.get('audio_cover_url') or item.get('cover_url'),
+                        audio_duration=audio_duration,
+                        ebook_source=item.get('ebook_source'),
+                        ebook_source_id=item.get('ebook_source_id'),
+                    )
+                    database_service.save_book(book)
+
+                    container.forge_service().start_auto_forge_match(
+                        abs_id=forge_id,
+                        text_item=text_item,
+                        title=forge_title,
+                        author=None,
+                        original_filename=original_filename,
+                        original_hash=kosync_doc_id,
+                        audio_source='BookLore',
+                        audio_source_id=audio_source_id,
+                    )
+                else:
+                    forge_id = item.get('abs_id')
+                    if not forge_id:
+                        logger.warning(
+                            "Batch Forge skipped '%s': missing ABS id",
+                            sanitize_log_data(item.get('audio_title') or item.get('abs_title')),
+                        )
+                        continue
+
+                    forge_title = item.get('abs_title') or item.get('audio_title') or forge_id
+                    book = Book(
+                        abs_id=forge_id,
+                        abs_title=forge_title,
+                        ebook_filename=original_filename,
+                        original_ebook_filename=original_filename,
+                        kosync_doc_id=kosync_doc_id or f"forging_{forge_id}",
+                        status="forging",
+                        duration=audio_duration or 0.0,
+                        audio_source='ABS',
+                        audio_source_id=forge_id,
+                        audio_provider_book_id=item.get('audio_provider_book_id') or forge_id,
+                        audio_provider_file_id=item.get('audio_provider_file_id'),
+                        audio_title=forge_title,
+                        audio_cover_url=item.get('audio_cover_url') or item.get('cover_url'),
+                        audio_duration=audio_duration,
+                        ebook_source=item.get('ebook_source'),
+                        ebook_source_id=item.get('ebook_source_id'),
+                    )
+                    database_service.save_book(book)
+
+                    container.forge_service().start_auto_forge_match(
+                        abs_id=forge_id,
+                        text_item=text_item,
+                        title=forge_title,
+                        author=None,
+                        original_filename=original_filename,
+                        original_hash=kosync_doc_id,
+                    )
+
+                database_service.dismiss_suggestion(forge_id)
+                if kosync_doc_id:
+                    database_service.dismiss_suggestion(kosync_doc_id)
+
+            session['queue'] = []
+            session.modified = True
+            return redirect(url_for('index'))
         elif action == 'process_queue':
             from src.db.models import Book
 
@@ -2912,6 +3213,7 @@ def suggestions_page():
             ebook_display_name = request.form.get('ebook_display_name', ebook_filename)
             ebook_source = (request.form.get('ebook_source') or '').strip() or None
             ebook_source_id = (request.form.get('ebook_source_id') or '').strip() or None
+            ebook_source_path = (request.form.get('ebook_source_path') or request.form.get('source_path') or '').strip() or None
             storyteller_uuid = request.form.get('storyteller_uuid', '')
             selected_audio = None
             if audio_source == 'ABS' and audio_source_id:
@@ -2960,6 +3262,7 @@ def suggestions_page():
                         "ebook_display_name": ebook_display_name,
                         "ebook_source": ebook_source,
                         "ebook_source_id": ebook_source_id,
+                        "ebook_source_path": ebook_source_path,
                         "storyteller_uuid": storyteller_uuid,
                         "duration": selected_audio['audio_duration'],
                         "cover_url": selected_audio['audio_cover_url'],

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -605,6 +605,250 @@ def _compute_storyteller_trilink_kosync_id(original_ebook_filename, storyteller_
     return get_kosync_id_for_ebook(storyteller_filename)
 
 
+def _is_storyteller_artifact_filename(filename):
+    if not isinstance(filename, str):
+        return False
+    return bool(filename and re.match(r"^storyteller_[0-9a-fA-F-]+\.epub$", filename))
+
+
+def _download_storyteller_artifact(storyteller_uuid, abs_title=None):
+    """Download Storyteller artifact to epub cache; fall back to local library when available."""
+    epub_cache = container.epub_cache_dir()
+    epub_cache.mkdir(parents=True, exist_ok=True)
+
+    artifact_filename = f"storyteller_{storyteller_uuid}.epub"
+    target_path = epub_cache / artifact_filename
+    downloaded = False
+
+    try:
+        downloaded = container.storyteller_client().download_book(storyteller_uuid, target_path)
+    except Exception as dl_err:
+        logger.warning(f"Storyteller API download failed for '{storyteller_uuid}': {dl_err}")
+
+    if downloaded:
+        return artifact_filename, target_path
+
+    st_lib = Path(os.environ.get("STORYTELLER_LIBRARY_DIR", "/storyteller_library"))
+    if abs_title and st_lib.exists():
+        for child in st_lib.iterdir():
+            if not child.is_dir():
+                continue
+            readaloud = list(child.glob("*readaloud*.epub")) + list(child.glob("*synced*/*.epub"))
+            if readaloud and child.name.lower().strip() == abs_title.lower().strip():
+                shutil.copy2(readaloud[0], target_path)
+                logger.warning(f"Storyteller local fallback used: '{readaloud[0]}'")
+                return artifact_filename, target_path
+
+    return None, None
+
+
+def _resolve_abs_chapters_for_storyteller_ingest(book):
+    if not book or getattr(book, "sync_mode", "audiobook") == "ebook_only":
+        return []
+    try:
+        item_details = container.abs_client().get_item_details(book.abs_id)
+    except Exception as abs_err:
+        logger.warning(f"Failed ABS chapter lookup for storyteller ingest '{book.abs_id}': {abs_err}")
+        return []
+    if not item_details:
+        return []
+    return item_details.get("media", {}).get("chapters", []) or []
+
+
+def _upsert_storyteller_mapping(
+    *,
+    mode_hint,
+    abs_id=None,
+    abs_title=None,
+    storyteller_uuid=None,
+    ebook_filename=None,
+    existing_book=None,
+    duration=None,
+):
+    """
+    Shared Storyteller/ebook mapping upsert for:
+    - existing row updates (modal link + match-based link updates)
+    - ebook-only creation from Match when no audiobook is selected
+    """
+    if mode_hint not in {"existing", "ebook_only_create"}:
+        raise ValueError(f"Unsupported mode_hint: {mode_hint}")
+
+    selected_storyteller_uuid = (storyteller_uuid or "").strip() or None
+    selected_ebook_filename = (ebook_filename or "").strip() or None
+
+    target_book = existing_book
+    if mode_hint == "existing":
+        if target_book is None and abs_id:
+            target_book = database_service.get_book(abs_id)
+        if not target_book:
+            return None, "Book not found", 404
+
+    original_ebook_filename = selected_ebook_filename
+    if not original_ebook_filename and target_book and target_book.original_ebook_filename:
+        original_ebook_filename = target_book.original_ebook_filename
+    if (
+        not original_ebook_filename
+        and target_book
+        and target_book.ebook_filename
+        and not _is_storyteller_artifact_filename(target_book.ebook_filename)
+    ):
+        original_ebook_filename = target_book.ebook_filename
+
+    resolved_ebook_filename = selected_ebook_filename or (target_book.ebook_filename if target_book else None)
+
+    if selected_storyteller_uuid:
+        artifact_filename, _artifact_path = _download_storyteller_artifact(selected_storyteller_uuid, abs_title)
+        if not artifact_filename:
+            return None, "Failed to download Storyteller artifact", 500
+        resolved_ebook_filename = artifact_filename
+
+    if not resolved_ebook_filename:
+        return None, "Please select a text source (Storyteller or Standard Ebook)", 400
+
+    kosync_doc_id = None
+    if selected_storyteller_uuid:
+        log_prefix = "Storyteller link" if mode_hint == "existing" else "Ebook-only Tri-Link"
+        kosync_doc_id = _compute_storyteller_trilink_kosync_id(
+            original_ebook_filename,
+            resolved_ebook_filename,
+            log_prefix,
+        )
+        if not kosync_doc_id and target_book and target_book.kosync_doc_id:
+            logger.warning(
+                "Storyteller link hash fallback failed for '%s'; preserving existing hash '%s'",
+                sanitize_log_data(target_book.abs_id),
+                target_book.kosync_doc_id,
+            )
+            kosync_doc_id = target_book.kosync_doc_id
+    else:
+        booklore_id = None
+        if container.booklore_client().is_configured():
+            bl_book = container.booklore_client().find_book_by_filename(resolved_ebook_filename)
+            if bl_book:
+                booklore_id = bl_book.get("id")
+        kosync_doc_id = get_kosync_id_for_ebook(resolved_ebook_filename, booklore_id)
+        if not kosync_doc_id and target_book and target_book.kosync_doc_id:
+            kosync_doc_id = target_book.kosync_doc_id
+
+    if not isinstance(kosync_doc_id, str) or not kosync_doc_id.strip():
+        kosync_doc_id = None
+
+    if not kosync_doc_id:
+        if mode_hint == "existing":
+            kosync_doc_id = target_book.kosync_doc_id if target_book else None
+            logger.warning(
+                "Proceeding without recomputed KOSync hash for existing mapping '%s'",
+                sanitize_log_data(abs_id or (target_book.abs_id if target_book else "")),
+            )
+        else:
+            return None, "Could not compute KOSync ID for ebook", 404
+
+    created_ebook_only = False
+    if mode_hint == "ebook_only_create":
+        existing_by_hash = database_service.get_book_by_kosync_id(kosync_doc_id)
+        if existing_by_hash:
+            target_book = existing_by_hash
+            logger.info(
+                "Match ebook-only create: reusing existing mapping '%s' for hash '%s'",
+                sanitize_log_data(target_book.abs_id),
+                kosync_doc_id,
+            )
+        if not target_book:
+            from src.db.models import Book
+
+            synthetic_abs_id = f"ebook-{kosync_doc_id[:16]}"
+            target_book = database_service.get_book(synthetic_abs_id)
+            if not target_book:
+                inferred_title = abs_title or Path(resolved_ebook_filename).stem or synthetic_abs_id
+                target_book = Book(
+                    abs_id=synthetic_abs_id,
+                    abs_title=inferred_title,
+                    sync_mode="ebook_only",
+                )
+                created_ebook_only = True
+                logger.info(
+                    "Match ebook-only create: creating new mapping '%s' for '%s'",
+                    sanitize_log_data(synthetic_abs_id),
+                    sanitize_log_data(inferred_title),
+                )
+
+    if not target_book:
+        return None, "Book not found", 404
+
+    target_book.abs_title = abs_title or target_book.abs_title or Path(resolved_ebook_filename).stem
+    target_book.ebook_filename = resolved_ebook_filename
+    target_book.kosync_doc_id = kosync_doc_id
+    target_book.status = "pending"
+
+    if original_ebook_filename:
+        target_book.original_ebook_filename = original_ebook_filename
+    elif mode_hint == "ebook_only_create" and not getattr(target_book, "original_ebook_filename", None):
+        if not _is_storyteller_artifact_filename(resolved_ebook_filename):
+            target_book.original_ebook_filename = resolved_ebook_filename
+
+    if duration is not None:
+        target_book.duration = duration
+
+    if mode_hint == "ebook_only_create":
+        if created_ebook_only or getattr(target_book, "sync_mode", "audiobook") == "ebook_only" or str(target_book.abs_id).startswith("ebook-"):
+            target_book.sync_mode = "ebook_only"
+        else:
+            logger.info(
+                "Match ebook-only create reused ABS-backed mapping '%s'; keeping sync_mode='%s'",
+                sanitize_log_data(target_book.abs_id),
+                getattr(target_book, "sync_mode", "audiobook"),
+            )
+
+    if selected_storyteller_uuid:
+        chapters = _resolve_abs_chapters_for_storyteller_ingest(target_book)
+        if getattr(target_book, "sync_mode", "audiobook") == "ebook_only":
+            logger.info(
+                "Storyteller ingest chapterless mode selected for ebook-only mapping '%s'",
+                sanitize_log_data(target_book.abs_id),
+            )
+        storyteller_manifest = ingest_storyteller_transcripts(
+            target_book.abs_id,
+            target_book.abs_title or "",
+            chapters,
+        )
+        target_book.storyteller_uuid = selected_storyteller_uuid
+        target_book.transcript_file = storyteller_manifest
+        target_book.transcript_source = _storyteller_transcript_source(
+            selected_storyteller_uuid,
+            storyteller_manifest,
+        )
+
+    saved_book = database_service.save_book(target_book)
+    if not isinstance(getattr(saved_book, "abs_id", None), str):
+        saved_book = target_book
+
+    if selected_storyteller_uuid and container.storyteller_client().is_configured():
+        try:
+            container.storyteller_client().add_to_collection_by_uuid(selected_storyteller_uuid)
+        except Exception as st_err:
+            logger.warning(f"Failed to add Storyteller UUID to collection: {st_err}")
+
+    shelf_filename = saved_book.original_ebook_filename or saved_book.ebook_filename
+    if (
+        shelf_filename
+        and not _is_storyteller_artifact_filename(shelf_filename)
+        and container.booklore_client().is_configured()
+    ):
+        try:
+            container.booklore_client().add_to_shelf(shelf_filename, BOOKLORE_SHELF_NAME)
+        except Exception as bl_err:
+            logger.warning(f"Failed to add Booklore shelf entry for '{shelf_filename}': {bl_err}")
+
+    if getattr(saved_book, "sync_mode", "audiobook") == "ebook_only":
+        logger.info("Skipping ABS collection side effects for ebook-only mapping '%s'", saved_book.abs_id)
+
+    database_service.dismiss_suggestion(saved_book.abs_id)
+    if isinstance(saved_book.kosync_doc_id, str) and saved_book.kosync_doc_id.strip():
+        database_service.dismiss_suggestion(saved_book.kosync_doc_id)
+
+    return saved_book, None, None
+
+
 class EbookResult:
     """Wrapper to provide consistent interface for ebooks from Booklore, CWA, ABS, or filesystem."""
 
@@ -1101,7 +1345,10 @@ def index():
         mapping['storyteller_legacy_link'] = is_legacy_link
 
         # Platform deep links for dashboard
-        mapping['abs_url'] = f"{manager.abs_client.base_url}/item/{book.abs_id}"
+        if mapping.get('sync_mode') == 'ebook_only':
+            mapping['abs_url'] = None
+        else:
+            mapping['abs_url'] = f"{manager.abs_client.base_url}/item/{book.abs_id}"
 
         # Booklore deep link (if configured and book found)
         if manager.booklore_client.is_configured():
@@ -1392,13 +1639,42 @@ def forge_process():
 
 def match():
     if request.method == 'POST':
-        abs_id = request.form.get('audiobook_id')
-        selected_filename = request.form.get('ebook_filename')
+        abs_id = (request.form.get('audiobook_id') or '').strip()
+        selected_filename = (request.form.get('ebook_filename') or '').strip() or None
+        storyteller_uuid = (request.form.get('storyteller_uuid') or '').strip() or None
         ebook_filename = selected_filename
         original_ebook_filename = selected_filename
         audiobooks = container.abs_client().get_all_audiobooks()
-        selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None)
-        if not selected_ab: return "Audiobook not found", 404
+        selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None) if abs_id else None
+
+        if request.form.get('action') == 'forge_match' and not selected_ab:
+            return "Audiobook not found", 404
+
+        if not selected_ab and request.form.get('action') != 'forge_match':
+            if not (storyteller_uuid or selected_filename):
+                return "Please select a text source (Storyteller or Standard Ebook)", 400
+
+            ebook_only_title = Path(selected_filename).stem if selected_filename else f"storyteller_{storyteller_uuid or 'book'}"
+            logger.info(
+                "Match: entering ebook-only create path (storyteller_selected=%s, ebook_selected=%s)",
+                bool(storyteller_uuid),
+                bool(selected_filename),
+            )
+            saved_book, err_msg, err_code = _upsert_storyteller_mapping(
+                mode_hint="ebook_only_create",
+                abs_title=ebook_only_title,
+                storyteller_uuid=storyteller_uuid,
+                ebook_filename=selected_filename,
+                duration=0.0,
+            )
+            if err_msg:
+                return err_msg, err_code
+            logger.info("Match: ebook-only mapping ready for '%s'", sanitize_log_data(saved_book.abs_id))
+            return redirect(url_for('index'))
+
+        if not selected_ab:
+            return "Audiobook not found", 404
+
         abs_title = manager.get_abs_title(selected_ab)
         item_details = container.abs_client().get_item_details(abs_id)
         chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
@@ -1500,44 +1776,16 @@ def match():
             return redirect(url_for('index'))
             
         # [NEW] Storyteller Tri-Link Logic
-        storyteller_uuid = request.form.get('storyteller_uuid')
-        
         if storyteller_uuid:
             # If Storyteller UUID is selected, we prioritize it
             try:
-                epub_cache = container.epub_cache_dir()
-                if not epub_cache.exists(): epub_cache.mkdir(parents=True, exist_ok=True)
-                
-                target_filename = f"storyteller_{storyteller_uuid}.epub"
-                target_path = epub_cache / target_filename
-                
                 logger.info(f"🔍 Using Storyteller Artifact: '{storyteller_uuid}'")
-                
-                downloaded = False
-                try:
-                    downloaded = container.storyteller_client().download_book(storyteller_uuid, target_path)
-                except Exception as dl_err:
-                    logger.warning(f"⚠️ Storyteller API download failed: {dl_err}")
-
-                if not downloaded:
-                    # Fallback: search Storyteller library for local readaloud EPUB
-                    st_lib = Path(os.environ.get("STORYTELLER_LIBRARY_DIR", "/storyteller_library"))
-                    if abs_title and st_lib.exists():
-                        for child in st_lib.iterdir():
-                            if not child.is_dir():
-                                continue
-                            readaloud = list(child.glob("*readaloud*.epub")) + list(child.glob("*synced*/*.epub"))
-                            if readaloud and child.name.lower().strip() == abs_title.lower().strip():
-                                shutil.copy2(readaloud[0], target_path)
-                                downloaded = True
-                                logger.warning(f"⚠️ Storyteller: Using local fallback: '{readaloud[0]}'")
-                                break
-
-                if not downloaded:
+                target_filename, _target_path = _download_storyteller_artifact(storyteller_uuid, abs_title)
+                if not target_filename:
                     return "Failed to download Storyteller artifact", 500
 
-                ebook_filename = target_filename # Override filename
-                original_ebook_filename = selected_filename # Preserve original
+                ebook_filename = target_filename
+                original_ebook_filename = selected_filename
 
                 kosync_doc_id = _compute_storyteller_trilink_kosync_id(
                     original_ebook_filename,
@@ -1569,47 +1817,66 @@ def match():
         if current_book_entry and current_book_entry.kosync_doc_id:
             logger.info(f"🔄 Preserving existing hash '{current_book_entry.kosync_doc_id}' for '{abs_id}' instead of new hash '{kosync_doc_id}'")
             kosync_doc_id = current_book_entry.kosync_doc_id
+        if current_book_entry and not original_ebook_filename:
+            original_ebook_filename = current_book_entry.original_ebook_filename
 
         # [DUPLICATE MERGE] Check if this ebook is already linked to another ABS ID (e.g. ebook-only entry)
         existing_book = database_service.get_book_by_kosync_id(kosync_doc_id)
         migration_source_id = None
-        
+        abs_ebook_item_id = None
+        preserved_storyteller_uuid = current_book_entry.storyteller_uuid if current_book_entry else None
+        preserved_transcript_source = current_book_entry.transcript_source if current_book_entry else None
+        preserved_transcript_file = current_book_entry.transcript_file if current_book_entry else None
+        preserved_original_ebook_filename = current_book_entry.original_ebook_filename if current_book_entry else None
+        preserved_abs_ebook_item_id = current_book_entry.abs_ebook_item_id if current_book_entry else None
+
         if existing_book and existing_book.abs_id != abs_id:
             logger.info(f"🔄 Found existing book entry '{existing_book.abs_id}' for this ebook — Merging into '{abs_id}'")
             migration_source_id = existing_book.abs_id
-            
-            # [ID SHADOWING] CAPTURE the old ID to use for Ebook sync
             abs_ebook_item_id = existing_book.abs_ebook_item_id or existing_book.abs_id
-            
-            # Preserve filename if available
-            if not original_ebook_filename:
-                original_ebook_filename = existing_book.original_ebook_filename or existing_book.ebook_filename
-        else:
-            # If no existing book, we assume this is a fresh link
-            # [ID SHADOWING] But wait, if we are linking a pure ebook file, we don't have an item ID unless...
-            # The logic relies on capturing it from the OLD book entry. 
-            # If there is no old entry, we default to abs_id? 
-            # Actually, per user instruction: "When existing_book is found... CAPTURE the old ID".
-            # So if it's a fresh match, abs_ebook_item_id is None, which is fine (uses default behavior or assumes same).
-            # But the user said "Add abs_ebook_item_id to Book model", which we did.
-            abs_ebook_item_id = None
+            preserved_storyteller_uuid = existing_book.storyteller_uuid or preserved_storyteller_uuid
+            preserved_transcript_source = existing_book.transcript_source or preserved_transcript_source
+            preserved_transcript_file = existing_book.transcript_file or preserved_transcript_file
+            preserved_original_ebook_filename = existing_book.original_ebook_filename or preserved_original_ebook_filename
+            preserved_abs_ebook_item_id = existing_book.abs_ebook_item_id or preserved_abs_ebook_item_id
+            logger.info(
+                "Match merge: preserving storyteller metadata from '%s' -> '%s' (uuid=%s, transcript=%s)",
+                sanitize_log_data(existing_book.abs_id),
+                sanitize_log_data(abs_id),
+                bool(preserved_storyteller_uuid),
+                bool(preserved_transcript_file),
+            )
+
+        if not original_ebook_filename:
+            original_ebook_filename = preserved_original_ebook_filename
+        if not original_ebook_filename and existing_book:
+            original_ebook_filename = existing_book.original_ebook_filename or existing_book.ebook_filename
+        if abs_ebook_item_id is None:
+            abs_ebook_item_id = preserved_abs_ebook_item_id
+        if abs_ebook_item_id is None and current_book_entry:
+            abs_ebook_item_id = current_book_entry.abs_ebook_item_id
 
         # Create Book object and save to database service
         from src.db.models import Book
         storyteller_manifest = ingest_storyteller_transcripts(abs_id, abs_title, chapters)
-        transcript_source = _storyteller_transcript_source(storyteller_uuid, storyteller_manifest)
+        effective_storyteller_uuid = storyteller_uuid or preserved_storyteller_uuid
+        transcript_source = (
+            _storyteller_transcript_source(effective_storyteller_uuid, storyteller_manifest)
+            or preserved_transcript_source
+        )
+        transcript_file = storyteller_manifest or preserved_transcript_file
         book = Book(
             abs_id=abs_id,
             abs_title=abs_title,
             ebook_filename=ebook_filename,
             kosync_doc_id=kosync_doc_id,
-            transcript_file=storyteller_manifest,
+            transcript_file=transcript_file,
             status="pending",
             duration=manager.get_duration(selected_ab),
             transcript_source=transcript_source,
-            storyteller_uuid=storyteller_uuid, # Save UUID
+            storyteller_uuid=effective_storyteller_uuid,
             original_ebook_filename=original_ebook_filename,
-            abs_ebook_item_id=abs_ebook_item_id # [ID SHADOWING]
+            abs_ebook_item_id=abs_ebook_item_id
         )
 
         database_service.save_book(book)
@@ -1632,7 +1899,8 @@ def match():
         if container.booklore_client().is_configured():
             # Use original filename for shelf if we switched to storyteller
             shelf_filename = original_ebook_filename or ebook_filename
-            container.booklore_client().add_to_shelf(shelf_filename, BOOKLORE_SHELF_NAME)
+            if shelf_filename and not _is_storyteller_artifact_filename(shelf_filename):
+                container.booklore_client().add_to_shelf(shelf_filename, BOOKLORE_SHELF_NAME)
         if container.storyteller_client().is_configured():
             if book.storyteller_uuid:
                 container.storyteller_client().add_to_collection_by_uuid(book.storyteller_uuid)
@@ -2464,11 +2732,14 @@ def cleanup_mapping_resources(book):
         logger.info(f"🗑️ Deleting KOSync document record for ebook-only mapping: '{book.kosync_doc_id[:8]}'")
         database_service.delete_kosync_document(book.kosync_doc_id)
 
-    collection_name = os.environ.get('ABS_COLLECTION_NAME', 'Synced with KOReader')
-    try:
-        container.abs_client().remove_from_collection(book.abs_id, collection_name)
-    except Exception as e:
-        logger.warning(f"⚠️ Failed to remove from ABS collection: {e}")
+    if getattr(book, 'sync_mode', 'audiobook') != 'ebook_only':
+        collection_name = os.environ.get('ABS_COLLECTION_NAME', 'Synced with KOReader')
+        try:
+            container.abs_client().remove_from_collection(book.abs_id, collection_name)
+        except Exception as e:
+            logger.warning(f"⚠️ Failed to remove from ABS collection: {e}")
+    else:
+        logger.info(f"Skipping ABS collection cleanup for ebook-only mapping '{book.abs_id}'")
 
     storyteller_uuid = getattr(book, 'storyteller_uuid', None)
     if not storyteller_uuid and getattr(book, 'ebook_filename', None):
@@ -2553,6 +2824,9 @@ def mark_complete(abs_id):
     
     for client_name, client in container.sync_clients().items():
         if client.is_configured():
+            if client_name.lower() == 'abs' and getattr(book, 'sync_mode', 'audiobook') == 'ebook_only':
+                logger.info(f"Skipping ABS mark-complete for ebook-only mapping '{book.abs_id}'")
+                continue
             if client_name.lower() == 'abs':
                 client.abs_client.mark_finished(abs_id)
             else:
@@ -2679,7 +2953,7 @@ def api_storyteller_link(abs_id):
     if not data or 'uuid' not in data:
         return jsonify({"error": "Missing 'uuid' in JSON payload"}), 400
 
-    storyteller_uuid = data['uuid']
+    storyteller_uuid = (data['uuid'] or '').strip()
     book = database_service.get_book(abs_id)
     if not book:
         return jsonify({"error": "Book not found"}), 404
@@ -2713,43 +2987,32 @@ def api_storyteller_link(abs_id):
         # Revert to original filename if it exists
         if book.original_ebook_filename:
             book.ebook_filename = book.original_ebook_filename
-            
-        book.status = 'pending' # Force re-process to align with standard EPUB
+        if getattr(book, 'sync_mode', 'audiobook') == 'ebook_only':
+            book.sync_mode = 'ebook_only'
+
+        book.status = 'pending'
         database_service.save_book(book)
         
         return jsonify({"message": "Storyteller unlinked successfully", "filename": book.ebook_filename}), 200
 
     try:
-        epub_cache = container.epub_cache_dir()
-        if not epub_cache.exists(): epub_cache.mkdir(parents=True, exist_ok=True)
-        
-        target_path = epub_cache / f"storyteller_{storyteller_uuid}.epub"
-        
-        if container.storyteller_client().download_book(storyteller_uuid, target_path):
+        source_filename = book.original_ebook_filename
+        if not source_filename and book.ebook_filename and not _is_storyteller_artifact_filename(book.ebook_filename):
+            source_filename = book.ebook_filename
 
+        saved_book, err_msg, err_code = _upsert_storyteller_mapping(
+            mode_hint="existing",
+            abs_id=abs_id,
+            abs_title=book.abs_title or '',
+            storyteller_uuid=storyteller_uuid,
+            ebook_filename=source_filename,
+            existing_book=book,
+            duration=book.duration,
+        )
+        if err_msg:
+            return jsonify({"error": err_msg}), err_code
 
-            # Preserve OLD filename as original if not already set
-            if not book.original_ebook_filename:
-                book.original_ebook_filename = book.ebook_filename
-                logger.info(f"   ⚡ Preserving original filename: '{book.original_ebook_filename}'")
-
-            book.ebook_filename = target_path.name
-            book.storyteller_uuid = storyteller_uuid
-            item_details = container.abs_client().get_item_details(abs_id)
-            chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
-            storyteller_manifest = ingest_storyteller_transcripts(abs_id, book.abs_title or '', chapters)
-            book.transcript_file = storyteller_manifest
-            book.transcript_source = _storyteller_transcript_source(storyteller_uuid, storyteller_manifest)
-            book.status = 'pending' # Force re-process to align with new EPUB
-            
-            database_service.save_book(book)
-            
-            # Dismiss suggestion if it exists
-            database_service.dismiss_suggestion(abs_id)
-            
-            return jsonify({"message": "Book linked successfully", "filename": target_path.name}), 200
-        else:
-            return jsonify({"error": "Failed to download Storyteller artifact"}), 500
+        return jsonify({"message": "Book linked successfully", "filename": saved_book.ebook_filename}), 200
     except Exception as e:
         logger.error(f"❌ Error linking Storyteller book for '{abs_id}': {e}")
         return jsonify({"error": str(e)}), 500

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1610,16 +1610,16 @@ def index():
 
 
 def shelfmark():
-    """Shelfmark view - renders an iframe with SHELFMARK_URL"""
+    """Shelfmark handoff - redirects to the configured SHELFMARK_URL."""
     url = os.environ.get("SHELFMARK_URL")
     if not url:
         return redirect(url_for('index'))
     
-    # Case-insensitive sanitization for the iframe source
+    # Case-insensitive sanitization for the external destination.
     if not url.lower().startswith(('http://', 'https://')):
         url = f"http://{url}"
         
-    return render_template('shelfmark.html', shelfmark_url=url)
+    return redirect(url)
 
 
 def forge():

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -28,6 +28,7 @@ from src.api.hardcover_routes import hardcover_bp, init_hardcover_routes
 from src.version import APP_VERSION, get_update_status
 from src.db.models import State
 from src.sync_clients.sync_client_interface import LocatorResult, UpdateProgressRequest
+from src.services.audio_source_adapters import AudioResult
 from src.utils.storyteller_transcript import StorytellerTranscript
 from src.utils.kosync_headers import hash_kosync_key
 
@@ -341,10 +342,18 @@ STORYTELLER_LIBRARY_DIR = Path(os.environ.get("STORYTELLER_LIBRARY_DIR", "/story
 # ---------------- HELPER FUNCTIONS ----------------
 def get_audiobooks_conditionally():
     """Get audiobooks either from specific library or all libraries based on ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID setting."""
-    abs_only_search_in_library = os.environ.get("ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID", "false").lower() == "true"
-    abs_library_id = os.environ.get("ABS_LIBRARY_ID")
+    raw_scope = (os.environ.get("ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID") or "").strip()
+    abs_library_id = None
+    lowered = raw_scope.lower()
+    if lowered in {"true", "1", "yes", "on"}:
+        abs_library_id = (os.environ.get("ABS_LIBRARY_ID") or "").strip() or None
+    elif lowered in {"false", "0", "no", "off", "none", ""}:
+        abs_library_id = None
+    else:
+        # Backward-compatible mode where this env var directly contains the library id.
+        abs_library_id = raw_scope
 
-    if abs_only_search_in_library and abs_library_id:
+    if abs_library_id:
         # Fetch audiobooks only from the specified library
         return container.abs_client().get_audiobooks_for_lib(abs_library_id)
     else:
@@ -884,6 +893,32 @@ class EbookResult:
         return self.name
 
 
+def get_searchable_audiobooks(search_term):
+    """Get audiobook results from all configured audio providers."""
+    adapters = container.audio_source_adapters() if hasattr(container, "audio_source_adapters") else {}
+    results = []
+    seen = set()
+
+    for source_name, adapter in adapters.items():
+        try:
+            provider_results = adapter.search(search_term)
+        except Exception as e:
+            logger.warning(f"⚠️ Audiobook search failed for {source_name}: {e}")
+            continue
+
+        for result in provider_results or []:
+            if not isinstance(result, AudioResult):
+                continue
+            key = (result.source, result.source_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(result)
+
+    results.sort(key=lambda item: (item.title or item.display_name or "").lower())
+    return results
+
+
 def get_searchable_ebooks(search_term):
     """Get ebooks from Booklore API, filesystem, ABS, and CWA.
     Returns list of EbookResult objects for consistent interface."""
@@ -997,6 +1032,139 @@ def get_searchable_ebooks(search_term):
         )
 
     return results
+
+
+def _build_bridge_key(audio_source, audio_source_id):
+    if audio_source == "BookLore":
+        return f"booklore:{audio_source_id}"
+    return audio_source_id
+
+
+def _parse_audio_duration(raw_value):
+    try:
+        if raw_value is None or raw_value == "":
+            return None
+        return float(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _create_or_update_booklore_audio_mapping(
+    *,
+    audio_source_id,
+    audio_title,
+    audio_cover_url,
+    audio_duration,
+    audio_provider_book_id,
+    audio_provider_file_id,
+    ebook_filename,
+    ebook_source,
+    ebook_source_id,
+    storyteller_uuid,
+):
+    bridge_key = _build_bridge_key("BookLore", audio_source_id)
+    existing_book = (
+        database_service.get_book(bridge_key)
+        or database_service.get_book_by_audio_source("BookLore", audio_source_id)
+    )
+
+    resolved_ebook_filename = (ebook_filename or "").strip() or None
+    original_ebook_filename = resolved_ebook_filename
+    if existing_book and not original_ebook_filename:
+        original_ebook_filename = existing_book.original_ebook_filename
+
+    if storyteller_uuid:
+        artifact_filename, _artifact_path = _download_storyteller_artifact(storyteller_uuid, audio_title)
+        if not artifact_filename:
+            return None, "Failed to download Storyteller artifact", 500
+        resolved_ebook_filename = artifact_filename
+
+    if not resolved_ebook_filename:
+        return None, "Please select a text source (Storyteller or Standard Ebook)", 400
+
+    booklore_ebook_id = None
+    if ebook_source == "BookLore":
+        booklore_ebook_id = ebook_source_id
+    elif container.booklore_client().is_configured():
+        bl_book = container.booklore_client().find_book_by_filename(original_ebook_filename or resolved_ebook_filename)
+        if bl_book:
+            booklore_ebook_id = bl_book.get("id")
+
+    if storyteller_uuid:
+        kosync_doc_id = _compute_storyteller_trilink_kosync_id(
+            original_ebook_filename,
+            resolved_ebook_filename,
+            "BookLore audiobook match",
+        )
+    else:
+        kosync_doc_id = get_kosync_id_for_ebook(resolved_ebook_filename, booklore_ebook_id)
+
+    if existing_book and existing_book.kosync_doc_id:
+        kosync_doc_id = existing_book.kosync_doc_id
+
+    if not kosync_doc_id:
+        return None, "Could not compute KOSync ID for ebook", 404
+
+    from src.db.models import Book
+
+    target_book = existing_book or Book(abs_id=bridge_key, sync_mode="audiobook")
+    target_book.abs_id = bridge_key
+    target_book.abs_title = audio_title or target_book.abs_title or bridge_key
+    target_book.audio_source = "BookLore"
+    target_book.audio_source_id = str(audio_source_id)
+    target_book.audio_title = audio_title or target_book.audio_title or target_book.abs_title
+    target_book.audio_cover_url = audio_cover_url or target_book.audio_cover_url or f"/api/booklore/audiobook-cover/{audio_source_id}"
+    target_book.audio_duration = audio_duration if audio_duration is not None else target_book.audio_duration
+    target_book.audio_provider_book_id = str(audio_provider_book_id or audio_source_id)
+    target_book.audio_provider_file_id = str(audio_provider_file_id) if audio_provider_file_id else target_book.audio_provider_file_id
+    target_book.ebook_filename = resolved_ebook_filename
+    target_book.original_ebook_filename = original_ebook_filename or target_book.original_ebook_filename
+    target_book.ebook_source = ebook_source or target_book.ebook_source
+    target_book.ebook_source_id = ebook_source_id or target_book.ebook_source_id
+    target_book.kosync_doc_id = kosync_doc_id
+    target_book.status = "pending"
+    target_book.sync_mode = "audiobook"
+    target_book.duration = audio_duration if audio_duration is not None else target_book.duration
+    target_book.storyteller_uuid = storyteller_uuid or target_book.storyteller_uuid
+    target_book.transcript_file = existing_book.transcript_file if existing_book else None
+    target_book.transcript_source = existing_book.transcript_source if existing_book else None
+
+    if storyteller_uuid:
+        storyteller_manifest = ingest_storyteller_transcripts(
+            target_book.abs_id,
+            target_book.abs_title or "",
+            [],
+        )
+        target_book.transcript_file = storyteller_manifest
+        target_book.transcript_source = _storyteller_transcript_source(
+            storyteller_uuid,
+            storyteller_manifest,
+        )
+
+    saved_book = database_service.save_book(target_book)
+
+    if container.storyteller_client().is_configured() and saved_book.storyteller_uuid:
+        try:
+            container.storyteller_client().add_to_collection_by_uuid(saved_book.storyteller_uuid)
+        except Exception as st_err:
+            logger.warning(f"Failed to add Storyteller UUID to collection: {st_err}")
+
+    shelf_filename = saved_book.original_ebook_filename or saved_book.ebook_filename
+    if (
+        shelf_filename
+        and not _is_storyteller_artifact_filename(shelf_filename)
+        and container.booklore_client().is_configured()
+    ):
+        try:
+            container.booklore_client().add_to_shelf(shelf_filename, BOOKLORE_SHELF_NAME)
+        except Exception as bl_err:
+            logger.warning(f"Failed to add Booklore shelf entry for '{shelf_filename}': {bl_err}")
+
+    database_service.dismiss_suggestion(saved_book.abs_id)
+    if isinstance(saved_book.kosync_doc_id, str) and saved_book.kosync_doc_id.strip():
+        database_service.dismiss_suggestion(saved_book.kosync_doc_id)
+
+    return saved_book, None, None
 
 
 
@@ -1272,6 +1440,11 @@ def index():
             'abs_title': book.abs_title,
             'abs_subtitle': abs_subtitle,
             'abs_author': abs_author,
+            'audio_source': getattr(book, 'audio_source', None) or ('ABS' if getattr(book, 'sync_mode', 'audiobook') != 'ebook_only' else None),
+            'audio_source_id': getattr(book, 'audio_source_id', None) or book.abs_id,
+            'audio_title': getattr(book, 'audio_title', None) or book.abs_title,
+            'audio_duration': getattr(book, 'audio_duration', None) or book.duration or 0,
+            'audio_cover_url': getattr(book, 'audio_cover_url', None),
             'ebook_filename': book.ebook_filename,
             'kosync_doc_id': book.kosync_doc_id,
             'transcript_file': book.transcript_file,
@@ -1347,8 +1520,14 @@ def index():
         # Platform deep links for dashboard
         if mapping.get('sync_mode') == 'ebook_only':
             mapping['abs_url'] = None
+            mapping['audio_url'] = None
         else:
-            mapping['abs_url'] = f"{manager.abs_client.base_url}/item/{book.abs_id}"
+            if mapping['audio_source'] == 'BookLore':
+                mapping['abs_url'] = None
+                mapping['audio_url'] = f"{manager.booklore_client.base_url}/book/{mapping['audio_source_id']}?tab=view"
+            else:
+                mapping['abs_url'] = f"{manager.abs_client.base_url}/item/{book.abs_id}"
+                mapping['audio_url'] = mapping['abs_url']
 
         # Booklore deep link (if configured and book found)
         if manager.booklore_client.is_configured():
@@ -1390,7 +1569,11 @@ def index():
             mapping['last_sync'] = "Never"
 
         # Set cover URL
-        if book.abs_id:
+        if mapping.get('audio_cover_url'):
+            mapping['cover_url'] = mapping['audio_cover_url']
+        elif mapping.get('audio_source') == 'BookLore' and mapping.get('audio_source_id'):
+            mapping['cover_url'] = f"/api/booklore/audiobook-cover/{mapping['audio_source_id']}"
+        elif book.abs_id and mapping.get('audio_source') != 'BookLore':
             mapping['cover_url'] = f"{manager.abs_client.base_url}/api/items/{book.abs_id}/cover?token={manager.abs_client.token}"
 
         # Add to totals for overall progress calculation
@@ -1640,15 +1823,44 @@ def forge_process():
 def match():
     if request.method == 'POST':
         abs_id = (request.form.get('audiobook_id') or '').strip()
+        audio_source = (request.form.get('audio_source') or ('ABS' if abs_id else '')).strip() or None
+        audio_source_id = (request.form.get('audio_source_id') or abs_id).strip() or None
+        audio_title = (request.form.get('audio_title') or '').strip() or None
+        audio_cover_url = (request.form.get('audio_cover_url') or '').strip() or None
+        audio_provider_book_id = (request.form.get('audio_provider_book_id') or audio_source_id or '').strip() or None
+        audio_provider_file_id = (request.form.get('audio_provider_file_id') or '').strip() or None
+        audio_duration = _parse_audio_duration(request.form.get('audio_duration'))
         selected_filename = (request.form.get('ebook_filename') or '').strip() or None
+        ebook_source = (request.form.get('ebook_source') or request.form.get('source_type') or '').strip() or None
+        ebook_source_id = (request.form.get('ebook_source_id') or request.form.get('source_id') or '').strip() or None
         storyteller_uuid = (request.form.get('storyteller_uuid') or '').strip() or None
         ebook_filename = selected_filename
         original_ebook_filename = selected_filename
         audiobooks = container.abs_client().get_all_audiobooks()
         selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None) if abs_id else None
 
+        if request.form.get('action') == 'forge_match' and audio_source != 'ABS':
+            return "Forge match currently supports ABS audiobooks only", 400
+
         if request.form.get('action') == 'forge_match' and not selected_ab:
             return "Audiobook not found", 404
+
+        if audio_source == 'BookLore' and audio_source_id:
+            saved_book, err_msg, err_code = _create_or_update_booklore_audio_mapping(
+                audio_source_id=audio_source_id,
+                audio_title=audio_title or Path(selected_filename or f"booklore_{audio_source_id}").stem,
+                audio_cover_url=audio_cover_url,
+                audio_duration=audio_duration,
+                audio_provider_book_id=audio_provider_book_id,
+                audio_provider_file_id=audio_provider_file_id,
+                ebook_filename=selected_filename,
+                ebook_source=ebook_source,
+                ebook_source_id=ebook_source_id,
+                storyteller_uuid=storyteller_uuid,
+            )
+            if err_msg:
+                return err_msg, err_code
+            return redirect(url_for('index'))
 
         if not selected_ab and request.form.get('action') != 'forge_match':
             if not (storyteller_uuid or selected_filename):
@@ -1868,6 +2080,12 @@ def match():
         book = Book(
             abs_id=abs_id,
             abs_title=abs_title,
+            audio_source="ABS",
+            audio_source_id=abs_id,
+            audio_title=abs_title,
+            audio_cover_url=f"{container.abs_client().base_url}/api/items/{abs_id}/cover?token={container.abs_client().token}",
+            audio_duration=manager.get_duration(selected_ab),
+            audio_provider_book_id=abs_id,
             ebook_filename=ebook_filename,
             kosync_doc_id=kosync_doc_id,
             transcript_file=transcript_file,
@@ -1876,7 +2094,9 @@ def match():
             transcript_source=transcript_source,
             storyteller_uuid=effective_storyteller_uuid,
             original_ebook_filename=original_ebook_filename,
-            abs_ebook_item_id=abs_ebook_item_id
+            abs_ebook_item_id=abs_ebook_item_id,
+            ebook_source=ebook_source,
+            ebook_source_id=ebook_source_id,
         )
 
         database_service.save_book(book)
@@ -1924,10 +2144,7 @@ def match():
     search = request.args.get('search', '').strip().lower()
     audiobooks, ebooks, storyteller_books = [], [], []
     if search:
-        # Fetch audiobooks conditionally based on ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID setting
-        audiobooks = get_audiobooks_conditionally()
-        audiobooks = [ab for ab in audiobooks if audiobook_matches_search(ab, search)]
-        for ab in audiobooks: ab['cover_url'] = f"{container.abs_client().base_url}/api/items/{ab['id']}/cover?token={container.abs_client().token}"
+        audiobooks = get_searchable_audiobooks(search)
 
         # Use new search method
         ebooks = get_searchable_ebooks(search)
@@ -1939,7 +2156,7 @@ def match():
             except Exception as e:
                 logger.warning(f"⚠️ Storyteller search failed in match route: {e}")
 
-    return render_template('match.html', audiobooks=audiobooks, ebooks=ebooks, storyteller_books=storyteller_books, search=search, get_title=manager.get_abs_title)
+    return render_template('match.html', audiobooks=audiobooks, ebooks=ebooks, storyteller_books=storyteller_books, search=search)
 
 
 def batch_match():
@@ -1948,21 +2165,58 @@ def batch_match():
         if action == 'add_to_queue':
             session.setdefault('queue', [])
             abs_id = request.form.get('audiobook_id')
+            audio_source = (request.form.get('audio_source') or ('ABS' if abs_id else '')).strip() or None
+            audio_source_id = (request.form.get('audio_source_id') or abs_id or '').strip() or None
+            audio_title = (request.form.get('audio_title') or '').strip() or None
+            audio_cover_url = (request.form.get('audio_cover_url') or '').strip() or None
+            audio_provider_book_id = (request.form.get('audio_provider_book_id') or audio_source_id or '').strip() or None
+            audio_provider_file_id = (request.form.get('audio_provider_file_id') or '').strip() or None
+            audio_duration = _parse_audio_duration(request.form.get('audio_duration'))
             ebook_filename = request.form.get('ebook_filename', '')
             ebook_display_name = request.form.get('ebook_display_name', ebook_filename)
+            ebook_source = (request.form.get('ebook_source') or request.form.get('source_type') or '').strip() or None
+            ebook_source_id = (request.form.get('ebook_source_id') or request.form.get('source_id') or '').strip() or None
             storyteller_uuid = request.form.get('storyteller_uuid', '')
             audiobooks = container.abs_client().get_all_audiobooks()
             selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None)
-            # Allow queue entry if audiobook selected and either an ebook or a storyteller UUID is provided
-            if selected_ab and (ebook_filename or storyteller_uuid):
-                if not any(item['abs_id'] == abs_id for item in session['queue']):
-                    session['queue'].append({"abs_id": abs_id,
-                                             "abs_title": manager.get_abs_title(selected_ab),
-                                             "ebook_filename": ebook_filename,
-                                             "ebook_display_name": ebook_display_name,
-                                             "storyteller_uuid": storyteller_uuid,
-                                             "duration": manager.get_duration(selected_ab),
-                                             "cover_url": f"{container.abs_client().base_url}/api/items/{abs_id}/cover?token={container.abs_client().token}"})
+            selected_audio = None
+            if audio_source == 'ABS' and selected_ab:
+                selected_audio = {
+                    'bridge_key': abs_id,
+                    'audio_source': 'ABS',
+                    'audio_source_id': abs_id,
+                    'audio_title': manager.get_abs_title(selected_ab),
+                    'audio_duration': manager.get_duration(selected_ab),
+                    'audio_cover_url': f"{container.abs_client().base_url}/api/items/{abs_id}/cover?token={container.abs_client().token}",
+                    'audio_provider_book_id': abs_id,
+                    'audio_provider_file_id': None,
+                }
+            elif audio_source == 'BookLore' and audio_source_id:
+                selected_audio = {
+                    'bridge_key': _build_bridge_key('BookLore', audio_source_id),
+                    'audio_source': 'BookLore',
+                    'audio_source_id': audio_source_id,
+                    'audio_title': audio_title or f"BookLore {audio_source_id}",
+                    'audio_duration': audio_duration,
+                    'audio_cover_url': audio_cover_url,
+                    'audio_provider_book_id': audio_provider_book_id,
+                    'audio_provider_file_id': audio_provider_file_id,
+                }
+
+            if selected_audio and (ebook_filename or storyteller_uuid):
+                if not any(item['bridge_key'] == selected_audio['bridge_key'] for item in session['queue']):
+                    session['queue'].append({
+                        **selected_audio,
+                        "abs_id": selected_audio['bridge_key'],
+                        "abs_title": selected_audio['audio_title'],
+                        "ebook_filename": ebook_filename,
+                        "ebook_display_name": ebook_display_name,
+                        "ebook_source": ebook_source,
+                        "ebook_source_id": ebook_source_id,
+                        "storyteller_uuid": storyteller_uuid,
+                        "duration": selected_audio['audio_duration'],
+                        "cover_url": selected_audio['audio_cover_url'],
+                    })
                     session.modified = True
             return redirect(url_for('batch_match', search=request.form.get('search', '')))
         elif action == 'remove_from_queue':
@@ -1978,6 +2232,28 @@ def batch_match():
             from src.db.models import Book
 
             for item in session.get('queue', []):
+                audio_source = item.get('audio_source') or 'ABS'
+                if audio_source == 'BookLore':
+                    saved_book, err_msg, _err_code = _create_or_update_booklore_audio_mapping(
+                        audio_source_id=item.get('audio_source_id'),
+                        audio_title=item.get('audio_title'),
+                        audio_cover_url=item.get('audio_cover_url'),
+                        audio_duration=_parse_audio_duration(item.get('audio_duration')),
+                        audio_provider_book_id=item.get('audio_provider_book_id'),
+                        audio_provider_file_id=item.get('audio_provider_file_id'),
+                        ebook_filename=item.get('ebook_filename'),
+                        ebook_source=item.get('ebook_source'),
+                        ebook_source_id=item.get('ebook_source_id'),
+                        storyteller_uuid=item.get('storyteller_uuid'),
+                    )
+                    if err_msg:
+                        logger.warning(
+                            "⚠️ Batch Match skipped BookLore audiobook '%s': %s",
+                            sanitize_log_data(item.get('audio_title') or item.get('audio_source_id')),
+                            err_msg,
+                        )
+                    continue
+
                 ebook_filename = item['ebook_filename']
                 storyteller_uuid = item.get('storyteller_uuid', '')
                 original_ebook_filename = item['ebook_filename']
@@ -2045,6 +2321,12 @@ def batch_match():
                 book = Book(
                     abs_id=item['abs_id'],
                     abs_title=item['abs_title'],
+                    audio_source="ABS",
+                    audio_source_id=item['abs_id'],
+                    audio_title=item['abs_title'],
+                    audio_cover_url=item.get('cover_url'),
+                    audio_duration=duration,
+                    audio_provider_book_id=item['abs_id'],
                     ebook_filename=ebook_filename,
                     kosync_doc_id=kosync_doc_id,
                     transcript_file=storyteller_manifest,
@@ -2052,7 +2334,9 @@ def batch_match():
                     duration=duration,
                     transcript_source=transcript_source,
                     storyteller_uuid=storyteller_uuid or None,
-                    original_ebook_filename=original_ebook_filename
+                    original_ebook_filename=original_ebook_filename,
+                    ebook_source=item.get('ebook_source'),
+                    ebook_source_id=item.get('ebook_source_id'),
                 )
 
                 database_service.save_book(book)
@@ -2088,9 +2372,7 @@ def batch_match():
     search = request.args.get('search', '').strip().lower()
     audiobooks, ebooks, storyteller_books = [], [], []
     if search:
-        audiobooks = get_audiobooks_conditionally()
-        audiobooks = [ab for ab in audiobooks if audiobook_matches_search(ab, search)]
-        for ab in audiobooks: ab['cover_url'] = f"{container.abs_client().base_url}/api/items/{ab['id']}/cover?token={container.abs_client().token}"
+        audiobooks = get_searchable_audiobooks(search)
 
         # Use new search method
         ebooks = get_searchable_ebooks(search)
@@ -2104,7 +2386,7 @@ def batch_match():
                 logger.warning(f"⚠️ Storyteller search failed in batch_match route: {e}")
 
     return render_template('batch_match.html', audiobooks=audiobooks, ebooks=ebooks, storyteller_books=storyteller_books,
-                           queue=session.get('queue', []), search=search, get_title=manager.get_abs_title)
+                           queue=session.get('queue', []), search=search)
 
 
 def _get_suggestions_service():
@@ -3473,6 +3755,24 @@ def get_booklore_libraries():
     return jsonify(libraries)
 
 
+def proxy_booklore_audiobook_cover(book_id):
+    """Stream a BookLore audiobook cover through the backend."""
+    client = container.booklore_client()
+    if not client.is_configured():
+        return "Booklore not configured", 400
+
+    try:
+        content, content_type = client.get_audiobook_cover_bytes(book_id)
+        if not content:
+            return "Cover not found", 404
+        from flask import Response
+
+        return Response(content, content_type=content_type or "image/jpeg")
+    except Exception as e:
+        logger.error(f"❌ Error proxying BookLore audiobook cover for '{book_id}': {e}")
+        return "Error loading cover", 500
+
+
 def api_booklore_refresh():
     """Clear Booklore cache and trigger a full refresh."""
     client = container.booklore_client()
@@ -3764,6 +4064,7 @@ def create_app(test_container=None):
     app.add_url_rule('/api/suggestions/clear_stale', 'clear_stale_suggestions', clear_stale_suggestions, methods=['POST'])
     app.add_url_rule('/api/cache/clean', 'clean_cache', clean_inactive_cache, methods=['POST'])
     app.add_url_rule('/api/cover-proxy/<abs_id>', 'proxy_cover', proxy_cover)
+    app.add_url_rule('/api/booklore/audiobook-cover/<book_id>', 'proxy_booklore_audiobook_cover', proxy_booklore_audiobook_cover, methods=['GET'])
     app.add_url_rule('/api/booklore/libraries', 'get_booklore_libraries', get_booklore_libraries, methods=['GET'])
     app.add_url_rule('/api/booklore/refresh', 'api_booklore_refresh', api_booklore_refresh, methods=['POST'])
     app.add_url_rule('/api/test-connection/<service>', 'test_connection', test_connection, methods=['POST'])

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -3473,6 +3473,24 @@ def get_booklore_libraries():
     return jsonify(libraries)
 
 
+def api_booklore_refresh():
+    """Clear Booklore cache and trigger a full refresh."""
+    client = container.booklore_client()
+    if not client.is_configured():
+        return jsonify({"success": False, "error": "Booklore not configured"}), 400
+
+    try:
+        refreshed = client.clear_and_refresh()
+    except Exception as e:
+        logger.error(f"❌ Booklore cache refresh failed: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+    if not refreshed:
+        return jsonify({"success": False, "error": "Booklore refresh failed"}), 500
+
+    return jsonify({"success": True, "message": "Booklore cache refreshed successfully"})
+
+
 def _test_conn_error(e: Exception) -> str:
     """Extract a user-friendly message from a requests exception."""
     msg = str(e)
@@ -3747,6 +3765,7 @@ def create_app(test_container=None):
     app.add_url_rule('/api/cache/clean', 'clean_cache', clean_inactive_cache, methods=['POST'])
     app.add_url_rule('/api/cover-proxy/<abs_id>', 'proxy_cover', proxy_cover)
     app.add_url_rule('/api/booklore/libraries', 'get_booklore_libraries', get_booklore_libraries, methods=['GET'])
+    app.add_url_rule('/api/booklore/refresh', 'api_booklore_refresh', api_booklore_refresh, methods=['POST'])
     app.add_url_rule('/api/test-connection/<service>', 'test_connection', test_connection, methods=['POST'])
 
     # Storyteller API routes

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1931,13 +1931,13 @@ def match():
         audiobooks = container.abs_client().get_all_audiobooks()
         selected_ab = next((ab for ab in audiobooks if ab['id'] == abs_id), None) if abs_id else None
 
-        if request.form.get('action') == 'forge_match' and audio_source != 'ABS':
-            return "Forge match currently supports ABS audiobooks only", 400
+        if request.form.get('action') == 'forge_match' and audio_source not in ('ABS', 'BookLore'):
+            return "Forge match requires an ABS or BookLore audiobook", 400
 
-        if request.form.get('action') == 'forge_match' and not selected_ab:
+        if request.form.get('action') == 'forge_match' and audio_source == 'ABS' and not selected_ab:
             return "Audiobook not found", 404
 
-        if audio_source == 'BookLore' and audio_source_id:
+        if audio_source == 'BookLore' and audio_source_id and request.form.get('action') != 'forge_match':
             saved_book, err_msg, err_code = _create_or_update_booklore_audio_mapping(
                 audio_source_id=audio_source_id,
                 audio_title=audio_title or Path(selected_filename or f"booklore_{audio_source_id}").stem,
@@ -1981,49 +1981,25 @@ def match():
             logger.info("Match: ebook-only mapping ready for '%s'", sanitize_log_data(saved_book.abs_id))
             return redirect(url_for('index'))
 
-        if not selected_ab:
-            return "Audiobook not found", 404
-
-        abs_title = manager.get_abs_title(selected_ab)
-        item_details = container.abs_client().get_item_details(abs_id)
-        chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
-
-        # Get booklore_id if available for API-based hash computation
-        booklore_id = None
-        
-        # [NEW ACTION] Forge & Match
+        # [NEW ACTION] Forge & Match (supports both ABS and BookLore audiobooks)
         if request.form.get('action') == 'forge_match':
             original_filename = request.form.get('ebook_filename')
             if not original_filename:
                 return "Original ebook filename required for forge match", 400
-                
-            # 1. Prepare text item (reconstruct from form/source logic or assume passed)
-            # Actually, standard match doesn't have 'text_item' logic fully exposed in form? 
-            # The forge UI sends text_item JSON. 
-            # But here we are arguably coming from the match page. 
-            # If we add "Forge" button, we need to know the SOURCE of the text.
-            # Assuming the form includes necessary details or we can infer.
-            # [SIMPLIFICATION] For now, assume 'ebook_filename' is a valid Local text file from search?
-            # Or is this action coming from the Forge modal? No, "Forge & Match".
-            # If it's from the match page, the user selected an ebook result.
-            # We need to reconstruct the `text_item` dict expected by ForgeService.
-            
-            # Extract source details from form (hidden inputs?)
-            # We'll need to update match.html to send these.
+
             source_type = request.form.get('source_type')
-            source_path = request.form.get('source_path') 
-            source_id = request.form.get('source_id') # booklore id, cwa id, etc
-            
+            source_path = request.form.get('source_path')
+            source_id = request.form.get('source_id')
+
             text_item = {
                 "source": source_type,
                 "path": source_path,
                 "booklore_id": source_id,
                 "cwa_id": source_id,
-                "abs_id": source_id, # ambiguous but handled by specific keys
+                "abs_id": source_id,
                 "filename": original_filename
             }
-            
-            # Map specific keys based on source
+
             if source_type == 'ABS': text_item['abs_id'] = source_id
             if source_type == 'Booklore': text_item['booklore_id'] = source_id
             if source_type == 'CWA':
@@ -2031,58 +2007,84 @@ def match():
                 if source_path:
                     text_item['download_url'] = source_path
             if source_type == 'Local File': text_item['path'] = source_path
-            
-            # 2. Calculate initial Kosync ID (Original) - strictly for DB record
-            # We use the ORIGINAL file for the ID initially (or forever if tri-linked).
+
             initial_booklore_id = source_id if source_type == 'Booklore' else None
             kosync_doc_id = get_kosync_id_for_ebook(original_filename, initial_booklore_id)
-            
+
             if not kosync_doc_id:
-                # If we can't get ID from original (e.g. remote only?), we might rely on the forged one later.
-                # But we need a DB record now.
-                # Generate a temporary or hash-based ID? Or fail?
-                # Failing is safer.
-                logger.warning(f"⚠️ Could not compute ID for original '{original_filename}'")
-                # return "Could not compute KOSync ID for original file", 400
-                # Actually, `start_auto_forge_match` can update it? 
-                # Let's proceed with a placeholder or fail.
-                # Use a specific error.
-                pass 
+                logger.warning(f"Could not compute ID for original '{original_filename}'")
 
             from src.db.models import Book
-            # Create dummy book record with status='forging'
-            book = Book(
-                abs_id=abs_id,
-                abs_title=abs_title,
-                ebook_filename=original_filename,
-                original_ebook_filename=original_filename,
-                kosync_doc_id=kosync_doc_id or f"forging_{abs_id}", # temporary
-                status="forging",
-                duration=manager.get_duration(selected_ab)
-            )
-            database_service.save_book(book)
-            
-            # Start Auto-Forge
-            author = get_abs_author(selected_ab)
-            title = abs_title
-            
-            # Async launch
-            container.forge_service().start_auto_forge_match(
-                abs_id=abs_id,
-                text_item=text_item,
-                title=title,
-                author=author,
-                original_filename=original_filename,
-                original_hash=kosync_doc_id
-            )
-            
-            # Dismiss pending suggestion if it exists (for both ABS ID and potential KOSync ID)
-            # This cleans up the suggestions list immediately upon starting the forge process
-            database_service.dismiss_suggestion(abs_id)
+
+            if audio_source == 'BookLore':
+                forge_title = audio_title or Path(selected_filename or f"booklore_{audio_source_id}").stem
+                forge_id = f"booklore_audio_{audio_source_id}"
+                book = Book(
+                    abs_id=forge_id,
+                    abs_title=forge_title,
+                    ebook_filename=original_filename,
+                    original_ebook_filename=original_filename,
+                    kosync_doc_id=kosync_doc_id or f"forging_{forge_id}",
+                    status="forging",
+                    duration=audio_duration or 0.0,
+                    audio_source='BookLore',
+                    audio_source_id=audio_source_id,
+                    audio_provider_book_id=audio_provider_book_id,
+                    audio_provider_file_id=audio_provider_file_id,
+                    audio_title=forge_title,
+                    audio_cover_url=audio_cover_url,
+                    audio_duration=audio_duration,
+                )
+                database_service.save_book(book)
+
+                container.forge_service().start_auto_forge_match(
+                    abs_id=forge_id,
+                    text_item=text_item,
+                    title=forge_title,
+                    author=None,
+                    original_filename=original_filename,
+                    original_hash=kosync_doc_id,
+                    audio_source='BookLore',
+                    audio_source_id=audio_source_id,
+                )
+            else:
+                abs_title = manager.get_abs_title(selected_ab)
+                book = Book(
+                    abs_id=abs_id,
+                    abs_title=abs_title,
+                    ebook_filename=original_filename,
+                    original_ebook_filename=original_filename,
+                    kosync_doc_id=kosync_doc_id or f"forging_{abs_id}",
+                    status="forging",
+                    duration=manager.get_duration(selected_ab)
+                )
+                database_service.save_book(book)
+
+                author = get_abs_author(selected_ab)
+                container.forge_service().start_auto_forge_match(
+                    abs_id=abs_id,
+                    text_item=text_item,
+                    title=abs_title,
+                    author=author,
+                    original_filename=original_filename,
+                    original_hash=kosync_doc_id
+                )
+
+            forge_book_id = forge_id if audio_source == 'BookLore' else abs_id
+            database_service.dismiss_suggestion(forge_book_id)
             if kosync_doc_id:
                 database_service.dismiss_suggestion(kosync_doc_id)
 
             return redirect(url_for('index'))
+
+        if not selected_ab:
+            return "Audiobook not found", 404
+
+        abs_title = manager.get_abs_title(selected_ab)
+        item_details = container.abs_client().get_item_details(abs_id)
+        chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
+
+        booklore_id = None
             
         # [NEW] Storyteller Tri-Link Logic
         if storyteller_uuid:

--- a/templates/batch_match.html
+++ b/templates/batch_match.html
@@ -711,7 +711,8 @@
                 {% endif %}
 
                 {% if shelfmark_url %}
-                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/templates/batch_match.html
+++ b/templates/batch_match.html
@@ -765,6 +765,7 @@
                     <input type="hidden" name="ebook_display_name" id="selected_ebook_display_name" value="">
                     <input type="hidden" name="ebook_source" id="selected_ebook_source" value="">
                     <input type="hidden" name="ebook_source_id" id="selected_ebook_source_id" value="">
+                    <input type="hidden" name="ebook_source_path" id="selected_ebook_source_path" value="">
                     <input type="hidden" name="storyteller_uuid" id="selected_storyteller_uuid" value="">
 
                     {% set single_ab_match = audiobooks|length == 1 %}
@@ -835,6 +836,7 @@
                             data-display-name="{{ eb.display_name | replace("'", "\\'") }}"
                             data-source-type="{{ eb.source }}"
                             data-source-id="{{ eb.source_id }}"
+                            data-source-path="{{ eb.path if eb.path else '' }}"
                             onclick="selectEbookCard(this, '{{ eb.name }}', '{{ eb.display_name | replace("'", "\\'") }}')">
                             <div class="resource-icon">📖</div>
                             <div class="resource-title" title="{{ eb.display_name }}">
@@ -905,6 +907,13 @@
                     </form>
 
                     <form method="POST" action="/batch-match">
+                        <input type="hidden" name="action" value="forge_and_match_queue">
+                        <button type="submit" class="btn btn-primary w-100">
+                            Forge + Match ({{ queue|length }})
+                        </button>
+                    </form>
+
+                    <form method="POST" action="/batch-match">
                         <input type="hidden" name="action" value="clear_queue">
                         <button type="submit" class="btn btn-danger w-100"
                             onclick="return confirm('Clear entire queue?')">
@@ -939,6 +948,9 @@
                 selectedEbookFilename = preSelectedEb.dataset.value;
                 document.getElementById('selected_ebook_filename').value = selectedEbookFilename;
                 document.getElementById('selected_ebook_display_name').value = preSelectedEb.dataset.displayName || selectedEbookFilename;
+                document.getElementById('selected_ebook_source').value = preSelectedEb.dataset.sourceType || '';
+                document.getElementById('selected_ebook_source_id').value = preSelectedEb.dataset.sourceId || '';
+                document.getElementById('selected_ebook_source_path').value = preSelectedEb.dataset.sourcePath || '';
             }
             const preSelectedSt = document.querySelector('.st-card.selected');
             if (preSelectedSt) {
@@ -976,6 +988,7 @@
             document.getElementById('selected_ebook_display_name').value = display_name || filename;
             document.getElementById('selected_ebook_source').value = element.dataset.sourceType || '';
             document.getElementById('selected_ebook_source_id').value = element.dataset.sourceId || '';
+            document.getElementById('selected_ebook_source_path').value = element.dataset.sourcePath || '';
             updateAddButton();
         }
 

--- a/templates/batch_match.html
+++ b/templates/batch_match.html
@@ -753,16 +753,33 @@
                     <input type="hidden" name="action" value="add_to_queue">
                     <input type="hidden" name="search" value="{{ search }}">
                     <input type="hidden" name="audiobook_id" id="selected_audiobook_id">
+                    <input type="hidden" name="audio_source" id="selected_audio_source">
+                    <input type="hidden" name="audio_source_id" id="selected_audio_source_id">
+                    <input type="hidden" name="audio_title" id="selected_audio_title">
+                    <input type="hidden" name="audio_duration" id="selected_audio_duration">
+                    <input type="hidden" name="audio_provider_book_id" id="selected_audio_provider_book_id">
+                    <input type="hidden" name="audio_provider_file_id" id="selected_audio_provider_file_id">
+                    <input type="hidden" name="audio_cover_url" id="selected_audio_cover_url">
                     <input type="hidden" name="ebook_filename" id="selected_ebook_filename">
                     <input type="hidden" name="ebook_display_name" id="selected_ebook_display_name" value="">
+                    <input type="hidden" name="ebook_source" id="selected_ebook_source" value="">
+                    <input type="hidden" name="ebook_source_id" id="selected_ebook_source_id" value="">
                     <input type="hidden" name="storyteller_uuid" id="selected_storyteller_uuid" value="">
 
                     {% set single_ab_match = audiobooks|length == 1 %}
                     <h3 class="section-title"><span class="section-number">1</span>Select Audiobook</h3>
                     <div class="matching-grid">
                         {% for ab in audiobooks %}
-                        <div class="book-card {% if single_ab_match %}selected{% endif %}" data-value="{{ ab.id }}"
-                            onclick="selectAudiobook(this, '{{ ab.id }}', '{{ get_title(ab) }}')">
+                        <div class="book-card {% if single_ab_match %}selected{% endif %}"
+                            data-value="{{ ab.source_id }}"
+                            data-audio-source="{{ ab.source }}"
+                            data-audio-source-id="{{ ab.source_id }}"
+                            data-audio-title="{{ ab.title }}"
+                            data-audio-duration="{{ ab.duration or '' }}"
+                            data-audio-provider-book-id="{{ ab.provider_book_id or ab.source_id }}"
+                            data-audio-provider-file-id="{{ ab.provider_file_id or '' }}"
+                            data-audio-cover-url="{{ ab.cover_url or '' }}"
+                            onclick="selectAudiobook(this)">
                             <div class="book-cover-container">
                                 {% if ab.cover_url %}
                                 <img src="{{ ab.cover_url }}" alt="Cover" class="book-cover"
@@ -772,7 +789,10 @@
                                 <div class="book-cover-placeholder">🎧</div>
                                 {% endif %}
                             </div>
-                            <div class="book-title">{{ get_title(ab) }}</div>
+                            <div class="book-title">
+                                {{ ab.title }}
+                                <span class="source-badge {{ ab.source.lower().replace(' ', '') }}">{{ ab.source }}</span>
+                            </div>
                         </div>
                         {% endfor %}
                     </div>
@@ -812,6 +832,8 @@
                         <div class="resource-card eb-card {% if single_eb_match %}selected{% endif %}"
                             data-value="{{ eb.name }}"
                             data-display-name="{{ eb.display_name | replace("'", "\\'") }}"
+                            data-source-type="{{ eb.source }}"
+                            data-source-id="{{ eb.source_id }}"
                             onclick="selectEbookCard(this, '{{ eb.name }}', '{{ eb.display_name | replace("'", "\\'") }}')">
                             <div class="resource-icon">📖</div>
                             <div class="resource-title" title="{{ eb.display_name }}">
@@ -859,6 +881,9 @@
                         {% else %}
                         <p class="queue-item-ebook" title="{{ item.ebook_filename }}">
                             📖 {{ item.ebook_display_name or item.ebook_filename }}
+                            {% if item.audio_source %}
+                            <span class="source-badge {{ item.audio_source.lower().replace(' ', '') }}">{{ item.audio_source }}</span>
+                            {% endif %}
                         </p>
                         {% endif %}
                     </div>
@@ -898,6 +923,7 @@
 
     <script>
         let selectedAudiobookId = null;
+        let selectedAudioSource = null;
         let selectedEbookFilename = null;
         let selectedStorytellerUuid = null;
 
@@ -905,8 +931,7 @@
         (function init() {
             const preSelectedAb = document.querySelector('.book-card.selected');
             if (preSelectedAb) {
-                selectedAudiobookId = preSelectedAb.dataset.value;
-                document.getElementById('selected_audiobook_id').value = selectedAudiobookId;
+                selectAudiobook(preSelectedAb);
             }
             const preSelectedEb = document.querySelector('.eb-card.selected');
             if (preSelectedEb) {
@@ -922,13 +947,21 @@
             updateAddButton();
         })();
 
-        function selectAudiobook(element, id, title) {
+        function selectAudiobook(element) {
             document.querySelectorAll('.book-card').forEach(el => {
                 el.classList.remove('selected');
             });
             element.classList.add('selected');
-            selectedAudiobookId = id;
-            document.getElementById('selected_audiobook_id').value = id;
+            selectedAudiobookId = element.dataset.audioSource === 'ABS' ? (element.dataset.audioSourceId || '') : '';
+            selectedAudioSource = element.dataset.audioSource || '';
+            document.getElementById('selected_audiobook_id').value = selectedAudiobookId;
+            document.getElementById('selected_audio_source').value = selectedAudioSource;
+            document.getElementById('selected_audio_source_id').value = element.dataset.audioSourceId || '';
+            document.getElementById('selected_audio_title').value = element.dataset.audioTitle || '';
+            document.getElementById('selected_audio_duration').value = element.dataset.audioDuration || '';
+            document.getElementById('selected_audio_provider_book_id').value = element.dataset.audioProviderBookId || '';
+            document.getElementById('selected_audio_provider_file_id').value = element.dataset.audioProviderFileId || '';
+            document.getElementById('selected_audio_cover_url').value = element.dataset.audioCoverUrl || '';
             updateAddButton();
         }
 
@@ -940,6 +973,8 @@
             selectedEbookFilename = filename;
             document.getElementById('selected_ebook_filename').value = filename;
             document.getElementById('selected_ebook_display_name').value = display_name || filename;
+            document.getElementById('selected_ebook_source').value = element.dataset.sourceType || '';
+            document.getElementById('selected_ebook_source_id').value = element.dataset.sourceId || '';
             updateAddButton();
         }
 
@@ -956,7 +991,7 @@
         function updateAddButton() {
             const btn = document.getElementById('addToQueueBtn');
             // Valid if: audiobook selected AND (ebook selected OR a real storyteller UUID selected)
-            if (selectedAudiobookId && (selectedEbookFilename || selectedStorytellerUuid)) {
+            if (selectedAudioSource && (selectedEbookFilename || selectedStorytellerUuid)) {
                 btn.disabled = false;
             } else {
                 btn.disabled = true;

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,9 @@
     {% if mapping.states.booklore is defined and mapping.states.booklore.percentage %}
     {% set _ = progress_values.append(mapping.states.booklore.percentage) %}
     {% endif %}
+    {% if mapping.states.bookloreaudio is defined and mapping.states.bookloreaudio.percentage %}
+    {% set _ = progress_values.append(mapping.states.bookloreaudio.percentage) %}
+    {% endif %}
     {% if mapping.states.kosync is defined and mapping.states.kosync.percentage %}
     {% set _ = progress_values.append(mapping.states.kosync.percentage) %}
     {% endif %}
@@ -58,6 +61,14 @@
             </div>
 
             <div class="book-author">{{ mapping.abs_author or mapping.ebook_filename }}</div>
+            {% if mapping.audio_source %}
+            <div class="mapping-meta">
+                <span class="mapping-badge">{{ mapping.audio_source }} Audio</span>
+                {% if mapping.audio_url %}
+                <a href="{{ mapping.audio_url }}" target="_blank" rel="noopener noreferrer" class="mapping-link">Open Audio</a>
+                {% endif %}
+            </div>
+            {% endif %}
 
             {# Unified progress bar #}
             <div class="unified-progress">
@@ -75,6 +86,19 @@
             {# Service progress - always visible #}
             {# [START REPLACEMENT BLOCK for service-progress] #}
             <div class="service-progress">
+                {% if integrations.bookloreaudio and mapping.audio_source == 'BookLore' and mapping.audio_url %}
+                <a href="{{ mapping.audio_url }}" target="_blank" rel="noopener noreferrer" class="service-item"
+                    title="Open BookLore audiobook">
+                    <img src="/static/booklore.png" alt="BLA" class="service-icon">
+                    <span class="service-name">BL Audio</span>
+                    {% if mapping.states.bookloreaudio is defined %}
+                    <span class="service-value">{{ '%.1f' | format(mapping.states.bookloreaudio.percentage|default(0)) }}%</span>
+                    {% else %}
+                    <span class="service-value">0.0%</span>
+                    {% endif %}
+                </a>
+                {% endif %}
+
                 {% if integrations.abs and mapping.sync_mode != 'ebook_only' and mapping.abs_url %}
                 <a href="{{ mapping.abs_url }}" target="_blank" rel="noopener noreferrer" class="service-item"
                     title="Open in Audiobookshelf">
@@ -547,6 +571,35 @@
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+        }
+
+        .mapping-meta {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+            flex-wrap: wrap;
+        }
+
+        .mapping-badge {
+            padding: 3px 8px;
+            border-radius: 999px;
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+            background: rgba(79, 195, 247, 0.18);
+            color: #81d4fa;
+        }
+
+        .mapping-link {
+            color: rgba(255, 255, 255, 0.75);
+            font-size: 11px;
+            text-decoration: none;
+        }
+
+        .mapping-link:hover {
+            color: #ffffff;
         }
 
         /* Status Badge */

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,7 +75,7 @@
             {# Service progress - always visible #}
             {# [START REPLACEMENT BLOCK for service-progress] #}
             <div class="service-progress">
-                {% if integrations.abs %}
+                {% if integrations.abs and mapping.sync_mode != 'ebook_only' and mapping.abs_url %}
                 <a href="{{ mapping.abs_url }}" target="_blank" rel="noopener noreferrer" class="service-item"
                     title="Open in Audiobookshelf">
                     <img src="/static/audiobookshelf.png" alt="ABS" class="service-icon">
@@ -107,9 +107,9 @@
                 </div>
                 {% endif %}
 
-                {# [CHANGED] Only show Storyteller if state exists, UUID link exists, or legacy link needs fix #}
+                {# [CHANGED] Show Storyteller for active links, legacy fixes, and ebook-only rows (link affordance). #}
                 {% if integrations.storyteller and (mapping.states.storyteller is defined or
-                mapping.storyteller_legacy_link or mapping.storyteller_uuid) %}
+                mapping.storyteller_legacy_link or mapping.storyteller_uuid or mapping.sync_mode == 'ebook_only') %}
                 <div class="service-item" title="Storyteller">
                     <img src="/static/storyteller.png" alt="ST" class="service-icon">
                     <span class="service-name">Storyteller</span>
@@ -124,6 +124,12 @@
                         }}%</span>
                     {% elif mapping.storyteller_uuid %}
                     <span class="service-value" title="Linked via UUID">0.0%</span>
+                    {% elif mapping.sync_mode == 'ebook_only' %}
+                    <span class="service-value cursor-pointer" style="color: #4FC3F7;"
+                        onclick='openStorytellerModal({{ mapping.abs_id|tojson }}, {{ mapping.abs_title|tojson }})'
+                        title="Link Storyteller">
+                        Link
+                    </span>
                     {% endif %}
                 </div>
                 {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1563,7 +1563,8 @@
 
                 {% if shelfmark_url and (get_bool('SHELFMARK_ENABLED') or (get_val('SHELFMARK_URL') != '' and
                 get_val('SHELFMARK_ENABLED') == '')) %}
-                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -432,7 +432,8 @@
                 {% endif %}
 
                 {% if shelfmark_url %}
-                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/templates/match.html
+++ b/templates/match.html
@@ -926,7 +926,7 @@
             // Forge Validation
             const forgeBtn = document.getElementById('forgeBtn');
             // Forge requires Audio + Standard Ebook (NOT Storyteller)
-            if (hasAudio && audioSource === 'ABS' && (ebVal !== "")) {
+            if (hasAudio && (audioSource === 'ABS' || audioSource === 'BookLore') && (ebVal !== "")) {
                 forgeBtn.disabled = false;
                 forgeBtn.style.opacity = "1";
             } else {

--- a/templates/match.html
+++ b/templates/match.html
@@ -686,15 +686,27 @@
 
                 <!-- GRID COL 1: Audiobook -->
                 <div class="section">
-                    <h3><span class="section-number">1</span>Audiobook (Required)</h3>
+                    <h3><span class="section-number">1</span>Audiobook (Optional)</h3>
                     <div class="scrollable-content">
                         {% if audiobooks %}
                         <div class="media-grid">
                             {% set single_match = audiobooks|length == 1 %}
+                            <!-- None / Skip Option -->
+                            <label class="audiobook-option ab-option ghost-card {% if not single_match %}selected{% endif %}"
+                                onclick="selectItem(this, 'audiobook_id')">
+                                <input type="radio" name="audiobook_id" value="" {% if not single_match %}checked{% endif %}>
+                                <div class="audiobook-cover-container">
+                                    <div class="audiobook-cover-placeholder">⊘</div>
+                                </div>
+                                <div class="audiobook-info">
+                                    <div class="audiobook-title">None / Skip</div>
+                                </div>
+                            </label>
+
                             {% for ab in audiobooks %}
                             <label class="audiobook-option ab-option {% if single_match %}selected{% endif %}"
                                 onclick="selectItem(this, 'audiobook_id')">
-                                <input type="radio" name="audiobook_id" value="{{ ab.id }}" required {% if single_match
+                                <input type="radio" name="audiobook_id" value="{{ ab.id }}" {% if single_match
                                     %}checked{% endif %}>
                                 <div class="audiobook-cover-container">
                                     {% if ab.cover_url %}
@@ -816,7 +828,7 @@
                     🔨 Forge & Match
                 </button>
                 <div id="validationMsg" style="margin-top: 10px; color: #ff6b6b; display: none;">
-                    Please select an Audiobook and a Text Source (Storyteller or Ebook)
+                    Please select a Text Source (Storyteller or Ebook)
                 </div>
             </div>
         </form>
@@ -869,20 +881,15 @@
 
             let hasText = (stVal !== "") || (ebVal !== "");
 
-            if (hasAudio && hasText) {
+            if (hasText) {
                 btn.disabled = false;
                 btn.style.opacity = "1";
                 msg.style.display = "none";
             } else {
                 btn.disabled = true;
                 btn.style.opacity = "0.5";
-                if (hasAudio && !hasText) {
-                    msg.textContent = "Please select a text source (Storyteller or Standard Ebook)";
-                    msg.style.display = "block";
-                } else if (!hasAudio) {
-                    msg.textContent = "Please select an Audiobook";
-                    msg.style.display = "block";
-                }
+                msg.textContent = "Please select a text source (Storyteller or Standard Ebook)";
+                msg.style.display = "block";
             }
 
             // Forge Validation

--- a/templates/match.html
+++ b/templates/match.html
@@ -681,6 +681,15 @@
             <input type="hidden" name="source_type" id="input_source_type">
             <input type="hidden" name="source_path" id="input_source_path">
             <input type="hidden" name="source_id" id="input_source_id">
+            <input type="hidden" name="audio_source" id="input_audio_source">
+            <input type="hidden" name="audio_source_id" id="input_audio_source_id">
+            <input type="hidden" name="audio_title" id="input_audio_title">
+            <input type="hidden" name="audio_duration" id="input_audio_duration">
+            <input type="hidden" name="audio_provider_book_id" id="input_audio_provider_book_id">
+            <input type="hidden" name="audio_provider_file_id" id="input_audio_provider_file_id">
+            <input type="hidden" name="audio_cover_url" id="input_audio_cover_url">
+            <input type="hidden" name="ebook_source" id="input_ebook_source">
+            <input type="hidden" name="ebook_source_id" id="input_ebook_source_id">
 
             <div class="selection-container">
 
@@ -705,8 +714,15 @@
 
                             {% for ab in audiobooks %}
                             <label class="audiobook-option ab-option {% if single_match %}selected{% endif %}"
+                                data-audio-source="{{ ab.source }}"
+                                data-audio-source-id="{{ ab.source_id }}"
+                                data-audio-title="{{ ab.title }}"
+                                data-audio-duration="{{ ab.duration or '' }}"
+                                data-audio-provider-book-id="{{ ab.provider_book_id or ab.source_id }}"
+                                data-audio-provider-file-id="{{ ab.provider_file_id or '' }}"
+                                data-audio-cover-url="{{ ab.cover_url or '' }}"
                                 onclick="selectItem(this, 'audiobook_id')">
-                                <input type="radio" name="audiobook_id" value="{{ ab.id }}" {% if single_match
+                                <input type="radio" name="audiobook_id" value="{% if ab.source == 'ABS' %}{{ ab.source_id }}{% endif %}" {% if single_match
                                     %}checked{% endif %}>
                                 <div class="audiobook-cover-container">
                                     {% if ab.cover_url %}
@@ -718,7 +734,8 @@
                                     {% endif %}
                                 </div>
                                 <div class="audiobook-info">
-                                    <div class="audiobook-title">{{ get_title(ab) }}</div>
+                                    <div class="audiobook-title">{{ ab.title }}</div>
+                                    <span class="source-badge {{ ab.source.lower().replace(' ', '') }}">{{ ab.source }}</span>
                                 </div>
                             </label>
                             {% endfor %}
@@ -854,11 +871,23 @@
             const radio = element.querySelector('input[type="radio"]');
             if (radio) radio.checked = true;
 
+            if (groupName === 'audiobook_id') {
+                document.getElementById('input_audio_source').value = element.dataset.audioSource || '';
+                document.getElementById('input_audio_source_id').value = element.dataset.audioSourceId || '';
+                document.getElementById('input_audio_title').value = element.dataset.audioTitle || '';
+                document.getElementById('input_audio_duration').value = element.dataset.audioDuration || '';
+                document.getElementById('input_audio_provider_book_id').value = element.dataset.audioProviderBookId || '';
+                document.getElementById('input_audio_provider_file_id').value = element.dataset.audioProviderFileId || '';
+                document.getElementById('input_audio_cover_url').value = element.dataset.audioCoverUrl || '';
+            }
+
             // If ebook option, populate hidden inputs for Forge
             if (groupName === 'ebook_filename') {
                 document.getElementById('input_source_type').value = element.dataset.sourceType || '';
                 document.getElementById('input_source_path').value = element.dataset.sourcePath || '';
                 document.getElementById('input_source_id').value = element.dataset.sourceId || '';
+                document.getElementById('input_ebook_source').value = element.dataset.sourceType || '';
+                document.getElementById('input_ebook_source_id').value = element.dataset.sourceId || '';
             }
 
             validateForm();
@@ -868,11 +897,12 @@
             const ab = document.querySelector('input[name="audiobook_id"]:checked');
             const st = document.querySelector('input[name="storyteller_uuid"]:checked');
             const eb = document.querySelector('input[name="ebook_filename"]:checked');
+            const audioSource = document.getElementById('input_audio_source').value;
 
             const btn = document.getElementById('submitBtn');
             const msg = document.getElementById('validationMsg');
 
-            let hasAudio = !!ab;
+            let hasAudio = !!audioSource;
             // Valid text source if: 
             // 1. Storyteller UUID is selected AND NOT EMPTY
             // 2. OR Ebook Filename is selected
@@ -895,7 +925,7 @@
             // Forge Validation
             const forgeBtn = document.getElementById('forgeBtn');
             // Forge requires Audio + Standard Ebook (NOT Storyteller)
-            if (hasAudio && (ebVal !== "")) {
+            if (hasAudio && audioSource === 'ABS' && (ebVal !== "")) {
                 forgeBtn.disabled = false;
                 forgeBtn.style.opacity = "1";
             } else {
@@ -906,6 +936,13 @@
 
         // Initial check and setup
         document.addEventListener('DOMContentLoaded', () => {
+            const initialAb = document.querySelector('input[name="audiobook_id"]:checked');
+            if (initialAb) {
+                const label = initialAb.closest('.ab-option');
+                if (label) {
+                    selectItem(label, 'audiobook_id');
+                }
+            }
             const initialEb = document.querySelector('input[name="ebook_filename"]:checked');
             if (initialEb) {
                 const label = initialEb.closest('.eb-option');

--- a/templates/match.html
+++ b/templates/match.html
@@ -638,7 +638,8 @@
                 {% endif %}
 
                 {% if shelfmark_url %}
-                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1078,6 +1078,19 @@
                         </div>
                     </div>
 
+                    <div class="form-group full-width">
+                        <label>Booklore Cache</label>
+                        <div class="cleanup-group">
+                            <button type="button" id="booklore_refresh_btn" class="btn btn-primary" onclick="refreshBookloreCache(this)">
+                                Refresh Booklore Cache
+                            </button>
+                            <p class="help-text flex-1 m-0">
+                                Rebuilds Booklore cache immediately, including stale metadata refresh.
+                                <span id="booklore_refresh_status"></span>
+                            </p>
+                        </div>
+                    </div>
+
                     <hr style="margin: 20px 0; border-color: var(--border-color); opacity: 0.3; grid-column: span 2;">
 
                     <!-- Transcription Settings -->
@@ -1413,6 +1426,50 @@
             } catch (err) {
                 console.error('Error cleaning cache:', err);
                 alert('An error occurred while cleaning cache. Check console for details.');
+            }
+        }
+
+        async function refreshBookloreCache(btn) {
+            const statusEl = document.getElementById('booklore_refresh_status');
+            const originalText = btn.innerHTML;
+            btn.disabled = true;
+            btn.innerHTML = 'Refreshing...';
+            if (statusEl) {
+                statusEl.textContent = ' Refresh in progress...';
+                statusEl.style.color = 'rgba(255, 255, 255, 0.55)';
+            }
+
+            try {
+                const response = await fetch('/api/booklore/refresh', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                });
+
+                const data = await response.json();
+                if (!response.ok || !data.success) {
+                    const message = data.error || 'Unknown error';
+                    if (statusEl) {
+                        statusEl.textContent = ` Refresh failed: ${message}`;
+                        statusEl.style.color = '#e57373';
+                    }
+                    return;
+                }
+
+                if (statusEl) {
+                    statusEl.textContent = ' Refresh complete.';
+                    statusEl.style.color = '#81c784';
+                }
+            } catch (err) {
+                console.error('Error refreshing Booklore cache:', err);
+                if (statusEl) {
+                    statusEl.textContent = ` Refresh failed: ${err}`;
+                    statusEl.style.color = '#e57373';
+                }
+            } finally {
+                btn.disabled = false;
+                btn.innerHTML = originalText;
             }
         }
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -444,7 +444,8 @@
                 {% endif %}
 
                 {% if shelfmark_url and get_bool('SHELFMARK_ENABLED') %}
-                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/templates/shelfmark.html
+++ b/templates/shelfmark.html
@@ -186,7 +186,8 @@
                 {% endif %}
 
                 {% if shelfmark_url %}
-                <a href="/shelfmark" class="nav-icon-link nav-icon-link-active" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link nav-icon-link-active" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/templates/suggestions.html
+++ b/templates/suggestions.html
@@ -217,16 +217,16 @@
                     <div class="suggestions-list" id="suggestionsList">
                         {% for s in suggestions %}
                         <div class="suggestion-card"
-                             id="suggestion-{{ s.abs_id }}"
-                             data-abs-id="{{ s.abs_id }}"
+                             id="suggestion-{{ s.bridge_key or s.abs_id }}"
+                             data-abs-id="{{ s.bridge_key or s.abs_id }}"
                              data-best-score="{% if s.matches and s.matches|length > 0 %}{{ s.matches[0].score }}{% else %}0{% endif %}"
-                             data-title="{{ s.abs_title or '' }}"
-                             onclick="selectSuggestion('{{ s.abs_id }}')">
+                             data-title="{{ s.audio_title or s.abs_title or '' }}"
+                             onclick="selectSuggestion('{{ s.bridge_key or s.abs_id }}')">
                             <div class="suggestion-main">
-                                <img src="{{ s.cover_url }}" alt="Cover" class="cover" onerror="this.style.opacity='0.25';">
+                                <img src="{{ s.audio_cover_url or s.cover_url }}" alt="Cover" class="cover" onerror="this.style.opacity='0.25';">
                                 <div>
-                                    <div class="title">{{ s.abs_title }}</div>
-                                    {% if s.abs_author %}<div class="author">{{ s.abs_author }}</div>{% endif %}
+                                    <div class="title">{{ s.audio_title or s.abs_title }}</div>
+                                    {% if s.audio_author or s.abs_author %}<div class="author">{{ s.audio_author or s.abs_author }}</div>{% endif %}
                                     <div class="score">{% if s.matches and s.matches|length > 0 %}Match {{ s.matches[0].score|round|int }}%{% else %}Match --{% endif %}</div>
                                     {% if s.matches and s.matches|length > 0 %}
                                     <div class="best" title="{{ s.matches[0].display_name }}">Best: {{ s.matches[0].display_name }} ({{ s.matches[0].score|round|int }}%)</div>
@@ -234,13 +234,14 @@
                                 </div>
                             </div>
                             <div class="card-actions">
-                                <button type="button" class="btn btn-small btn-dismiss" onclick="dismissSuggestion(event, '{{ s.abs_id }}')">Dismiss</button>
+                                <button type="button" class="btn btn-small btn-dismiss" onclick="dismissSuggestion(event, '{{ s.bridge_key or s.abs_id }}')">Dismiss</button>
                                 <form method="POST" action="/suggestions" class="inline-form" onsubmit="event.stopPropagation();">
                                     <input type="hidden" name="action" value="never">
-                                    <input type="hidden" name="abs_id" value="{{ s.abs_id }}">
-                                    <input type="hidden" name="abs_title" value="{{ s.abs_title }}">
-                                    <input type="hidden" name="abs_author" value="{{ s.abs_author }}">
-                                    <input type="hidden" name="cover_url" value="{{ s.cover_url }}">
+                                    <input type="hidden" name="bridge_key" value="{{ s.bridge_key or s.abs_id }}">
+                                    <input type="hidden" name="audio_source" value="{{ s.audio_source or '' }}">
+                                    <input type="hidden" name="audio_title" value="{{ s.audio_title or s.abs_title }}">
+                                    <input type="hidden" name="audio_author" value="{{ s.audio_author or s.abs_author }}">
+                                    <input type="hidden" name="cover_url" value="{{ s.audio_cover_url or s.cover_url }}">
                                     <button type="submit" class="btn btn-small btn-reject" onclick="event.stopPropagation();">Reject</button>
                                 </form>
                             </div>
@@ -279,8 +280,18 @@
                         <form method="POST" action="/suggestions" id="addToQueueForm">
                             <input type="hidden" name="action" value="add_to_queue">
                             <input type="hidden" name="audiobook_id" id="selected_audiobook_id">
+                            <input type="hidden" name="audio_source" id="selected_audio_source" value="">
+                            <input type="hidden" name="audio_source_id" id="selected_audio_source_id" value="">
+                            <input type="hidden" name="audio_title" id="selected_audio_title" value="">
+                            <input type="hidden" name="audio_author" id="selected_audio_author" value="">
+                            <input type="hidden" name="audio_cover_url" id="selected_audio_cover_url" value="">
+                            <input type="hidden" name="audio_duration" id="selected_audio_duration" value="">
+                            <input type="hidden" name="audio_provider_book_id" id="selected_audio_provider_book_id" value="">
+                            <input type="hidden" name="audio_provider_file_id" id="selected_audio_provider_file_id" value="">
                             <input type="hidden" name="ebook_filename" id="selected_ebook_filename">
                             <input type="hidden" name="ebook_display_name" id="selected_ebook_display_name" value="">
+                            <input type="hidden" name="ebook_source" id="selected_ebook_source" value="">
+                            <input type="hidden" name="ebook_source_id" id="selected_ebook_source_id" value="">
                             <input type="hidden" name="storyteller_uuid" id="selected_storyteller_uuid" value="">
                             <label class="field-label" for="storytellerCardGrid">Storyteller (Preferred)</label>
                             <p class="field-hint">Optional. Choose this to create a tri-link.</p>
@@ -421,10 +432,12 @@
                 });
         }
 
-        function setSelectedEbook(filename, displayName) {
+        function setSelectedEbook(filename, displayName, source = '', sourceId = '') {
             const hasSelection = !!filename;
             document.getElementById('selected_ebook_filename').value = hasSelection ? filename : '';
             document.getElementById('selected_ebook_display_name').value = hasSelection ? (displayName || filename) : '';
+            document.getElementById('selected_ebook_source').value = hasSelection ? (source || '') : '';
+            document.getElementById('selected_ebook_source_id').value = hasSelection ? (sourceId || '') : '';
             updateAddButton();
         }
 
@@ -432,10 +445,10 @@
             document.querySelectorAll('#ebookCardGrid .ebook-card').forEach((card) => card.classList.remove('selected'));
         }
 
-        function selectEbookCard(element, filename, displayName) {
+        function selectEbookCard(element, filename, displayName, source, sourceId) {
             clearSelectedEbookCards();
             if (element) element.classList.add('selected');
-            setSelectedEbook(filename, displayName);
+            setSelectedEbook(filename, displayName, source, sourceId);
         }
 
         function updateAddButton() {
@@ -478,7 +491,7 @@
                 return;
             }
 
-            const queryParts = [suggestion.abs_title || '', suggestion.abs_author || '']
+            const queryParts = [suggestion.audio_title || suggestion.abs_title || '', suggestion.audio_author || suggestion.abs_author || '']
                 .map((s) => (s || '').trim())
                 .filter((s) => !!s);
             if (!queryParts.length) {
@@ -607,7 +620,15 @@
             document.getElementById('selectionDetails').classList.add('hidden');
             document.getElementById('selectionPlaceholder').style.display = 'block';
             document.getElementById('selected_audiobook_id').value = '';
-            setSelectedEbook('', '');
+            document.getElementById('selected_audio_source').value = '';
+            document.getElementById('selected_audio_source_id').value = '';
+            document.getElementById('selected_audio_title').value = '';
+            document.getElementById('selected_audio_author').value = '';
+            document.getElementById('selected_audio_cover_url').value = '';
+            document.getElementById('selected_audio_duration').value = '';
+            document.getElementById('selected_audio_provider_book_id').value = '';
+            document.getElementById('selected_audio_provider_file_id').value = '';
+            setSelectedEbook('', '', '', '');
             selectedStorytellerUuid = '';
             document.getElementById('selected_storyteller_uuid').value = '';
             const grid = document.getElementById('ebookCardGrid');
@@ -622,19 +643,27 @@
             updateAddButton();
         }
 
-        function selectSuggestion(absId) {
-            const suggestion = suggestionsData.find((item) => item.abs_id === absId);
+        function selectSuggestion(suggestionKey) {
+            const suggestion = suggestionsData.find((item) => (item.bridge_key || item.abs_id) === suggestionKey);
             if (!suggestion || !suggestion.matches || suggestion.matches.length === 0) return;
 
-            selectedSuggestionId = absId;
-            document.querySelectorAll('.suggestion-card').forEach((card) => card.classList.toggle('selected', card.dataset.absId === absId));
+            selectedSuggestionId = suggestionKey;
+            document.querySelectorAll('.suggestion-card').forEach((card) => card.classList.toggle('selected', card.dataset.absId === suggestionKey));
 
             document.getElementById('selectionPlaceholder').style.display = 'none';
             document.getElementById('selectionDetails').classList.remove('hidden');
-            document.getElementById('selected_audiobook_id').value = suggestion.abs_id || '';
-            document.getElementById('selectedTitle').textContent = suggestion.abs_title || '';
-            document.getElementById('selectedAuthor').textContent = suggestion.abs_author || '';
-            document.getElementById('selectedCover').src = suggestion.cover_url || '';
+            document.getElementById('selected_audiobook_id').value = suggestion.bridge_key || suggestion.abs_id || '';
+            document.getElementById('selected_audio_source').value = suggestion.audio_source || '';
+            document.getElementById('selected_audio_source_id').value = suggestion.audio_source_id || '';
+            document.getElementById('selected_audio_title').value = suggestion.audio_title || suggestion.abs_title || '';
+            document.getElementById('selected_audio_author').value = suggestion.audio_author || suggestion.abs_author || '';
+            document.getElementById('selected_audio_cover_url').value = suggestion.audio_cover_url || suggestion.cover_url || '';
+            document.getElementById('selected_audio_duration').value = suggestion.audio_duration ?? suggestion.duration ?? '';
+            document.getElementById('selected_audio_provider_book_id').value = suggestion.audio_provider_book_id || suggestion.audio_source_id || '';
+            document.getElementById('selected_audio_provider_file_id').value = suggestion.audio_provider_file_id || '';
+            document.getElementById('selectedTitle').textContent = suggestion.audio_title || suggestion.abs_title || '';
+            document.getElementById('selectedAuthor').textContent = suggestion.audio_author || suggestion.abs_author || '';
+            document.getElementById('selectedCover').src = suggestion.audio_cover_url || suggestion.cover_url || '';
             renderStorytellerOptions(suggestion);
 
             const matches = [...suggestion.matches].sort((a, b) => (b.score || 0) - (a.score || 0));
@@ -646,6 +675,7 @@
                 const ebookFilename = match.ebook_filename || '';
                 const displayName = match.display_name || ebookFilename;
                 const source = match.source || inferSourceFromFilename(ebookFilename);
+                const sourceId = match.source_id || '';
                 const author = match.author || '';
                 const score = Math.round(match.score || 0);
 
@@ -653,7 +683,9 @@
                 card.className = 'ebook-card';
                 card.dataset.value = ebookFilename;
                 card.dataset.displayName = displayName;
-                card.onclick = () => selectEbookCard(card, ebookFilename, displayName);
+                card.dataset.source = source || '';
+                card.dataset.sourceId = sourceId || '';
+                card.onclick = () => selectEbookCard(card, ebookFilename, displayName, source, sourceId);
 
                 const icon = document.createElement('div');
                 icon.className = 'ebook-icon';
@@ -693,10 +725,16 @@
                 emptyLabel.classList.add('hidden');
                 const firstCard = grid.querySelector('.ebook-card');
                 if (firstCard) {
-                    selectEbookCard(firstCard, firstCard.dataset.value || '', firstCard.dataset.displayName || '');
+                    selectEbookCard(
+                        firstCard,
+                        firstCard.dataset.value || '',
+                        firstCard.dataset.displayName || '',
+                        firstCard.dataset.source || '',
+                        firstCard.dataset.sourceId || '',
+                    );
                 }
             } else {
-                setSelectedEbook('', '');
+                setSelectedEbook('', '', '', '');
                 emptyLabel.classList.remove('hidden');
             }
         }
@@ -717,13 +755,13 @@
             }
         }
 
-        function dismissSuggestion(event, absId) {
+        function dismissSuggestion(event, suggestionKey) {
             event.preventDefault();
             event.stopPropagation();
-            const card = document.getElementById(`suggestion-${absId}`);
+            const card = document.getElementById(`suggestion-${suggestionKey}`);
             if (card) card.remove();
-            suggestionsData = suggestionsData.filter((item) => item.abs_id !== absId);
-            if (selectedSuggestionId === absId) clearSelection();
+            suggestionsData = suggestionsData.filter((item) => (item.bridge_key || item.abs_id) !== suggestionKey);
+            if (selectedSuggestionId === suggestionKey) clearSelection();
             updateVisibleCounts();
         }
 

--- a/templates/suggestions.html
+++ b/templates/suggestions.html
@@ -143,7 +143,8 @@
                 </a>
                 {% endif %}
                 {% if shelfmark_url %}
-                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool">
+                <a href="/shelfmark" class="nav-icon-link" title="Shelfmark Tool" target="_blank"
+                    rel="noopener noreferrer">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path><line x1="7" y1="7" x2="7.01" y2="7"></line>
                     </svg>

--- a/tests/test_booklore_audio_sync_client.py
+++ b/tests/test_booklore_audio_sync_client.py
@@ -1,0 +1,128 @@
+from unittest.mock import MagicMock, patch
+
+from src.db.models import Book
+from src.sync_clients.booklore_audio_sync_client import BookLoreAudioSyncClient
+from src.sync_clients.sync_client_interface import LocatorResult, UpdateProgressRequest
+
+
+def _make_book(**overrides):
+    values = {
+        "abs_id": "abs-1",
+        "abs_title": "BookLore Audio Test",
+        "audio_source": "BookLore",
+        "audio_source_id": "bl-1",
+        "audio_duration": 100.0,
+        "duration": 100.0,
+        "ebook_filename": "test.epub",
+        "status": "active",
+    }
+    values.update(overrides)
+    return Book(**values)
+
+
+def _folder_based_info():
+    return {
+        "bookFileId": 10157,
+        "folderBased": True,
+        "tracks": [
+            {"index": 0, "durationMs": 30000, "cumulativeStartMs": 0},
+            {"index": 1, "durationMs": 40000, "cumulativeStartMs": 30000},
+            {"index": 2, "durationMs": 30000, "cumulativeStartMs": 70000},
+        ],
+    }
+
+
+def test_get_service_state_reconstructs_absolute_timestamp_from_track_progress():
+    booklore_client = MagicMock()
+    booklore_client.get_audiobook_progress.return_value = {
+        "pct": 0.5,
+        "position_ms": 5000,
+        "track_index": 1,
+    }
+    booklore_client.get_audiobook_info.return_value = _folder_based_info()
+    booklore_client.is_configured.return_value = True
+
+    client = BookLoreAudioSyncClient(booklore_client, MagicMock())
+    state = client.get_service_state(_make_book(), None)
+
+    assert state is not None
+    assert state.current["pct"] == 0.5
+    assert state.current["ts"] == 35.0
+    booklore_client.get_audiobook_info.assert_called_once_with("bl-1")
+
+
+def test_update_progress_converts_absolute_target_to_track_relative_resume_fields():
+    booklore_client = MagicMock()
+    booklore_client.get_audiobook_info.return_value = _folder_based_info()
+    booklore_client.update_audiobook_progress.return_value = True
+
+    client = BookLoreAudioSyncClient(booklore_client, MagicMock())
+    book = _make_book()
+    request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5))
+
+    with patch("src.services.write_tracker.record_write"):
+        result = client.update_progress(book, request)
+
+    assert result.success is True
+    assert result.location == 50.0
+    kwargs = booklore_client.update_audiobook_progress.call_args.kwargs
+    assert kwargs["book_file_id"] == "10157"
+    assert kwargs["position_ms"] == 20000
+    assert kwargs["track_index"] == 1
+    assert kwargs["track_position_ms"] == 20000
+    booklore_client.get_audiobook_info.assert_called_once_with("bl-1")
+
+
+def test_update_progress_clamps_end_of_book_to_final_track():
+    booklore_client = MagicMock()
+    booklore_client.get_audiobook_info.return_value = _folder_based_info()
+    booklore_client.update_audiobook_progress.return_value = True
+
+    client = BookLoreAudioSyncClient(booklore_client, MagicMock())
+    request = UpdateProgressRequest(locator_result=LocatorResult(percentage=1.0))
+
+    with patch("src.services.write_tracker.record_write"):
+        result = client.update_progress(_make_book(), request)
+
+    assert result.success is True
+    kwargs = booklore_client.update_audiobook_progress.call_args.kwargs
+    assert kwargs["position_ms"] == 30000
+    assert kwargs["track_index"] == 2
+    assert kwargs["track_position_ms"] == 30000
+
+
+def test_get_service_state_falls_back_to_percentage_when_track_metadata_is_missing():
+    booklore_client = MagicMock()
+    booklore_client.get_audiobook_progress.return_value = {
+        "pct": 0.25,
+        "position_ms": 5000,
+        "track_index": 1,
+    }
+    booklore_client.get_audiobook_info.return_value = None
+    booklore_client.is_configured.return_value = True
+
+    client = BookLoreAudioSyncClient(booklore_client, MagicMock())
+    state = client.get_service_state(_make_book(audio_duration=100.0, duration=100.0), None)
+
+    assert state is not None
+    assert state.current["pct"] == 0.25
+    assert state.current["ts"] == 25.0
+
+
+def test_update_progress_zero_reset_writes_start_of_first_track():
+    booklore_client = MagicMock()
+    booklore_client.get_audiobook_info.return_value = _folder_based_info()
+    booklore_client.update_audiobook_progress.return_value = True
+
+    client = BookLoreAudioSyncClient(booklore_client, MagicMock())
+    request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.0))
+
+    with patch("src.services.write_tracker.record_write"):
+        result = client.update_progress(_make_book(), request)
+
+    assert result.success is True
+    assert result.location == 0.0
+    kwargs = booklore_client.update_audiobook_progress.call_args.kwargs
+    assert kwargs["position_ms"] == 0
+    assert kwargs["track_index"] == 0
+    assert kwargs["track_position_ms"] == 0

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -836,3 +836,148 @@ def test_search_books_finds_lightweight_entries_without_detail_fetch(booklore_cl
     assert results[0]["id"] == "bl-1"
     assert results[0]["fileName"] == "Fever Dream - Samanta Schweblin (2016).epub"
     booklore_client._fetch_and_cache_detail.assert_not_called()
+
+
+def test_search_audiobooks_includes_combined_book_using_alternative_formats(booklore_client):
+    combined_detail = {
+        "id": 6798,
+        "libraryId": "lib-1",
+        "metadata": {
+            "title": "The Mars Anomaly",
+            "authors": ["Joshua T. Calvert"],
+            "audiobookMetadata": {
+                "durationSeconds": 33945,
+                "chapterCount": 50,
+            },
+        },
+        "primaryFile": {
+            "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).epub",
+            "filePath": "/books/The Mars Anomaly - Joshua T. Calvert (2024).epub",
+            "bookType": "EPUB",
+            "id": 7605,
+        },
+        "alternativeFormats": [
+            {
+                "id": 10157,
+                "bookType": "AUDIOBOOK",
+                "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).m4b",
+            }
+        ],
+        "supplementaryFiles": [],
+        "audiobookProgress": None,
+        "epubProgress": None,
+    }
+    booklore_client._process_book_detail(combined_detail)
+    booklore_client._cache_timestamp = time.time()
+    booklore_client.get_audiobook_info = MagicMock(return_value={"bookFileId": 10157, "durationMs": 33945000})
+
+    results = booklore_client.search_audiobooks("Mars Anomaly")
+
+    assert len(results) == 1
+    assert results[0]["id"] == 6798
+    assert results[0]["audiobookInfo"]["bookFileId"] == 10157
+
+
+def test_search_audiobooks_force_refreshes_legacy_cached_detail_missing_audio_shape(booklore_client):
+    legacy_cached = {
+        "id": 6798,
+        "title": "The Mars Anomaly",
+        "authors": "Joshua T. Calvert",
+        "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).epub",
+        "bookType": "EPUB",
+        "primaryFile": {
+            "bookType": "EPUB",
+            "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).epub",
+        },
+        "_detail_fetched_at": time.time() - 3600,
+    }
+    refreshed = {
+        **legacy_cached,
+        "alternativeFormats": [
+            {
+                "id": 10157,
+                "bookType": "AUDIOBOOK",
+                "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).m4b",
+            }
+        ],
+        "supplementaryFiles": [],
+        "audiobookMetadata": {"durationSeconds": 33945},
+    }
+
+    booklore_client._book_cache = {legacy_cached["fileName"].lower(): legacy_cached}
+    booklore_client._book_id_cache = {6798: legacy_cached}
+    booklore_client._cache_timestamp = time.time()
+    booklore_client._fetch_and_cache_detail = MagicMock(return_value=refreshed)
+    booklore_client.get_audiobook_info = MagicMock(return_value={"bookFileId": 10157})
+
+    results = booklore_client.search_audiobooks("Mars Anomaly")
+
+    booklore_client._fetch_and_cache_detail.assert_called_once_with(6798, force_refresh=True)
+    assert len(results) == 1
+    assert results[0]["id"] == 6798
+
+
+def test_search_books_dedupes_stale_filename_aliases_by_book_id(booklore_client):
+    stale = {
+        "id": 6798,
+        "title": "The Mars Anomaly",
+        "authors": "Joshua T. Calvert",
+        "fileName": "Mars Anomaly_ Hard Science Fiction, The - Joshua T. Calvert.epub",
+        "bookType": "EPUB",
+    }
+    current = {
+        "id": 6798,
+        "title": "The Mars Anomaly",
+        "authors": "Joshua T. Calvert",
+        "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).epub",
+        "bookType": "EPUB",
+    }
+
+    booklore_client._book_cache = {
+        stale["fileName"].lower(): stale,
+        current["fileName"].lower(): current,
+    }
+    booklore_client._book_id_cache = {6798: current}
+    booklore_client._cache_timestamp = time.time()
+
+    results = booklore_client.search_books("Mars Anomaly")
+
+    assert len(results) == 1
+    assert results[0]["fileName"] == current["fileName"]
+
+
+def test_process_book_detail_removes_stale_filename_aliases_for_same_id(booklore_client):
+    old_name = "mars anomaly_ hard science fiction, the - joshua t. calvert.epub"
+    new_name = "the mars anomaly - joshua t. calvert (2024).epub"
+    booklore_client._book_cache = {
+        old_name: {
+            "id": 6798,
+            "fileName": "Mars Anomaly_ Hard Science Fiction, The - Joshua T. Calvert.epub",
+            "title": "The Mars Anomaly",
+            "authors": "Joshua T. Calvert",
+            "bookType": "EPUB",
+        }
+    }
+    booklore_client._book_id_cache = {
+        6798: booklore_client._book_cache[old_name]
+    }
+
+    detail = {
+        "id": 6798,
+        "libraryId": "lib-1",
+        "metadata": {
+            "title": "The Mars Anomaly",
+            "authors": ["Joshua T. Calvert"],
+        },
+        "primaryFile": {
+            "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).epub",
+            "filePath": "/books/The Mars Anomaly - Joshua T. Calvert (2024).epub",
+            "bookType": "EPUB",
+        },
+    }
+
+    booklore_client._process_book_detail(detail)
+
+    assert old_name not in booklore_client._book_cache
+    assert new_name in booklore_client._book_cache
+    booklore_client.db.delete_booklore_book.assert_called_with(old_name)

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -398,7 +398,7 @@ def test_search_books_miss_triggers_single_refresh_and_returns_new_match(booklor
     booklore_client._cache_timestamp = time.time() - 120
     booklore_client._is_refresh_on_cooldown = MagicMock(return_value=False)
 
-    def refresh_side_effect():
+    def refresh_side_effect(**kwargs):
         booklore_client._book_cache["new-book.epub"] = {
             "fileName": "new-book.epub",
             "title": "New Arrival",
@@ -465,10 +465,11 @@ def test_search_books_hit_triggers_single_refresh_and_prunes_deleted_result_when
     booklore_client._book_id_cache = {
         "deleted": {"id": "deleted", "fileName": "deleted.epub", "title": "Deleted Book", "authors": "Old Author"}
     }
-    booklore_client._cache_timestamp = time.time() - 120
+    booklore_client._cache_timestamp = time.time() - 1900
+    booklore_client._search_hit_refresh_min_age = 60
     booklore_client._is_refresh_on_cooldown = MagicMock(return_value=False)
 
-    def refresh_side_effect():
+    def refresh_side_effect(**kwargs):
         booklore_client._book_cache.clear()
         booklore_client._book_id_cache.clear()
         booklore_client._cache_timestamp = time.time()
@@ -512,7 +513,7 @@ def test_refresh_book_cache_hydrates_small_library(booklore_client):
         )
     )
 
-    assert booklore_client._refresh_book_cache() is True
+    assert booklore_client._refresh_book_cache(refresh_stale_details=False) is True
     assert booklore_client._fetch_book_detail.call_count == 3
     assert len(booklore_client._book_cache) == 3
     assert len(booklore_client._book_id_cache) == 3
@@ -529,7 +530,7 @@ def test_refresh_book_cache_skips_bulk_detail_fetch_for_large_library(booklore_c
     booklore_client._get_fresh_token = MagicMock(return_value="token")
     booklore_client._fetch_book_detail = MagicMock()
 
-    assert booklore_client._refresh_book_cache() is True
+    assert booklore_client._refresh_book_cache(refresh_stale_details=False) is True
     assert booklore_client._fetch_book_detail.call_count == 0
     assert len(booklore_client._book_cache) == 0
     assert len(booklore_client._book_id_cache) == len(books)

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -752,6 +752,152 @@ def test_get_progress_404_evicts_stale_hydrated_entry(booklore_client):
     booklore_client.db.delete_booklore_book.assert_called_once_with("gone.epub")
 
 
+def test_update_audiobook_progress_single_file_uses_plain_file_progress_payload(booklore_client):
+    post_resp = MagicMock()
+    post_resp.status_code = 200
+
+    verify_resp = MagicMock()
+    verify_resp.status_code = 200
+    verify_resp.json.return_value = {
+        "audiobookProgress": {"percentage": 50.0, "positionMs": 12345}
+    }
+
+    booklore_client._make_request = MagicMock(side_effect=[post_resp, verify_resp])
+
+    ok = booklore_client.update_audiobook_progress(
+        book_id=6043,
+        book_file_id=10157,
+        position_ms=12345,
+        percentage=0.5,
+    )
+
+    assert ok is True
+    assert booklore_client._make_request.call_count == 2
+    first_post = booklore_client._make_request.call_args_list[0][0]
+    assert first_post[0] == "POST"
+    assert first_post[1] == "/api/v1/books/progress"
+    assert first_post[2]["fileProgress"]["bookFileId"] == 10157
+    assert first_post[2]["fileProgress"]["positionData"] == "12345"
+    assert first_post[2]["fileProgress"]["progressPercent"] == 50.0
+    assert "positionHref" not in first_post[2]["fileProgress"]
+    assert "audiobookProgress" not in first_post[2]
+
+
+def test_update_audiobook_progress_folder_based_uses_track_relative_file_progress(booklore_client):
+    post_resp = MagicMock()
+    post_resp.status_code = 200
+
+    verify_resp = MagicMock()
+    verify_resp.status_code = 200
+    verify_resp.json.return_value = {
+        "audiobookProgress": {"percentage": 75.0, "positionMs": 15000, "trackIndex": 2}
+    }
+
+    booklore_client._make_request = MagicMock(side_effect=[post_resp, verify_resp])
+
+    ok = booklore_client.update_audiobook_progress(
+        book_id=6043,
+        book_file_id=10157,
+        position_ms=15000,
+        percentage=0.75,
+        track_index=2,
+        track_position_ms=15000,
+    )
+
+    assert ok is True
+    first_post = booklore_client._make_request.call_args_list[0][0]
+    assert first_post[2]["fileProgress"]["positionData"] == "15000"
+    assert first_post[2]["fileProgress"]["positionHref"] == "2"
+    assert first_post[2]["fileProgress"]["progressPercent"] == 75.0
+
+
+def test_update_audiobook_progress_requires_verified_position_for_nonzero_resume(booklore_client):
+    post_resp = MagicMock()
+    post_resp.status_code = 200
+
+    verify_resp = MagicMock()
+    verify_resp.status_code = 200
+    verify_resp.json.return_value = {
+        "audiobookProgress": {"percentage": 50.0, "positionMs": None}
+    }
+
+    booklore_client._make_request = MagicMock(side_effect=[post_resp, verify_resp])
+
+    ok = booklore_client.update_audiobook_progress(
+        book_id=6043,
+        book_file_id=None,
+        position_ms=12345,
+        percentage=0.5,
+    )
+
+    assert ok is False
+    assert booklore_client._make_request.call_count == 2
+
+
+def test_update_audiobook_progress_prefers_file_progress_and_only_falls_back_on_http_failure(booklore_client):
+    file_progress_failure = MagicMock()
+    file_progress_failure.status_code = 500
+    file_progress_failure.text = "write failed"
+
+    fallback_post = MagicMock()
+    fallback_post.status_code = 200
+
+    verify_resp = MagicMock()
+    verify_resp.status_code = 200
+    verify_resp.json.return_value = {
+        "audiobookProgress": {"percentage": 60.0, "positionMs": 1000, "trackIndex": 1}
+    }
+
+    booklore_client._make_request = MagicMock(
+        side_effect=[file_progress_failure, fallback_post, verify_resp]
+    )
+
+    ok = booklore_client.update_audiobook_progress(
+        book_id=6043,
+        book_file_id=10157,
+        position_ms=1000,
+        percentage=0.6,
+        track_index=1,
+        track_position_ms=1000,
+    )
+
+    assert ok is True
+    assert booklore_client._make_request.call_count == 3
+    first_post = booklore_client._make_request.call_args_list[0][0]
+    second_post = booklore_client._make_request.call_args_list[1][0]
+    assert "fileProgress" in first_post[2]
+    assert "audiobookProgress" not in first_post[2]
+    assert "audiobookProgress" in second_post[2]
+    assert second_post[2]["audiobookProgress"]["positionMs"] == 1000
+    assert second_post[2]["audiobookProgress"]["trackIndex"] == 1
+
+
+def test_get_audiobook_info_uses_plural_endpoint(booklore_client):
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"bookFileId": 10157}
+    booklore_client._make_request = MagicMock(return_value=response)
+
+    info = booklore_client.get_audiobook_info(6043)
+
+    assert info == {"bookFileId": 10157}
+    booklore_client._make_request.assert_called_once_with("GET", "/api/v1/audiobooks/6043/info")
+
+
+def test_get_audiobook_cover_bytes_uses_plural_endpoint(booklore_client):
+    response = MagicMock()
+    response.status_code = 200
+    response.content = b"cover"
+    response.headers = {"Content-Type": "image/jpeg"}
+    booklore_client._make_request = MagicMock(return_value=response)
+
+    content, content_type = booklore_client.get_audiobook_cover_bytes(6043)
+
+    assert content == b"cover"
+    assert content_type == "image/jpeg"
+    booklore_client._make_request.assert_called_once_with("GET", "/api/v1/audiobooks/6043/cover")
+
+
 def test_add_to_shelf_404_evicts_stale_hydrated_entry(booklore_client):
     booklore_client._process_book_detail(make_detail("gone", title="Gone Book", filename="gone.epub"))
     booklore_client.db.delete_booklore_book.reset_mock()

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -951,6 +951,42 @@ def test_search_audiobooks_force_refreshes_legacy_cached_detail_missing_audio_sh
     assert results[0]["id"] == 6798
 
 
+def test_search_audiobooks_can_skip_per_book_info_fetch(booklore_client):
+    combined_detail = {
+        "id": 6798,
+        "libraryId": "lib-1",
+        "metadata": {
+            "title": "The Mars Anomaly",
+            "authors": ["Joshua T. Calvert"],
+            "audiobookMetadata": {"durationSeconds": 33945},
+        },
+        "primaryFile": {
+            "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).epub",
+            "filePath": "/books/The Mars Anomaly - Joshua T. Calvert (2024).epub",
+            "bookType": "EPUB",
+            "id": 7605,
+        },
+        "alternativeFormats": [
+            {
+                "id": 10157,
+                "bookType": "AUDIOBOOK",
+                "fileName": "The Mars Anomaly - Joshua T. Calvert (2024).m4b",
+            }
+        ],
+        "supplementaryFiles": [],
+    }
+    booklore_client._process_book_detail(combined_detail)
+    booklore_client._cache_timestamp = time.time()
+    booklore_client.get_audiobook_info = MagicMock(return_value={"bookFileId": 10157})
+
+    results = booklore_client.search_audiobooks("", include_info=False)
+
+    assert len(results) == 1
+    assert results[0]["id"] == 6798
+    assert "audiobookInfo" not in results[0]
+    booklore_client.get_audiobook_info.assert_not_called()
+
+
 def test_search_books_dedupes_stale_filename_aliases_by_book_id(booklore_client):
     stale = {
         "id": 6798,

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -194,6 +194,40 @@ def test_save_to_db_on_fetch(mock_db):
              assert saved_book.filename == "newbook.epub"
 
 
+def test_get_fresh_token_retries_duplicate_refresh_token_conflict(booklore_client):
+    conflict_response = MagicMock()
+    conflict_response.status_code = 400
+    conflict_response.text = (
+        "Duplicate entry 'abc' for key 'uq_refresh_token'"
+    )
+
+    success_response = MagicMock()
+    success_response.status_code = 200
+    success_response.json.return_value = {"accessToken": "token-123"}
+
+    booklore_client.session.post = MagicMock(
+        side_effect=[conflict_response, success_response]
+    )
+
+    with patch("time.sleep") as mock_sleep:
+        token = booklore_client._get_fresh_token()
+
+    assert token == "token-123"
+    assert booklore_client.session.post.call_count == 2
+    mock_sleep.assert_called_once_with(booklore_client._token_login_retry_delay)
+
+
+def test_get_fresh_token_skips_login_when_cached_token_is_fresh(booklore_client):
+    booklore_client._token = "cached-token"
+    booklore_client._token_timestamp = time.time()
+    booklore_client.session.post = MagicMock()
+
+    token = booklore_client._get_fresh_token()
+
+    assert token == "cached-token"
+    booklore_client.session.post.assert_not_called()
+
+
 def test_update_progress_zero_clears_cfi(booklore_client):
     booklore_client.find_book_by_filename = MagicMock(return_value={
         "id": 6043,

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -987,6 +987,43 @@ def test_search_audiobooks_can_skip_per_book_info_fetch(booklore_client):
     booklore_client.get_audiobook_info.assert_not_called()
 
 
+def test_search_audiobooks_miss_forces_single_refresh_and_returns_new_match(booklore_client):
+    new_audio = {
+        "id": 7101,
+        "title": "New Audio Arrival",
+        "authors": "Test Author",
+        "fileName": "New Audio Arrival.m4b",
+        "bookType": "AUDIOBOOK",
+    }
+    booklore_client._cache_timestamp = time.time()
+    booklore_client.search_books = MagicMock(side_effect=[[], [new_audio]])
+    booklore_client._is_refresh_on_cooldown = MagicMock(return_value=False)
+    booklore_client._refresh_book_cache = MagicMock(return_value=True)
+    booklore_client.get_audiobook_info = MagicMock(return_value=None)
+
+    results = booklore_client.search_audiobooks("New Audio Arrival")
+
+    assert len(results) == 1
+    assert results[0]["id"] == 7101
+    booklore_client._refresh_book_cache.assert_called_once_with(refresh_stale_details=False)
+    assert booklore_client.search_books.call_count == 2
+
+
+def test_search_audiobooks_miss_refresh_is_throttled(booklore_client):
+    booklore_client._cache_timestamp = time.time()
+    booklore_client.search_books = MagicMock(return_value=[])
+    booklore_client._is_refresh_on_cooldown = MagicMock(return_value=False)
+    booklore_client._refresh_book_cache = MagicMock(return_value=True)
+    booklore_client._audiobook_search_miss_refresh_cooldown = 60
+    booklore_client._last_audiobook_search_miss_refresh_attempt = time.time()
+
+    results = booklore_client.search_audiobooks("Still Missing")
+
+    assert results == []
+    booklore_client._refresh_book_cache.assert_not_called()
+    booklore_client.search_books.assert_called_once_with("Still Missing")
+
+
 def test_search_books_dedupes_stale_filename_aliases_by_book_id(booklore_client):
     stale = {
         "id": 6798,

--- a/tests/test_clear_progress.py
+++ b/tests/test_clear_progress.py
@@ -91,6 +91,12 @@ class TestClearProgressMethod(unittest.TestCase):
         self.mock_abs_client = Mock()
 
         # Configure mock clients
+        self.mock_kosync_client.get_supported_sync_types.return_value = {'audiobook', 'ebook'}
+        self.mock_kosync_client.supports_book.return_value = True
+        self.mock_storyteller_client.get_supported_sync_types.return_value = {'audiobook', 'ebook'}
+        self.mock_storyteller_client.supports_book.return_value = True
+        self.mock_abs_client.get_supported_sync_types.return_value = {'audiobook'}
+        self.mock_abs_client.supports_book.return_value = True
         self.mock_kosync_client.update_progress.return_value = SyncResult(success=True, location=0.0)
         self.mock_storyteller_client.update_progress.return_value = SyncResult(success=True, location=0.0)
         self.mock_abs_client.update_progress.return_value = SyncResult(success=True, location=0.0)

--- a/tests/test_cross_format_normalization_locator_priority.py
+++ b/tests/test_cross_format_normalization_locator_priority.py
@@ -75,6 +75,7 @@ def test_normalization_prefers_cfi_before_percent():
     normalized = manager._normalize_for_cross_format_comparison(book, config)
 
     assert normalized["BookLore"] == 777.0
+    assert config["BookLore"].current["_normalized_ts"] == 777.0
     _, kwargs = manager.alignment_service.get_time_for_text.call_args
     assert kwargs["char_offset_hint"] == 321
     manager.ebook_parser.resolve_cfi_to_index.assert_called_once()
@@ -232,6 +233,50 @@ def test_normalization_uses_cached_extract_once_per_book_per_cycle():
     manager._normalize_for_cross_format_comparison(book, config)
 
     assert manager.ebook_parser.extract_text_and_map.call_count == 1
+
+
+def test_normalization_uses_client_specific_epub_contexts():
+    manager = _manager_with_mocks()
+    manager.sync_clients = {
+        "ABS": object(),
+        "Storyteller": object(),
+        "BookLore": object(),
+    }
+    full_text = "abcdefghijklmnopqrstuvwxyz " * 100
+    manager.ebook_parser.resolve_book_path.side_effect = lambda filename: filename
+    manager.ebook_parser.extract_text_and_map.return_value = (
+        full_text,
+        [{"href": "chapter.xhtml", "start": 300, "end": 700}],
+    )
+    manager.ebook_parser.resolve_locator_id.return_value = full_text[340:460]
+    manager.ebook_parser.resolve_cfi_to_index.return_value = 420
+    manager.alignment_service.get_time_for_text.return_value = 123.0
+
+    book = SimpleNamespace(
+        abs_id="abs-ctx",
+        transcript_file="DB_MANAGED",
+        ebook_filename="storyteller_uuid.epub",
+        original_ebook_filename="original.epub",
+    )
+    config = {
+        "ABS": _state({"ts": 10.0}),
+        "Storyteller": _state({"pct": 0.2, "href": "chapter.xhtml", "frag": "x_c001-sentence001"}),
+        "BookLore": _state({"pct": 0.2, "cfi": "epubcfi(/6/10!/4:0)"}),
+    }
+
+    normalized = manager._normalize_for_cross_format_comparison(book, config)
+
+    assert normalized["Storyteller"] == 123.0
+    assert normalized["BookLore"] == 123.0
+    manager.ebook_parser.resolve_locator_id.assert_any_call(
+        "storyteller_uuid.epub",
+        "chapter.xhtml",
+        "x_c001-sentence001",
+    )
+    manager.ebook_parser.resolve_cfi_to_index.assert_called_once_with(
+        "original.epub",
+        "epubcfi(/6/10!/4:0)",
+    )
 
 
 def test_determine_leader_uses_locator_pct_when_raw_pct_is_inconsistent():

--- a/tests/test_cross_format_normalization_locator_priority.py
+++ b/tests/test_cross_format_normalization_locator_priority.py
@@ -24,14 +24,22 @@ def _state(current: dict) -> ServiceState:
     )
 
 
+class _StubClient:
+    def get_supported_sync_types(self):
+        return {'audiobook', 'ebook'}
+
+    def can_be_leader(self):
+        return True
+
+
 def _manager_with_mocks():
     manager = SyncManager.__new__(SyncManager)
     manager.ebook_parser = MagicMock()
     manager.alignment_service = MagicMock()
     manager.sync_clients = {
-        "ABS": object(),
-        "KoSync": object(),
-        "BookLore": object(),
+        "ABS": _StubClient(),
+        "KoSync": _StubClient(),
+        "BookLore": _StubClient(),
     }
     return manager
 
@@ -238,9 +246,9 @@ def test_normalization_uses_cached_extract_once_per_book_per_cycle():
 def test_normalization_uses_client_specific_epub_contexts():
     manager = _manager_with_mocks()
     manager.sync_clients = {
-        "ABS": object(),
-        "Storyteller": object(),
-        "BookLore": object(),
+        "ABS": _StubClient(),
+        "Storyteller": _StubClient(),
+        "BookLore": _StubClient(),
     }
     full_text = "abcdefghijklmnopqrstuvwxyz " * 100
     manager.ebook_parser.resolve_book_path.side_effect = lambda filename: filename

--- a/tests/test_cross_format_normalization_locator_priority.py
+++ b/tests/test_cross_format_normalization_locator_priority.py
@@ -506,13 +506,16 @@ def test_deadband_allows_switch_when_delta_exceeds_threshold():
     assert leader_pct == config["KoSync"].current["pct"]
 
 
-def test_alignment_locator_roundtrip_degrades_to_percent_only_when_unstable():
+def test_alignment_locator_roundtrip_regenerates_cfi_when_unstable():
     manager = SyncManager.__new__(SyncManager)
     manager.ebook_parser = MagicMock()
     manager.ebook_parser.locator_roundtrip_tolerance = 2
     manager.ebook_parser.resolve_xpath_to_index.return_value = 250
     manager.ebook_parser.get_sentence_level_ko_xpath.return_value = "/body/DocFragment[1]/body/p[1]/text().0"
-    manager.ebook_parser.resolve_cfi_to_index.return_value = 260
+    manager.ebook_parser.resolve_cfi_to_index.side_effect = [260, 100]
+    manager.ebook_parser.get_locator_from_char_offset.return_value = SimpleNamespace(
+        cfi="epubcfi(/6/16!/4/2:0)"
+    )
 
     locator = SimpleNamespace(
         percentage=0.5,
@@ -532,7 +535,7 @@ def test_alignment_locator_roundtrip_degrades_to_percent_only_when_unstable():
 
     assert stable.xpath is None
     assert stable.perfect_ko_xpath is None
-    assert stable.cfi is None
+    assert stable.cfi == "epubcfi(/6/16!/4/2:0)"
 
 
 def test_roundtrip_prefers_sentence_xpath_before_percent_only():

--- a/tests/test_crossformat_drift_cycles.py
+++ b/tests/test_crossformat_drift_cycles.py
@@ -26,6 +26,9 @@ class _LeaderClient:
     def can_be_leader(self):
         return True
 
+    def get_supported_sync_types(self):
+        return {'audiobook', 'ebook'}
+
 
 class _DeterministicAlignmentService:
     def __init__(self, chars_per_second: float = 4.0):

--- a/tests/test_crossformat_payload_contracts.py
+++ b/tests/test_crossformat_payload_contracts.py
@@ -127,3 +127,39 @@ def test_storyteller_update_position_call_shape_preserved():
     assert isinstance(args[2], LocatorResult)
     assert args[2].href == "chapter.xhtml"
 
+
+def test_storyteller_update_prefers_storyteller_epub_remap_when_text_available():
+    storyteller_api = MagicMock()
+    storyteller_api.update_position.return_value = True
+    ebook_parser = MagicMock()
+    ebook_parser.resolve_book_path.return_value = "/tmp/storyteller_st-uuid-9.epub"
+    ebook_parser.find_text_location.return_value = LocatorResult(
+        percentage=0.61,
+        href="OEBPS/Text/part0083.xhtml",
+        fragment="x_c079-sentence123",
+    )
+    client = StorytellerSyncClient(storyteller_api, ebook_parser)
+
+    book = SimpleNamespace(
+        abs_id="abs-9",
+        abs_title="Test",
+        ebook_filename="original.epub",
+        original_ebook_filename="original.epub",
+        storyteller_uuid="st-uuid-9",
+    )
+    locator = LocatorResult(percentage=0.61, href="orig.xhtml", fragment="orig-frag")
+    request = UpdateProgressRequest(locator_result=locator, txt="anchor text from leader")
+
+    result = client.update_progress(book, request)
+
+    assert result.success is True
+    ebook_parser.find_text_location.assert_called_once_with(
+        "storyteller_st-uuid-9.epub",
+        "anchor text from leader",
+        hint_percentage=0.61,
+    )
+    args = storyteller_api.update_position.call_args[0]
+    assert args[0] == "st-uuid-9"
+    assert args[2].href == "OEBPS/Text/part0083.xhtml"
+    assert args[2].fragment == "x_c079-sentence123"
+

--- a/tests/test_forge_service.py
+++ b/tests/test_forge_service.py
@@ -83,7 +83,8 @@ class TestForgeService(unittest.TestCase):
             
             mock_thread_cls.assert_called_with(
                 target=self.service._auto_forge_background_task,
-                args=("abs789", {"booklore_id": 1}, "Auto Book", "Auto Author", "orig.epub", "hash123"),
+                args=("abs789", {"booklore_id": 1}, "Auto Book", "Auto Author", "orig.epub", "hash123",
+                      None, None),
                 daemon=True
             )
             mock_thread_instance.start.assert_called_once()

--- a/tests/test_match_paths_regression.py
+++ b/tests/test_match_paths_regression.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 import json
+import time
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -502,6 +503,124 @@ class TestMatchPathsRegression(unittest.TestCase):
             self.assertEqual(done_payload["count"], 2)
             self.assertEqual(done_payload["stats"]["scanned_new"], 2)
 
+    @patch("src.web_server.render_template", return_value="ok")
+    def test_suggestions_page_dedupes_same_source_title_author(self, _mock_render):
+        import src.web_server as web_server
+
+        self.mock_container.mock_database_service.get_all_books.return_value = []
+
+        with self.client.session_transaction() as session_data:
+            session_data["suggestions_state_id"] = "state-dedupe"
+
+        with web_server.SUGGESTIONS_STATE_LOCK:
+            web_server.SUGGESTIONS_STATE_STORE["state-dedupe"] = {
+                "scan_results": [
+                    {
+                        "bridge_key": "ab-duplicate-1",
+                        "abs_id": "ab-duplicate-1",
+                        "audio_source": "ABS",
+                        "audio_title": "Dark Hollow",
+                        "audio_author": "Brian Keene",
+                        "matches": [{"display_name": "dark-hollow.epub", "score": 92.0}],
+                    },
+                    {
+                        "bridge_key": "ab-duplicate-2",
+                        "abs_id": "ab-duplicate-2",
+                        "audio_source": "ABS",
+                        "audio_title": "Dark Hollow",
+                        "audio_author": "Brian Keene",
+                        "matches": [{"display_name": "dark-hollow-alt.epub", "score": 89.0}],
+                    },
+                    {
+                        "bridge_key": "ab-unique-1",
+                        "abs_id": "ab-unique-1",
+                        "audio_source": "ABS",
+                        "audio_title": "Unique Title",
+                        "audio_author": "Unique Author",
+                        "matches": [{"display_name": "unique.epub", "score": 85.0}],
+                    },
+                ],
+                "scan_cache_by_abs": {
+                    "ab-duplicate-1": {"bridge_key": "ab-duplicate-1"},
+                    "ab-duplicate-2": {"bridge_key": "ab-duplicate-2"},
+                    "ab-unique-1": {"bridge_key": "ab-unique-1"},
+                },
+                "scan_cache_no_match_abs_ids": [],
+                "scan_last_stats": {},
+                "scan_has_run": True,
+                "created_at": time.time(),
+                "updated_at": time.time(),
+            }
+
+        response = self.client.get("/suggestions")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, b"ok")
+
+        rendered = _mock_render.call_args.kwargs["suggestions"]
+        rendered_keys = [(s.get("bridge_key") or s.get("abs_id")) for s in rendered]
+        self.assertEqual(rendered_keys, ["ab-duplicate-1", "ab-unique-1"])
+
+        with web_server.SUGGESTIONS_STATE_LOCK:
+            updated_state = web_server.SUGGESTIONS_STATE_STORE["state-dedupe"]
+            self.assertEqual(len(updated_state.get("scan_results", [])), 2)
+            self.assertNotIn("ab-duplicate-2", updated_state.get("scan_cache_by_abs", {}))
+
+    @patch("src.web_server.render_template", return_value="ok")
+    def test_suggestions_page_filters_active_booklore_legacy_mapping(self, _mock_render):
+        import src.web_server as web_server
+
+        active_book = Mock()
+        active_book.abs_id = "booklore_audio_8655"
+        active_book.audio_source = "BookLore"
+        active_book.audio_source_id = "8655"
+        self.mock_container.mock_database_service.get_all_books.return_value = [active_book]
+
+        with self.client.session_transaction() as session_data:
+            session_data["suggestions_state_id"] = "state-legacy"
+
+        with web_server.SUGGESTIONS_STATE_LOCK:
+            web_server.SUGGESTIONS_STATE_STORE["state-legacy"] = {
+                "scan_results": [
+                    {
+                        "bridge_key": "booklore:8655",
+                        "abs_id": "booklore:8655",
+                        "audio_source": "BookLore",
+                        "audio_source_id": "8655",
+                        "audio_title": "Legacy BookLore",
+                        "audio_author": "Test Author",
+                        "audio_cover_url": "/api/booklore/audiobook-cover/8655",
+                        "matches": [{"display_name": "legacy.epub", "score": 88.0}],
+                    }
+                ],
+                "scan_cache_by_abs": {
+                    "booklore:8655": {
+                        "bridge_key": "booklore:8655",
+                        "abs_id": "booklore:8655",
+                        "audio_source": "BookLore",
+                        "audio_source_id": "8655",
+                        "audio_title": "Legacy BookLore",
+                        "audio_author": "Test Author",
+                        "audio_cover_url": "/api/booklore/audiobook-cover/8655",
+                        "matches": [{"display_name": "legacy.epub", "score": 88.0}],
+                    }
+                },
+                "scan_cache_no_match_abs_ids": ["booklore:8655"],
+                "scan_last_stats": {},
+                "scan_has_run": True,
+                "created_at": time.time(),
+                "updated_at": time.time(),
+            }
+
+        response = self.client.get("/suggestions")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, b"ok")
+
+        with web_server.SUGGESTIONS_STATE_LOCK:
+            updated_state = web_server.SUGGESTIONS_STATE_STORE["state-legacy"]
+            self.assertEqual(updated_state.get("scan_results", []), [])
+            self.assertEqual(updated_state.get("scan_cache_by_abs", {}), {})
+            self.assertEqual(updated_state.get("scan_cache_no_match_abs_ids", []), [])
+
     @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-suggestions-1")
     def test_suggestions_queue_add_and_process(self, _mock_kosync):
         add_response = self.client.post(
@@ -527,6 +646,50 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.assertTrue(process_response.location.endswith("/"))
 
         self.mock_container.mock_database_service.save_book.assert_called_once()
+        with self.client.session_transaction() as session_data:
+            self.assertEqual(session_data.get("queue", []), [])
+
+    @patch("src.web_server._create_or_update_booklore_audio_mapping", return_value=(Mock(abs_id="booklore:42"), None, None))
+    def test_suggestions_queue_add_and_process_booklore_audio(self, _mock_booklore_mapping):
+        add_response = self.client.post(
+            "/suggestions",
+            data={
+                "action": "add_to_queue",
+                "audiobook_id": "booklore:42",
+                "audio_source": "BookLore",
+                "audio_source_id": "42",
+                "audio_title": "BookLore Regression",
+                "audio_cover_url": "/api/booklore/audiobook-cover/42",
+                "audio_duration": "5123",
+                "audio_provider_book_id": "42",
+                "audio_provider_file_id": "991",
+                "ebook_filename": "booklore-suggested.epub",
+                "ebook_display_name": "BookLore Suggested",
+                "ebook_source": "BookLore",
+                "ebook_source_id": "6798",
+            },
+        )
+        self.assertEqual(add_response.status_code, 302)
+
+        with self.client.session_transaction() as session_data:
+            queue = session_data.get("queue", [])
+            self.assertEqual(len(queue), 1)
+            self.assertEqual(queue[0]["abs_id"], "booklore:42")
+            self.assertEqual(queue[0]["audio_source"], "BookLore")
+
+        process_response = self.client.post("/suggestions", data={"action": "process_queue"})
+        self.assertEqual(process_response.status_code, 302)
+        self.assertTrue(process_response.location.endswith("/"))
+
+        _mock_booklore_mapping.assert_called_once()
+        call_kwargs = _mock_booklore_mapping.call_args.kwargs
+        self.assertEqual(call_kwargs["audio_source_id"], "42")
+        self.assertEqual(call_kwargs["audio_title"], "BookLore Regression")
+        self.assertEqual(call_kwargs["ebook_filename"], "booklore-suggested.epub")
+        self.assertEqual(call_kwargs["ebook_source"], "BookLore")
+        self.assertEqual(call_kwargs["ebook_source_id"], "6798")
+
+        self.mock_container.mock_database_service.save_book.assert_not_called()
         with self.client.session_transaction() as session_data:
             self.assertEqual(session_data.get("queue", []), [])
 

--- a/tests/test_match_paths_regression.py
+++ b/tests/test_match_paths_regression.py
@@ -186,6 +186,12 @@ class TestMatchPathsRegression(unittest.TestCase):
     @patch("src.web_server.get_kosync_id_for_ebook", return_value="1234567890abcdef1234567890abcdef")
     def test_match_route_creates_ebook_only_mapping_from_storyteller_without_audiobook(self, _mock_kosync):
         self.mock_container.mock_storyteller_client.download_book.return_value = True
+        self.mock_container.mock_storyteller_client.is_configured.return_value = True
+        self.mock_container.mock_storyteller_client.get_book_details.return_value = {
+            "title": "Story Only Title",
+            "subtitle": "Story Only Subtitle",
+            "authors": [{"name": "Story Only Author"}],
+        }
 
         response = self.client.post(
             "/match",
@@ -198,6 +204,7 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.mock_container.mock_database_service.save_book.assert_called_once()
         saved_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
         self.assertEqual(saved_book.abs_id, "ebook-1234567890abcdef")
+        self.assertEqual(saved_book.abs_title, "Story Only Title")
         self.assertEqual(saved_book.sync_mode, "ebook_only")
         self.assertEqual(saved_book.storyteller_uuid, "story-uuid-ebook-only")
         self.assertEqual(saved_book.transcript_source, "storyteller")

--- a/tests/test_match_paths_regression.py
+++ b/tests/test_match_paths_regression.py
@@ -183,6 +183,52 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.mock_container.mock_abs_client.add_to_collection.assert_called_once_with("ab-1", "Synced with KOReader")
         self.mock_container.mock_booklore_client.add_to_shelf.assert_called_once_with("book.epub", "Kobo")
 
+    @patch("src.web_server.get_kosync_id_for_ebook", return_value="1234567890abcdef1234567890abcdef")
+    def test_match_route_creates_ebook_only_mapping_from_storyteller_without_audiobook(self, _mock_kosync):
+        self.mock_container.mock_storyteller_client.download_book.return_value = True
+
+        response = self.client.post(
+            "/match",
+            data={
+                "storyteller_uuid": "story-uuid-ebook-only",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.mock_container.mock_database_service.save_book.assert_called_once()
+        saved_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(saved_book.abs_id, "ebook-1234567890abcdef")
+        self.assertEqual(saved_book.sync_mode, "ebook_only")
+        self.assertEqual(saved_book.storyteller_uuid, "story-uuid-ebook-only")
+        self.assertEqual(saved_book.transcript_source, "storyteller")
+        self.mock_container.mock_abs_client.add_to_collection.assert_not_called()
+
+    @patch("src.web_server.get_kosync_id_for_ebook", return_value="abcdef1234567890abcdef1234567890")
+    def test_match_route_ebook_only_storyteller_preserves_original_filename_for_hash(self, _mock_kosync):
+        self.mock_container.mock_storyteller_client.download_book.return_value = True
+        self.mock_container.mock_booklore_client.find_book_by_filename.return_value = None
+
+        response = self.client.post(
+            "/match",
+            data={
+                "ebook_filename": "ebook-source.epub",
+                "storyteller_uuid": "story-uuid-with-original",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.mock_container.mock_database_service.save_book.assert_called_once()
+        saved_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(saved_book.sync_mode, "ebook_only")
+        self.assertEqual(saved_book.original_ebook_filename, "ebook-source.epub")
+        self.assertEqual(saved_book.ebook_filename, "storyteller_story-uuid-with-original.epub")
+        self.assertEqual(saved_book.kosync_doc_id, "abcdef1234567890abcdef1234567890")
+
+    def test_match_route_rejects_ebook_only_without_text_source(self):
+        response = self.client.post("/match", data={})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Please select a text source", response.get_data(as_text=True))
+
     @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-match-story-real")
     def test_match_storyteller_uuid_real_ingest_persists_manifest(self, _mock_kosync):
         self._prepare_storyteller_assets("Regression Book", chapter_count=2)

--- a/tests/test_match_paths_regression.py
+++ b/tests/test_match_paths_regression.py
@@ -316,6 +316,37 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.mock_container.mock_abs_client.add_to_collection.assert_not_called()
         self.mock_container.mock_booklore_client.add_to_shelf.assert_not_called()
 
+    @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-forge-booklore")
+    def test_match_forge_booklore_uses_bridge_key_identity(self, _mock_kosync):
+        response = self.client.post(
+            "/match",
+            data={
+                "action": "forge_match",
+                "audio_source": "BookLore",
+                "audio_source_id": "42",
+                "audio_title": "BookLore Forge",
+                "ebook_filename": "source.epub",
+                "source_type": "Booklore",
+                "source_id": "42",
+                "source_path": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.location.endswith("/"))
+
+        self.mock_container.mock_database_service.save_book.assert_called_once()
+        staged_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(staged_book.abs_id, "booklore:42")
+        self.assertEqual(staged_book.audio_source, "BookLore")
+        self.assertEqual(staged_book.status, "forging")
+
+        self.mock_container.mock_forge_service.start_auto_forge_match.assert_called_once()
+        kwargs = self.mock_container.mock_forge_service.start_auto_forge_match.call_args.kwargs
+        self.assertEqual(kwargs["abs_id"], "booklore:42")
+        self.assertEqual(kwargs["audio_source"], "BookLore")
+        self.assertEqual(kwargs["audio_source_id"], "42")
+
     @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-batch-1")
     def test_batch_match_add_and_process_queue(self, _mock_kosync):
         add_response = self.client.post(
@@ -348,6 +379,120 @@ class TestMatchPathsRegression(unittest.TestCase):
 
         with self.client.session_transaction() as session_data:
             self.assertEqual(session_data.get("queue", []), [])
+
+    @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-batch-forge-1")
+    def test_batch_match_add_and_forge_queue_stages_without_storyteller(self, _mock_kosync):
+        add_response = self.client.post(
+            "/batch-match",
+            data={
+                "action": "add_to_queue",
+                "audiobook_id": "ab-1",
+                "ebook_filename": "batch-forge.epub",
+                "ebook_display_name": "Batch Forge",
+                "ebook_source": "Booklore",
+                "ebook_source_id": "42",
+                "ebook_source_path": "",
+            },
+        )
+        self.assertEqual(add_response.status_code, 302)
+
+        with self.client.session_transaction() as session_data:
+            queue = session_data.get("queue", [])
+            self.assertEqual(len(queue), 1)
+            self.assertIsNone(queue[0]["ebook_source_path"])
+
+        process_response = self.client.post(
+            "/batch-match",
+            data={"action": "forge_and_match_queue"},
+        )
+        self.assertEqual(process_response.status_code, 302)
+        self.assertTrue(process_response.location.endswith("/"))
+
+        self.mock_container.mock_database_service.save_book.assert_called_once()
+        staged_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(staged_book.abs_id, "ab-1")
+        self.assertEqual(staged_book.status, "forging")
+        self.assertEqual(staged_book.ebook_filename, "batch-forge.epub")
+
+        self.mock_container.mock_forge_service.start_auto_forge_match.assert_called_once()
+        forge_kwargs = self.mock_container.mock_forge_service.start_auto_forge_match.call_args.kwargs
+        self.assertEqual(forge_kwargs["abs_id"], "ab-1")
+        self.assertEqual(forge_kwargs["text_item"]["source"], "Booklore")
+        self.assertEqual(forge_kwargs["text_item"]["booklore_id"], "42")
+
+        self.mock_container.mock_abs_client.add_to_collection.assert_not_called()
+
+        with self.client.session_transaction() as session_data:
+            self.assertEqual(session_data.get("queue", []), [])
+
+    @patch("src.web_server.ingest_storyteller_transcripts", return_value=None)
+    @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-batch-forge-story")
+    def test_batch_match_forge_queue_storyteller_items_use_direct_match(self, _mock_kosync, _mock_ingest):
+        self.mock_container.mock_storyteller_client.download_book.return_value = True
+
+        add_response = self.client.post(
+            "/batch-match",
+            data={
+                "action": "add_to_queue",
+                "audiobook_id": "ab-1",
+                "ebook_filename": "batch-story.epub",
+                "ebook_display_name": "Batch Story",
+                "storyteller_uuid": "story-uuid-batch-forge",
+            },
+        )
+        self.assertEqual(add_response.status_code, 302)
+
+        process_response = self.client.post(
+            "/batch-match",
+            data={"action": "forge_and_match_queue"},
+        )
+        self.assertEqual(process_response.status_code, 302)
+
+        self.mock_container.mock_database_service.save_book.assert_called_once()
+        processed_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(processed_book.status, "pending")
+        self.assertEqual(processed_book.storyteller_uuid, "story-uuid-batch-forge")
+        self.mock_container.mock_forge_service.start_auto_forge_match.assert_not_called()
+
+    @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-batch-forge-booklore")
+    def test_batch_match_forge_queue_booklore_uses_bridge_key_identity(self, _mock_kosync):
+        add_response = self.client.post(
+            "/batch-match",
+            data={
+                "action": "add_to_queue",
+                "audiobook_id": "",
+                "audio_source": "BookLore",
+                "audio_source_id": "42",
+                "audio_title": "BookLore Batch Forge",
+                "audio_cover_url": "/api/booklore/audiobook-cover/42",
+                "audio_duration": "5123",
+                "audio_provider_book_id": "42",
+                "audio_provider_file_id": "991",
+                "ebook_filename": "booklore-source.epub",
+                "ebook_display_name": "BookLore Source",
+                "ebook_source": "Booklore",
+                "ebook_source_id": "6798",
+            },
+        )
+        self.assertEqual(add_response.status_code, 302)
+
+        process_response = self.client.post(
+            "/batch-match",
+            data={"action": "forge_and_match_queue"},
+        )
+        self.assertEqual(process_response.status_code, 302)
+
+        self.mock_container.mock_database_service.save_book.assert_called_once()
+        staged_book = self.mock_container.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(staged_book.abs_id, "booklore:42")
+        self.assertEqual(staged_book.audio_source, "BookLore")
+        self.assertEqual(staged_book.status, "forging")
+
+        self.mock_container.mock_forge_service.start_auto_forge_match.assert_called_once()
+        kwargs = self.mock_container.mock_forge_service.start_auto_forge_match.call_args.kwargs
+        self.assertEqual(kwargs["abs_id"], "booklore:42")
+        self.assertEqual(kwargs["audio_source"], "BookLore")
+        self.assertEqual(kwargs["audio_source_id"], "42")
 
     @patch("src.web_server.ingest_storyteller_transcripts", return_value=None)
     @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-batch-story-1")

--- a/tests/test_storyteller_transcript.py
+++ b/tests/test_storyteller_transcript.py
@@ -219,6 +219,47 @@ def test_storyteller_ingest_removes_stale_canonical_files(tmp_path, monkeypatch)
     assert not (target_dir / "00000-00003.json").exists()
 
 
+def test_storyteller_ingest_chapterless_mode_builds_manifest_from_transcripts(tmp_path, monkeypatch):
+    assets_root = tmp_path / "storyteller_assets"
+    data_dir = tmp_path / "data"
+    transcriptions_dir = assets_root / "assets" / "Book Three" / "transcriptions"
+    transcriptions_dir.mkdir(parents=True, exist_ok=True)
+
+    chapter_one = {
+        "transcript": "chapter one text",
+        "wordTimeline": [
+            {"startTime": 0.0, "endTime": 4.0},
+            {"startTime": 4.0, "endTime": 5.0},
+        ],
+    }
+    chapter_two = {
+        "transcript": "chapter two text",
+        "wordTimeline": [
+            {"startTime": 0.0, "endTime": 2.0},
+            {"startTime": 2.0, "endTime": 3.0},
+        ],
+    }
+    (transcriptions_dir / "00001-00001.json").write_text(json.dumps(chapter_one), encoding="utf-8")
+    (transcriptions_dir / "00002-00001.json").write_text(json.dumps(chapter_two), encoding="utf-8")
+
+    monkeypatch.setenv("STORYTELLER_ASSETS_DIR", str(assets_root))
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+
+    manifest_path = ingest_storyteller_transcripts("ebook-hash-1", "Book Three", [])
+    assert manifest_path is not None
+
+    manifest_payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    assert manifest_payload["chapter_count"] == 2
+    assert manifest_payload["duration"] == 8.0
+    assert [c["file"] for c in manifest_payload["chapters"]] == ["00000-00001.json", "00000-00002.json"]
+    assert manifest_payload["chapters"][0]["start"] == 0.0
+    assert manifest_payload["chapters"][0]["end"] == 5.0
+    assert manifest_payload["chapters"][1]["start"] == 5.0
+    assert manifest_payload["chapters"][1]["end"] == 8.0
+    assert manifest_payload["chapters"][0]["text_len"] > 0
+    assert manifest_payload["chapters"][1]["text_len_utf16"] > 0
+
+
 def test_transcriber_format_dispatch(tmp_path):
     transcriber = AudioTranscriber(tmp_path, MagicMock(), MagicMock())
 

--- a/tests/test_syncmanager_ebook_only_background.py
+++ b/tests/test_syncmanager_ebook_only_background.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from src.db.models import Book
+from src.sync_manager import SyncManager
+
+
+def test_ebook_only_background_skips_transcript_pipeline_and_activates(tmp_path):
+    manager = SyncManager.__new__(SyncManager)
+    manager.abs_client = MagicMock()
+    manager.booklore_client = MagicMock()
+    manager.hardcover_client = MagicMock()
+    manager.transcriber = MagicMock()
+    manager.ebook_parser = MagicMock()
+    manager.database_service = MagicMock()
+    manager.storyteller_client = MagicMock()
+    manager.alignment_service = MagicMock()
+    manager.library_service = None
+    manager.migration_service = None
+    manager.data_dir = tmp_path
+    manager.books_dir = tmp_path
+    manager.epub_cache_dir = tmp_path / "epub_cache"
+
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_text("dummy", encoding="utf-8")
+
+    manager._get_local_epub = MagicMock(return_value=epub_path)
+    manager.ebook_parser.extract_text_and_map.return_value = ("hello world", [])
+    manager.database_service.update_latest_job = MagicMock()
+
+    job = SimpleNamespace(retry_count=2, last_error="prev", progress=0.4)
+    manager.database_service.get_latest_job.return_value = job
+
+    book = Book(
+        abs_id="ebook-abc123",
+        abs_title="Ebook Only",
+        ebook_filename="book.epub",
+        kosync_doc_id="hash-1",
+        sync_mode="ebook_only",
+        status="processing",
+    )
+
+    manager._run_background_job(book, 1, 1)
+
+    manager.abs_client.get_item_details.assert_not_called()
+    manager.transcriber.transcribe_from_smil.assert_not_called()
+    manager.transcriber.process_audio.assert_not_called()
+    manager.abs_client.get_audio_files.assert_not_called()
+    manager.alignment_service.align_and_store.assert_not_called()
+
+    assert book.status == "active"
+    manager.database_service.save_book.assert_called()
+    manager.database_service.save_job.assert_called()
+    assert job.progress == 1.0
+    assert job.last_error is None
+    assert job.retry_count == 0
+

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -607,6 +607,32 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         self.assertIsNotNone(saved_book.transcript_file)
         self.assertTrue(Path(saved_book.transcript_file).exists())
 
+    @patch('src.web_server.ingest_storyteller_transcripts', return_value='/tmp/storyteller-manifest.json')
+    @patch('src.web_server.get_kosync_id_for_ebook', return_value='hash-ebook-only-link-1')
+    def test_api_storyteller_link_ebook_only_skips_abs_chapter_lookup(self, _mock_kosync, _mock_ingest):
+        from src.db.models import Book
+
+        test_book = Book(
+            abs_id='ebook-link-1',
+            abs_title='Ebook Link',
+            ebook_filename='ebook-link.epub',
+            kosync_doc_id='hash-existing',
+            sync_mode='ebook_only',
+            status='active',
+        )
+        self.mock_database_service.get_book.return_value = test_book
+        self.mock_storyteller_client.download_book.return_value = True
+
+        response = self.client.post('/api/storyteller/link/ebook-link-1', json={'uuid': 'uuid-ebook-only'})
+
+        self.assertEqual(response.status_code, 200)
+        self.mock_abs_client.get_item_details.assert_not_called()
+        self.mock_database_service.save_book.assert_called_once()
+        saved_book = self.mock_database_service.save_book.call_args[0][0]
+        self.assertEqual(saved_book.sync_mode, 'ebook_only')
+        self.assertEqual(saved_book.storyteller_uuid, 'uuid-ebook-only')
+        self.assertEqual(saved_book.transcript_source, 'storyteller')
+
     def test_clear_progress_endpoint_clean_di(self):
         """Test clear progress endpoint with clean dependency injection."""
         # Setup mock book

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -698,6 +698,20 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         finally:
             src.web_server.render_template = original_render
 
+    def test_shelfmark_redirects_to_configured_external_url(self):
+        with patch.dict(os.environ, {'SHELFMARK_URL': 'shelfmark.blackcatmedia.xyz'}, clear=False):
+            response = self.client.get('/shelfmark')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers['Location'], 'http://shelfmark.blackcatmedia.xyz')
+
+    def test_shelfmark_redirects_to_index_when_not_configured(self):
+        with patch.dict(os.environ, {'SHELFMARK_URL': ''}, clear=False):
+            response = self.client.get('/shelfmark')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.headers['Location'].endswith('/'))
+
     def test_api_health_endpoint(self):
         response = self.client.get('/api/health')
 

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -633,6 +633,103 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         self.assertEqual(saved_book.storyteller_uuid, 'uuid-ebook-only')
         self.assertEqual(saved_book.transcript_source, 'storyteller')
 
+    def test_index_endpoint_ebook_only_uses_cached_ebook_metadata_for_display(self):
+        from src.db.models import Book, BookloreBook
+
+        test_book = Book(
+            abs_id='ebook-only-1',
+            abs_title='book-file',
+            ebook_filename='book-file.epub',
+            sync_mode='ebook_only',
+            status='active'
+        )
+        cached_book = BookloreBook(
+            filename='book-file.epub',
+            title='Displayed Title',
+            authors='Displayed Author',
+            raw_metadata=json.dumps({
+                'title': 'Displayed Title',
+                'subtitle': 'Displayed Subtitle',
+                'authors': 'Displayed Author'
+            })
+        )
+
+        self.mock_database_service.get_all_books.return_value = [test_book]
+        self.mock_database_service.get_all_states.return_value = []
+        self.mock_database_service.get_all_hardcover_details.return_value = []
+        self.mock_database_service.get_all_pending_suggestions.return_value = []
+        self.mock_database_service.get_booklore_book.side_effect = lambda filename: cached_book if filename == 'book-file.epub' else None
+        self.mock_booklore_client.is_configured.return_value = False
+
+        clients_dict = {
+            'ABS': Mock(is_configured=Mock(return_value=True)),
+            'KoSync': Mock(is_configured=Mock(return_value=True)),
+            'Storyteller': Mock(is_configured=Mock(return_value=False))
+        }
+        self.mock_container.mock_sync_clients.items.return_value = clients_dict.items()
+
+        import src.web_server
+        original_render = src.web_server.render_template
+        mock_render = Mock(return_value="Mocked HTML Response")
+        src.web_server.render_template = mock_render
+
+        try:
+            response = self.client.get('/')
+            self.assertEqual(response.status_code, 200)
+            mapping = mock_render.call_args.kwargs['mappings'][0]
+            self.assertEqual(mapping['abs_title'], 'Displayed Title')
+            self.assertEqual(mapping['abs_subtitle'], 'Displayed Subtitle')
+            self.assertEqual(mapping['abs_author'], 'Displayed Author')
+        finally:
+            src.web_server.render_template = original_render
+
+    def test_index_endpoint_storyteller_uses_storyteller_metadata_for_display(self):
+        from src.db.models import Book
+
+        test_book = Book(
+            abs_id='ebook-storyteller-1',
+            abs_title='storyteller_uuid-book',
+            ebook_filename='storyteller_uuid-book.epub',
+            storyteller_uuid='uuid-story-1',
+            sync_mode='ebook_only',
+            status='active'
+        )
+
+        self.mock_database_service.get_all_books.return_value = [test_book]
+        self.mock_database_service.get_all_states.return_value = []
+        self.mock_database_service.get_all_hardcover_details.return_value = []
+        self.mock_database_service.get_all_pending_suggestions.return_value = []
+        self.mock_database_service.get_booklore_book.return_value = None
+        self.mock_booklore_client.is_configured.return_value = False
+        self.mock_storyteller_client.is_configured.return_value = True
+        self.mock_storyteller_client.get_book_details.return_value = {
+            'title': 'Storyteller Title',
+            'subtitle': 'Storyteller Subtitle',
+            'authors': [{'name': 'Storyteller Author'}]
+        }
+
+        clients_dict = {
+            'ABS': Mock(is_configured=Mock(return_value=True)),
+            'KoSync': Mock(is_configured=Mock(return_value=True)),
+            'Storyteller': Mock(is_configured=Mock(return_value=True))
+        }
+        self.mock_container.mock_sync_clients.items.return_value = clients_dict.items()
+
+        import src.web_server
+        original_render = src.web_server.render_template
+        mock_render = Mock(return_value="Mocked HTML Response")
+        src.web_server.render_template = mock_render
+
+        try:
+            response = self.client.get('/')
+            self.assertEqual(response.status_code, 200)
+            mapping = mock_render.call_args.kwargs['mappings'][0]
+            self.assertEqual(mapping['abs_title'], 'Storyteller Title')
+            self.assertEqual(mapping['abs_subtitle'], 'Storyteller Subtitle')
+            self.assertEqual(mapping['abs_author'], 'Storyteller Author')
+        finally:
+            src.web_server.render_template = original_render
+
     def test_clear_progress_endpoint_clean_di(self):
         """Test clear progress endpoint with clean dependency injection."""
         # Setup mock book


### PR DESCRIPTION
Added


    Added support for using Booklore audiobooks as the audio side of a sync, including matching, batch processing, suggestions, Forge, and dashboard tracking.
    Added more flexible linking flows, including ebook-only links, Storyteller-only links, and a one-click Refresh Booklore Cache action in Settings.

Changed

    Suggestions scans now run in the background with progress updates, cached repeat scans, and a Full Refresh option for rescanning the whole unmatched library.
    Match, Batch Match, Suggestions, and the dashboard now show clearer source badges and audio-source details so it is easier to tell where each book came from.
    Storyteller transcript import is more forgiving of real-world file layouts and continues to prefer Storyteller timing data before falling back to SMIL or Whisper.

Fixed

    Fixed cases where small cross-format differences could cause progress bounce-backs or an incorrect reset when switching between audiobook and ebook apps.
    Fixed ebook-only links getting stuck in processing by skipping audiobook preparation work they do not need.
    Fixed edge cases where Storyteller-only links or stale Booklore data could break matching, hashing, or syncing until the book was refreshed.
