### PR TITLE
Fix trilink ebook-led sync routing for ebook passthrough and audio alignment

### DIFF
--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -167,6 +167,26 @@ class ABSSyncClient(SyncClient):
 
     def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
         book_title = book.abs_title or 'Unknown Book'
+
+        if request.seek_timestamp is not None:
+            target_ts = max(float(request.seek_timestamp), 0.0)
+            response = self.abs_client.get_progress(book.abs_id)
+            abs_ts = response.get('currentTime') if response is not None else None
+            if abs_ts is not None and target_ts < abs_ts:
+                logger.info(f"🔄 '{book_title}' Not updating ABS progress — target timestamp {target_ts:.2f}s is before current ABS position {abs_ts:.2f}s")
+                return SyncResult(abs_ts, True, {
+                    'ts': abs_ts,
+                    'pct': self._abs_to_percentage(abs_ts, book) or 0
+                })
+
+            result, final_ts = self._update_abs_progress_with_offset(book.abs_id, target_ts, abs_ts if abs_ts is not None else 0.0)
+            pct = self._abs_to_percentage(final_ts, book)
+            updated_state = {
+                'ts': final_ts,
+                'pct': pct or 0
+            }
+            return SyncResult(final_ts, result.get("success", False), updated_state)
+
         if request.locator_result.percentage == 0.0:
             logger.info(f"🔄 '{book_title}' Locator percentage is 0.0% — Setting ABS progress to start of book")
             result, final_ts = self._update_abs_progress_with_offset(book.abs_id, 0.0)

--- a/src/sync_clients/booklore_audio_sync_client.py
+++ b/src/sync_clients/booklore_audio_sync_client.py
@@ -260,7 +260,9 @@ class BookLoreAudioSyncClient(SyncClient):
             return SyncResult(None, False)
 
         target_ts = None
-        if request.locator_result.percentage == 0.0:
+        if request.seek_timestamp is not None:
+            target_ts = max(float(request.seek_timestamp), 0.0)
+        elif request.locator_result.percentage == 0.0:
             target_ts = 0.0
         elif book.transcript_file == "DB_MANAGED" and self.alignment_service and request.txt:
             target_ts = self.alignment_service.get_time_for_text(

--- a/src/sync_clients/sync_client_interface.py
+++ b/src/sync_clients/sync_client_interface.py
@@ -34,6 +34,8 @@ class UpdateProgressRequest:
     txt: Optional[str] = None
     # can be percentage or timestamp (ABS)
     previous_location: Optional[float] = None
+    # optional direct audio seek target (seconds)
+    seek_timestamp: Optional[float] = None
 
 @dataclass
 class SyncResult:

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -233,6 +233,43 @@ class SyncManager:
         except Exception:
             return None, None
 
+    def _resolve_locator_char_offset(self, book: Book, locator: LocatorResult, epub_filename: str | None):
+        """Resolve the best available global character offset for a locator."""
+        if not locator:
+            return None, None
+
+        if locator.match_index is not None:
+            try:
+                return int(locator.match_index), "match_index"
+            except (TypeError, ValueError):
+                pass
+
+        target_epub = epub_filename or self._get_non_story_ebook_filename(book) or getattr(book, "ebook_filename", None)
+        if not target_epub:
+            return None, None
+
+        if locator.perfect_ko_xpath:
+            idx = self.ebook_parser.resolve_xpath_to_index(target_epub, locator.perfect_ko_xpath)
+            if idx is not None:
+                return int(idx), "perfect_ko_xpath"
+
+        if locator.xpath:
+            idx = self.ebook_parser.resolve_xpath_to_index(target_epub, locator.xpath)
+            if idx is not None:
+                return int(idx), "xpath"
+
+        if locator.cfi:
+            idx = self.ebook_parser.resolve_cfi_to_index(target_epub, locator.cfi)
+            if idx is not None:
+                return int(idx), "cfi"
+
+        if locator.href:
+            idx, reason = self._resolve_href_to_char_offset(target_epub, locator.href, locator.chapter_progress)
+            if idx is not None:
+                return int(idx), reason or "href"
+
+        return None, None
+
     def _validate_and_stabilize_locator(
         self,
         book: Book,
@@ -1936,28 +1973,46 @@ class SyncManager:
                             )
 
                 if not locator:
-                    if not epub:
-                        logger.warning(
-                            f"⚠️ '{abs_id}' '{title_snip}' Missing locator target EPUB; cannot derive cross-client locator"
+                    if leader != primary_audio_client:
+                        current = leader_state.current or {}
+                        locator = LocatorResult(
+                            percentage=leader_pct,
+                            xpath=current.get('xpath'),
+                            cfi=current.get('cfi'),
+                            href=current.get('href'),
+                            fragment=current.get('frag') or current.get('fragment'),
+                            chapter_progress=current.get('chapter_progress'),
                         )
-                        continue
-                    txt = leader_client.get_text_from_current_state(book, leader_state)
-                    if not txt:
-                        logger.warning(f"⚠️ '{abs_id}' '{title_snip}' Could not get text from leader '{leader}'")
-                        continue
+                        if locator.perfect_ko_xpath is None and leader == 'KoSync':
+                            locator.perfect_ko_xpath = current.get('xpath')
+                        match_index, source = self._resolve_locator_char_offset(book, locator, epub)
+                        if match_index is not None:
+                            locator.match_index = match_index
+                        locator_source = f"ebook_leader_passthrough:{source or 'state_fields'}"
+                        txt = None
+                    else:
+                        if not epub:
+                            logger.warning(
+                                f"⚠️ '{abs_id}' '{title_snip}' Missing locator target EPUB; cannot derive cross-client locator"
+                            )
+                            continue
+                        txt = leader_client.get_text_from_current_state(book, leader_state)
+                        if not txt:
+                            logger.warning(f"⚠️ '{abs_id}' '{title_snip}' Could not get text from leader '{leader}'")
+                            continue
 
-                    locator = leader_client.get_locator_from_text(txt, epub, leader_pct)
-                    if locator:
-                        locator_source = "fuzzy_text"
-                    if not locator:
-                        if getattr(self.ebook_parser, 'useXpathSegmentFallback', False):
-                            fallback_txt = leader_client.get_fallback_text(book, leader_state)
-                            if fallback_txt and fallback_txt != txt:
-                                logger.info(f"🔄 '{abs_id}' '{title_snip}' Primary text match failed. Trying previous segment fallback...")
-                                locator = leader_client.get_locator_from_text(fallback_txt, epub, leader_pct)
-                                if locator:
-                                    logger.info(f"✅ '{abs_id}' '{title_snip}' Fallback successful!")
-                                    locator_source = "fuzzy_text_previous_segment"
+                        locator = leader_client.get_locator_from_text(txt, epub, leader_pct)
+                        if locator:
+                            locator_source = "fuzzy_text"
+                        if not locator:
+                            if getattr(self.ebook_parser, 'useXpathSegmentFallback', False):
+                                fallback_txt = leader_client.get_fallback_text(book, leader_state)
+                                if fallback_txt and fallback_txt != txt:
+                                    logger.info(f"🔄 '{abs_id}' '{title_snip}' Primary text match failed. Trying previous segment fallback...")
+                                    locator = leader_client.get_locator_from_text(fallback_txt, epub, leader_pct)
+                                    if locator:
+                                        logger.info(f"✅ '{abs_id}' '{title_snip}' Fallback successful!")
+                                        locator_source = "fuzzy_text_previous_segment"
 
                 if not locator:
                     logger.warning(f"⚠️ '{abs_id}' '{title_snip}' Could not resolve locator from text for leader '{leader}', falling back to percentage of leader")
@@ -1974,12 +2029,49 @@ class SyncManager:
 
                 # Update all other clients and store results
                 results: dict[str, SyncResult] = {}
+                leader_is_audio = leader == primary_audio_client
                 for client_name, client in active_clients.items():
                     if client_name == leader:
                         continue
 
                     try:
-                        request = UpdateProgressRequest(locator, txt, previous_location=config.get(client_name).previous_pct if config.get(client_name) else None)
+                        previous_location = config.get(client_name).previous_pct if config.get(client_name) else None
+                        request = UpdateProgressRequest(locator, txt, previous_location=previous_location)
+
+                        follower_supports = client.get_supported_sync_types()
+                        follower_is_audio = client_name == primary_audio_client
+                        follower_is_ebook = 'ebook' in follower_supports and not follower_is_audio
+
+                        if (not leader_is_audio) and follower_is_ebook:
+                            logger.debug(
+                                f"'{abs_id}' '{title_snip}' Routing '{leader}' -> '{client_name}': ebook→ebook passthrough"
+                            )
+
+                        elif (not leader_is_audio) and follower_is_audio:
+                            char_offset, char_source = self._resolve_locator_char_offset(book, locator, epub)
+                            if char_offset is not None and self.alignment_service:
+                                seek_ts = self.alignment_service.get_time_for_text(
+                                    book.abs_id,
+                                    query_text=None,
+                                    char_offset_hint=char_offset,
+                                )
+                                if seek_ts is not None:
+                                    request.seek_timestamp = seek_ts
+                                    logger.debug(
+                                        f"'{abs_id}' '{title_snip}' Routing '{leader}' -> '{client_name}': "
+                                        f"ebook→audio alignment via char offset ({char_source}, idx={char_offset}, ts={seek_ts:.2f}s)"
+                                    )
+                                else:
+                                    logger.warning(
+                                        f"⚠️ '{abs_id}' '{title_snip}' Routing '{leader}' -> '{client_name}': "
+                                        f"ebook→audio fallback to percentage (timestamp lookup failed for idx={char_offset})"
+                                    )
+                            else:
+                                logger.warning(
+                                    f"⚠️ '{abs_id}' '{title_snip}' Routing '{leader}' -> '{client_name}': "
+                                    "ebook→audio fallback to percentage (char offset unavailable)"
+                                )
+
                         result = client.update_progress(book, request)
                         results[client_name] = result
                     except Exception as e:

--- a/tests/test_trilink_audio_routing.py
+++ b/tests/test_trilink_audio_routing.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from src.sync_clients.abs_sync_client import ABSSyncClient
+from src.sync_clients.booklore_audio_sync_client import BookLoreAudioSyncClient
+from src.sync_clients.sync_client_interface import LocatorResult, UpdateProgressRequest
+from src.sync_manager import SyncManager
+
+
+def test_abs_sync_client_prefers_seek_timestamp():
+    abs_client = MagicMock()
+    abs_client.get_progress.return_value = {"currentTime": 10.0}
+    abs_client.update_progress.return_value = {"success": True}
+
+    client = ABSSyncClient(abs_client=abs_client, transcriber=MagicMock(), ebook_parser=MagicMock(), alignment_service=MagicMock())
+    book = SimpleNamespace(abs_id="abs-1", abs_title="Book", duration=200.0, transcript_file="DB_MANAGED")
+    req = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.3), txt=None, seek_timestamp=50.0)
+
+    result = client.update_progress(book, req)
+
+    assert result.success is True
+    assert result.updated_state["ts"] == 50.0
+    abs_client.update_progress.assert_called_once()
+    call = abs_client.update_progress.call_args
+    assert call.args[1] == 50.0
+
+
+def test_booklore_audio_prefers_seek_timestamp_for_resume_fields():
+    bl_client = MagicMock()
+    bl_client.get_audiobook_info.return_value = {
+        "bookFileId": 123,
+        "folderBased": True,
+        "tracks": [
+            {"index": 0, "durationMs": 30000, "cumulativeStartMs": 0},
+            {"index": 1, "durationMs": 30000, "cumulativeStartMs": 30000},
+        ],
+    }
+    bl_client.update_audiobook_progress.return_value = True
+
+    client = BookLoreAudioSyncClient(bl_client, MagicMock(), alignment_service=MagicMock())
+    book = SimpleNamespace(
+        abs_id="abs-1",
+        abs_title="Book",
+        audio_source="BookLore",
+        audio_source_id="bl-1",
+        audio_duration=60.0,
+        duration=60.0,
+        transcript_file="DB_MANAGED",
+    )
+    req = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.1), seek_timestamp=40.0)
+
+    result = client.update_progress(book, req)
+
+    assert result.success is True
+    kwargs = bl_client.update_audiobook_progress.call_args.kwargs
+    assert kwargs["position_ms"] == 10000
+    assert kwargs["track_index"] == 1
+
+
+def test_sync_manager_resolve_locator_char_offset_fallbacks():
+    manager = SyncManager.__new__(SyncManager)
+    manager.ebook_parser = MagicMock()
+
+    book = SimpleNamespace(ebook_filename="book.epub", original_ebook_filename=None)
+    loc = LocatorResult(percentage=0.2, xpath="/x")
+
+    manager.ebook_parser.resolve_xpath_to_index.return_value = 123
+    offset, source = manager._resolve_locator_char_offset(book, loc, "book.epub")
+
+    assert offset == 123
+    assert source == "xpath"


### PR DESCRIPTION
### Motivation
- Prevent audio followers from converting ebook-derived percentages into timestamps (causing 1–2 page drift) by routing ebook-led updates to audio clients with a precomputed timestamp when possible.
- Avoid unnecessary text extraction and fuzzy rematching for ebook→ebook follower updates by passing leader locators through directly.
- Provide deterministic char-offset resolution for locators coming from various ebook leader types (xpath, cfi, href, match_index) so alignment lookups are accurate.

### Description
- Added an optional `seek_timestamp` field to `UpdateProgressRequest` so a precomputed audio seek target can be passed directly to audio clients (`src/sync_clients/sync_client_interface.py`).
- Updated `ABSSyncClient.update_progress` to prefer `request.seek_timestamp` when present (preserving the existing “don’t move backwards” checks and all fallbacks) and return updated ABS state accordingly (`src/sync_clients/abs_sync_client.py`).
- Updated `BookLoreAudioSyncClient.update_progress` to accept `request.seek_timestamp` and convert it to resume fields, preserving the existing DB-managed/text and percentage fallback behavior (`src/sync_clients/booklore_audio_sync_client.py`).
- Implemented `_resolve_locator_char_offset` in `SyncManager` to derive a global character offset from a `LocatorResult` with precedence: `match_index` → `perfect_ko_xpath` → `xpath` → `cfi` → `href` (+ chapter progression) (`src/sync_manager.py`).
- Changed ebook-led broadcast routing in `SyncManager` so that when a non-audio ebook client is the leader: (1) other ebook followers receive the `LocatorResult` directly (passthrough) and (2) the primary audio follower is given a `seek_timestamp` derived by calling `alignment_service.get_time_for_text(book.abs_id, query_text=None, char_offset_hint=char_offset)` when a char offset can be resolved, otherwise falling back to percentage; routing decisions are logged at debug/warning levels (`src/sync_manager.py`).
- Preserved all existing fallbacks and audio-led behavior; added debug logs for routing decisions like "ebook→ebook passthrough", "ebook→audio alignment via char offset", and fallback warnings.
- Added unit tests covering ABS direct seek usage, BookLoreAudio direct seek usage, and `_resolve_locator_char_offset` behavior (`tests/test_trilink_audio_routing.py`).

### Testing
- Ran `pytest -q tests/test_trilink_audio_routing.py tests/test_booklore_audio_sync_client.py` and all tests passed (8 passed, 1 warning).
- Ran `pytest -q tests/test_cross_format_normalization_locator_priority.py -k "normalization_prefers_xpath_offset or normalization_prefers_cfi_before_percent"` and both selected tests passed (2 passed, 1 warning).
- Existing cross-format normalization tests that exercise alignment lookup logic were left intact and continued to pass during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60e804c3c8333b532e2845ecfcb91)