### PR TITLE
Use error-align for word-level anchors, add fallback edit-distance, and introduce smart alignment refresh (API + UI)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ epubcfi
 beautifulsoup4
 rapidfuzz
 fuzzysearch
+error-align
 tqdm
 gTTs
 ffmpeg
@@ -17,4 +18,3 @@ sqlalchemy
 alembic
 python-socketio[client]
 mkdocs-material
-

--- a/src/services/alignment_service.py
+++ b/src/services/alignment_service.py
@@ -14,6 +14,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
 
+try:
+    from rapidfuzz.distance import Levenshtein
+except Exception:
+    Levenshtein = None
+
 from src.db.models import BookAlignment
 from src.utils.polisher import Polisher
 from src.utils.logging_utils import time_execution
@@ -334,6 +339,162 @@ class AlignmentService:
         result_indices.reverse()
         return [anchors[i] for i in result_indices]
 
+    def _generate_alignment_map_error_align(
+        self,
+        transcript_words: List[Dict],
+        book_words: List[Dict],
+        segments: List[Dict],
+        full_text: str,
+    ) -> Optional[List[Dict]]:
+        """
+        Build anchors via error-align word-level mapping.
+
+        Returns a list of monotonic anchors (char/ts with token indices) or None when
+        the dependency is unavailable or the output quality is too low.
+        """
+        try:
+            from error_align import error_align
+        except Exception as import_err:
+            logger.warning("error-align unavailable; using legacy n-gram alignment (%s)", import_err)
+            return None
+
+        ref_words = [w.get("word", "") for w in book_words]
+        hyp_words = [w.get("word", "") for w in transcript_words]
+        if not ref_words or not hyp_words:
+            return None
+
+        try:
+            alignments = error_align(ref=ref_words, hyp=hyp_words)
+        except Exception as align_err:
+            logger.warning("error-align failed; falling back to legacy n-gram alignment (%s)", align_err)
+            return None
+
+        anchors: List[Dict] = []
+        b_idx = 0
+        t_idx = 0
+
+        def _norm_type(entry) -> str:
+            raw = str(getattr(entry, "type", "")).lower()
+            if "." in raw:
+                raw = raw.split(".")[-1]
+            return raw
+
+        def _word_at(obj, key):
+            val = getattr(obj, key, None)
+            if isinstance(val, list) and val:
+                return str(val[0])
+            if val is None:
+                return ""
+            return str(val)
+
+        def _advance(entry_type: str):
+            nonlocal b_idx, t_idx
+            # Conservative one-step advancement by operation type; if error-align returns
+            # richer structures, sequential processing still produces dense anchors.
+            if entry_type in {"match", "equal", "substitute", "replace", "similar"}:
+                b_idx += 1
+                t_idx += 1
+            elif entry_type in {"insert", "insertion"}:
+                t_idx += 1
+            elif entry_type in {"delete", "deletion"}:
+                b_idx += 1
+            else:
+                # Unknown op type; fail-safe forward motion to avoid stalling.
+                b_idx += 1
+                t_idx += 1
+
+        for entry in alignments or []:
+            if b_idx >= len(book_words) or t_idx >= len(transcript_words):
+                break
+
+            op = _norm_type(entry)
+            if op in {"match", "equal"}:
+                anchors.append(
+                    {
+                        "char": book_words[b_idx]["char"],
+                        "ts": transcript_words[t_idx]["ts"],
+                        "t_idx": transcript_words[t_idx]["orig_index"],
+                        "b_idx": book_words[b_idx]["orig_index"],
+                    }
+                )
+            elif op in {"substitute", "replace", "similar"}:
+                ref_word = _word_at(entry, "ref") or book_words[b_idx]["word"]
+                hyp_word = _word_at(entry, "hyp") or transcript_words[t_idx]["word"]
+                # Keep minor substitutions only (apostrophe/plural/one-char drift).
+                if self._word_edit_distance(ref_word, hyp_word) <= 1:
+                    anchors.append(
+                        {
+                            "char": book_words[b_idx]["char"],
+                            "ts": transcript_words[t_idx]["ts"],
+                            "t_idx": transcript_words[t_idx]["orig_index"],
+                            "b_idx": book_words[b_idx]["orig_index"],
+                        }
+                    )
+
+            _advance(op)
+
+        if not anchors:
+            return None
+
+        anchors.sort(key=lambda x: x["char"])
+        valid = self._filter_monotonic_lis(anchors)
+        if not valid:
+            return None
+
+        # Quality gates: avoid accepting tiny/low-coverage maps.
+        # For longer books/transcripts, require a slightly denser anchor set.
+        coverage = 0.0
+        if len(full_text) > 0 and len(valid) > 1:
+            coverage = max(0.0, (valid[-1]["char"] - valid[0]["char"]) / float(len(full_text)))
+        min_anchor_count = max(5, min(20, len(transcript_words) // 300))
+        transcript_anchor_ratio = (len(valid) / float(len(transcript_words))) if transcript_words else 0.0
+        if len(valid) < min_anchor_count or coverage < 0.08 or transcript_anchor_ratio < 0.003:
+            logger.info(
+                "   ⚠️ error-align produced low-confidence anchors (%d anchors, %.1f%% coverage, %.2f%% token anchor ratio; min=%d, substitution_dist<=1)",
+                len(valid),
+                coverage * 100.0,
+                transcript_anchor_ratio * 100.0,
+                min_anchor_count,
+            )
+            return None
+
+        logger.info(
+            "   ✅ error-align anchors: %d candidates -> %d monotonic (%.1f%% coverage, %.2f%% token anchor ratio; substitution_dist<=1)",
+            len(anchors),
+            len(valid),
+            coverage * 100.0,
+            transcript_anchor_ratio * 100.0,
+        )
+        return valid
+
+    @staticmethod
+    def _word_edit_distance(left: str, right: str) -> int:
+        """Tiny fallback for substitution filtering when rapidfuzz isn't installed."""
+        if Levenshtein is not None:
+            return int(Levenshtein.distance(left, right))
+
+        a = left or ""
+        b = right or ""
+        if a == b:
+            return 0
+        # Small dynamic programming fallback; words are short so this is cheap.
+        rows = len(a) + 1
+        cols = len(b) + 1
+        dp = [[0] * cols for _ in range(rows)]
+        for i in range(rows):
+            dp[i][0] = i
+        for j in range(cols):
+            dp[0][j] = j
+        for i in range(1, rows):
+            for j in range(1, cols):
+                cost = 0 if a[i - 1] == b[j - 1] else 1
+                dp[i][j] = min(
+                    dp[i - 1][j] + 1,
+                    dp[i][j - 1] + 1,
+                    dp[i - 1][j - 1] + cost,
+                )
+        return dp[-1][-1]
+
     def _generate_alignment_map(self, segments: List[Dict], full_text: str) -> List[Dict]:
         """
         Core Anchored Alignment Algorithm (Two-Pass).
@@ -392,7 +553,15 @@ class AlignmentService:
         if not transcript_words or not book_words:
             return _build_linear_fallback_map("insufficient normalized tokens")
 
-        # --- Helper for N-Gram Logic ---
+        # 3. Prefer error-align when available; fall back to legacy n-gram anchors.
+        valid_anchors = self._generate_alignment_map_error_align(
+            transcript_words=transcript_words,
+            book_words=book_words,
+            segments=segments,
+            full_text=full_text,
+        )
+
+        # --- Helper for Legacy N-Gram Logic ---
         def _find_anchors(t_tokens, b_tokens, n_size):
             # Build N-Grams
             def build_ngrams(items, is_book=False):
@@ -424,43 +593,46 @@ class AlignmentService:
                         })
             return found
 
-        # 3. PASS 1: Global Search (N=12)
-        anchors = _find_anchors(transcript_words, book_words, n_size=12)
-        
-        # Sort by character position
-        anchors.sort(key=lambda x: x['char'])
-        
-        # Filter Monotonic (Global) — Longest Increasing Subsequence
-        valid_anchors = self._filter_monotonic_lis(anchors)
-        logger.info(f"   📊 Monotonic LIS filter: {len(anchors)} candidates -> {len(valid_anchors)} valid")
-        if len(anchors) > len(valid_anchors):
-            logger.info(f"      📊 Dropped {len(anchors) - len(valid_anchors)} non-monotonic anchors")
+        if not valid_anchors:
+            logger.info("   ℹ️ error-align unavailable/insufficient; using legacy n-gram anchors")
 
-        # 4. PASS 2: Backfill Start (N=6) "Work Backwards"
-        # If the first anchor is significantly into the book, try to recover the intro.
-        # Threshold: First anchor is > 1000 chars in AND > 30 seconds in
-        if valid_anchors and valid_anchors[0]['char'] > 1000 and valid_anchors[0]['ts'] > 30.0:
-            first = valid_anchors[0]
-            logger.info(f"   🔄 Late start detected (Char: {first['char']}, TS: {first['ts']:.1f}s) — Attempting backfill")
+            # PASS 1: Global Search (N=12)
+            anchors = _find_anchors(transcript_words, book_words, n_size=12)
 
-            # Slice the data: Everything BEFORE the first anchor
-            # We use the indices we stored during tokenization
-            t_slice = transcript_words[:first['t_idx']]
-            b_slice = book_words[:first['b_idx']]
+            # Sort by character position
+            anchors.sort(key=lambda x: x['char'])
 
-            if t_slice and b_slice:
-                # Run with reduced N-Gram (N=6)
-                # Lower N is risky globally, but safe in this small constrained window
-                early_anchors = _find_anchors(t_slice, b_slice, n_size=6)
-                
-                # Filter Early Anchors (Must be monotonic with themselves)
-                early_anchors.sort(key=lambda x: x['char'])
-                valid_early = self._filter_monotonic_lis(early_anchors)
-                
-                if valid_early:
-                    logger.info(f"   ✅ Backfill success: Recovered {len(valid_early)} early anchors.")
-                    # Prepend to main list
-                    valid_anchors = valid_early + valid_anchors
+            # Filter Monotonic (Global) — Longest Increasing Subsequence
+            valid_anchors = self._filter_monotonic_lis(anchors)
+            logger.info(f"   📊 Monotonic LIS filter: {len(anchors)} candidates -> {len(valid_anchors)} valid")
+            if len(anchors) > len(valid_anchors):
+                logger.info(f"      📊 Dropped {len(anchors) - len(valid_anchors)} non-monotonic anchors")
+
+            # PASS 2: Backfill Start (N=6) "Work Backwards"
+            # If the first anchor is significantly into the book, try to recover the intro.
+            # Threshold: First anchor is > 1000 chars in AND > 30 seconds in
+            if valid_anchors and valid_anchors[0]['char'] > 1000 and valid_anchors[0]['ts'] > 30.0:
+                first = valid_anchors[0]
+                logger.info(f"   🔄 Late start detected (Char: {first['char']}, TS: {first['ts']:.1f}s) — Attempting backfill")
+
+                # Slice the data: Everything BEFORE the first anchor
+                # We use the indices we stored during tokenization
+                t_slice = transcript_words[:first['t_idx']]
+                b_slice = book_words[:first['b_idx']]
+
+                if t_slice and b_slice:
+                    # Run with reduced N-Gram (N=6)
+                    # Lower N is risky globally, but safe in this small constrained window
+                    early_anchors = _find_anchors(t_slice, b_slice, n_size=6)
+
+                    # Filter Early Anchors (Must be monotonic with themselves)
+                    early_anchors.sort(key=lambda x: x['char'])
+                    valid_early = self._filter_monotonic_lis(early_anchors)
+
+                    if valid_early:
+                        logger.info(f"   ✅ Backfill success: Recovered {len(valid_early)} early anchors.")
+                        # Prepend to main list
+                        valid_anchors = valid_early + valid_anchors
 
 
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -4696,6 +4696,191 @@ def api_storyteller_backfill():
     return jsonify(summary), status_code
 
 
+def _run_smart_alignment_refresh(include_whisper: bool = False):
+    """
+    Re-run alignment for already matched books.
+    Priority:
+      1) Storyteller manifest alignment when available.
+      2) SMIL extraction + alignment when available from EPUB overlays.
+      3) Optional Whisper re-transcription fallback when include_whisper=True.
+    """
+    started_at = time.time()
+    summary = {
+        "success": True,
+        "scanned": 0,
+        "aligned": 0,
+        "skipped": 0,
+        "skipped_reasons": {},
+        "failed": 0,
+        "duration_seconds": 0.0,
+    }
+
+    def _skip(reason: str, abs_id: str | None = None):
+        summary["skipped"] += 1
+        summary["skipped_reasons"][reason] = int(summary["skipped_reasons"].get(reason, 0)) + 1
+        if abs_id:
+            logger.info("Smart alignment refresh skipped '%s': %s", abs_id, reason)
+
+    if not manager or not database_service:
+        return {"success": False, "error": "Sync manager not initialized", **summary}, 500
+
+    books = database_service.get_all_books() or []
+    candidates = [
+        b for b in books
+        if getattr(b, "status", None) == "active" and getattr(b, "ebook_filename", None)
+    ]
+
+    abs_client = container.abs_client() if container else None
+    ebook_parser = container.ebook_parser() if container else None
+    transcriber = getattr(manager, "transcriber", None)
+    alignment_service = getattr(manager, "alignment_service", None)
+
+    if not alignment_service or not ebook_parser:
+        return {
+            "success": False,
+            "error": "Alignment components unavailable",
+            **summary,
+        }, 500
+
+    for book in candidates:
+        summary["scanned"] += 1
+        abs_id = getattr(book, "abs_id", None)
+        if not abs_id:
+            _skip("missing_abs_id")
+            continue
+
+        try:
+            preferred_ebook = manager._get_non_story_ebook_filename(book) or manager._get_storyteller_ebook_filename(book)
+            if not preferred_ebook:
+                _skip("missing_ebook_filename", abs_id)
+                continue
+
+            epub_path = manager._get_local_epub(preferred_ebook)
+            if not epub_path:
+                _skip("epub_unavailable", abs_id)
+                continue
+
+            book_text, _ = ebook_parser.extract_text_and_map(epub_path)
+            if not book_text:
+                _skip("ebook_text_empty", abs_id)
+                continue
+
+            aligned = False
+
+            storyteller_manifest = manager._get_storyteller_manifest_path(book)
+            if storyteller_manifest:
+                try:
+                    storyteller_transcript = StorytellerTranscript(storyteller_manifest)
+                    aligned = alignment_service.align_storyteller_and_store(abs_id, storyteller_transcript, ebook_text=book_text)
+                    if aligned:
+                        book.transcript_source = "storyteller"
+                except Exception as st_err:
+                    logger.warning(f"Smart refresh storyteller alignment failed for '{abs_id}': {st_err}")
+
+            # If no storyteller map generated, attempt SMIL refresh.
+            if not aligned and transcriber and hasattr(transcriber, "transcribe_from_smil"):
+                chapters = []
+                if abs_client:
+                    item_details = abs_client.get_item_details(abs_id)
+                    chapters = item_details.get("media", {}).get("chapters", []) if item_details else []
+
+                smil_segments = transcriber.transcribe_from_smil(
+                    abs_id,
+                    Path(epub_path),
+                    chapters,
+                    full_book_text=book_text,
+                )
+                if smil_segments:
+                    aligned = alignment_service.align_and_store(abs_id, smil_segments, book_text, chapters)
+                    if aligned:
+                        book.transcript_source = "smil"
+                else:
+                    logger.info("Smart alignment refresh '%s': no acceptable SMIL transcript", abs_id)
+            elif not aligned:
+                logger.info("Smart alignment refresh '%s': transcriber missing SMIL support", abs_id)
+
+            # Optional: Whisper re-transcription for remaining books.
+            if not aligned and include_whisper:
+                try:
+                    audio_adapter = manager._get_audio_source_adapter(book)
+                    audio_source = manager._get_audio_source_name(book)
+                    audio_source_id = getattr(book, "audio_source_id", None) or abs_id
+
+                    if not audio_adapter:
+                        _skip("whisper_no_audio_adapter", abs_id)
+                        continue
+
+                    audio_files = audio_adapter.get_audio_files(audio_source_id, bridge_key=abs_id)
+                    if not audio_files:
+                        _skip("whisper_no_audio_files", abs_id)
+                        continue
+
+                    whisper_segments = transcriber.process_audio(
+                        abs_id,
+                        audio_files,
+                        full_book_text=book_text,
+                        progress_callback=None,
+                    )
+                    if whisper_segments:
+                        chapters = []
+                        if audio_adapter and hasattr(audio_adapter, "get_chapters"):
+                            try:
+                                chapters = audio_adapter.get_chapters(audio_source_id) or []
+                            except Exception:
+                                chapters = []
+                        if not chapters and abs_client and (audio_source or "ABS") == "ABS":
+                            item_details = abs_client.get_item_details(abs_id)
+                            chapters = item_details.get("media", {}).get("chapters", []) if item_details else []
+
+                        aligned = alignment_service.align_and_store(abs_id, whisper_segments, book_text, chapters)
+                        if aligned:
+                            book.transcript_source = "whisper"
+                    else:
+                        _skip("whisper_transcription_empty", abs_id)
+                        continue
+                except Exception as whisper_err:
+                    logger.warning("Smart alignment refresh whisper fallback failed for '%s': %s", abs_id, whisper_err)
+                    _skip("whisper_refresh_failed", abs_id)
+                    continue
+
+            if aligned:
+                summary["aligned"] += 1
+                book.transcript_file = "DB_MANAGED"
+                database_service.save_book(book)
+            else:
+                if include_whisper:
+                    if storyteller_manifest:
+                        _skip("storyteller_smil_whisper_not_alignable", abs_id)
+                    else:
+                        _skip("no_storyteller_manifest_smil_whisper_not_alignable", abs_id)
+                else:
+                    if storyteller_manifest:
+                        _skip("storyteller_or_smil_not_alignable", abs_id)
+                    else:
+                        _skip("no_storyteller_manifest_and_smil_unavailable", abs_id)
+
+        except Exception as e:
+            summary["failed"] += 1
+            logger.warning(f"Smart alignment refresh failed for '{abs_id}': {e}")
+
+    summary["duration_seconds"] = round(time.time() - started_at, 3)
+    logger.info(
+        "Smart alignment refresh summary: "
+        f"scanned={summary['scanned']} aligned={summary['aligned']} "
+        f"skipped={summary['skipped']} failed={summary['failed']} reasons={summary['skipped_reasons']} "
+        f"duration={summary['duration_seconds']}s"
+    )
+    return summary, 200
+
+
+def api_alignment_smart_refresh():
+    payload = request.get_json(silent=True) or {}
+    include_whisper = bool(payload.get("include_whisper", False))
+    summary, status_code = _run_smart_alignment_refresh(include_whisper=include_whisper)
+    summary["include_whisper"] = include_whisper
+    return jsonify(summary), status_code
+
+
 def proxy_cover(abs_id):
     """Proxy cover access to allow loading covers from local network ABS instances."""
     try:
@@ -5106,6 +5291,7 @@ def create_app(test_container=None):
     app.add_url_rule('/api/storyteller/search', 'api_storyteller_search', api_storyteller_search, methods=['GET'])
     app.add_url_rule('/api/storyteller/link/<abs_id>', 'api_storyteller_link', api_storyteller_link, methods=['POST'])
     app.add_url_rule('/api/storyteller/backfill', 'api_storyteller_backfill', api_storyteller_backfill, methods=['POST'])
+    app.add_url_rule('/api/alignment/smart-refresh', 'api_alignment_smart_refresh', api_alignment_smart_refresh, methods=['POST'])
 
     # Forge routes
     app.add_url_rule('/api/forge/search_audio', 'forge_search_audio', forge_search_audio, methods=['GET'])
@@ -5220,5 +5406,3 @@ if __name__ == '__main__':
         logger.info(f"🚀 Split-Port Mode Active: Sync-only server on port {sync_port}")
 
     app.run(host='0.0.0.0', port=5757, debug=False)
-
-

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1119,6 +1119,25 @@
                     </div>
 
                     <div class="form-group full-width">
+                        <label>Smart Alignment Refresh</label>
+                        <div class="cleanup-group">
+                            <button type="button" class="btn btn-primary" onclick="smartRefreshAlignments()">
+                                Smart Refresh Alignments
+                            </button>
+                            <p class="help-text flex-1 m-0">
+                                Re-runs alignment for already matched books using existing Storyteller/SMIL transcript sources.
+                                This upgrades existing libraries to newer alignment logic without forcing a full rematch.
+                            </p>
+                        </div>
+                        <div class="mt-8" style="display:flex; align-items:center; gap:8px;">
+                            <input type="checkbox" id="smart_refresh_include_whisper">
+                            <label for="smart_refresh_include_whisper" style="margin:0; font-size:0.9rem; color:rgba(255,255,255,.85); cursor:pointer;">
+                                Include Whisper re-transcription for books without Storyteller/SMIL (slow)
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="form-group full-width">
                         <label>Cache Cleanup</label>
                         <div class="cleanup-group">
                             <button type="button" class="btn btn-danger" onclick="cleanInactiveCache()">
@@ -1615,6 +1634,46 @@
             } catch (err) {
                 console.error('Error running storyteller backfill:', err);
                 alert('An error occurred while running storyteller backfill. Check console for details.');
+            }
+        }
+
+        async function smartRefreshAlignments() {
+            const includeWhisper = !!document.getElementById('smart_refresh_include_whisper')?.checked;
+            const warn = includeWhisper
+                ? "Run smart alignment refresh now?\n\nThis will reprocess matched books and INCLUDE Whisper re-transcription when Storyteller/SMIL are unavailable. This can take a long time on large libraries."
+                : "Run smart alignment refresh now?\n\nThis will reprocess currently matched books using Storyteller/SMIL when available. Whisper-only rematch work will be skipped.";
+            if (!confirm(warn)) {
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/alignment/smart-refresh', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ include_whisper: includeWhisper })
+                });
+
+                const data = await response.json();
+                if (!response.ok || data.success === false) {
+                    alert(`Smart refresh failed: ${data.error || 'Unknown error'}`);
+                    return;
+                }
+
+                alert(
+                    `Smart refresh complete.\n` +
+                    `Include Whisper: ${data.include_whisper ? 'Yes' : 'No'}\n` +
+                    `Scanned: ${data.scanned}\n` +
+                    `Aligned: ${data.aligned}\n` +
+                    `Skipped: ${data.skipped}\n` +
+                    `Skip reasons: ${JSON.stringify(data.skipped_reasons || {})}\n` +
+                    `Failed: ${data.failed}\n` +
+                    `Duration: ${data.duration_seconds}s`
+                );
+            } catch (err) {
+                console.error('Error running smart refresh:', err);
+                alert('An error occurred while running smart alignment refresh. Check console for details.');
             }
         }
 

--- a/tests/test_alignment_service.py
+++ b/tests/test_alignment_service.py
@@ -1,6 +1,9 @@
 import pytest
 import json
+import sys
+import types
 from unittest.mock import MagicMock
+from src.services import alignment_service as alignment_service_module
 from src.services.alignment_service import AlignmentService
 from src.utils.polisher import Polisher
 from src.db.models import BookAlignment
@@ -88,3 +91,96 @@ def test_get_time_for_text(service, mock_db):
     # Test Interpolation (50 chars -> 5.0s)
     ts = service.get_time_for_text("test_id", "query", char_offset_hint=50)
     assert ts == 5.0
+
+
+def test_error_align_anchors_outperform_legacy_ngram(service, monkeypatch):
+    # Build long enough corpus for legacy N=12 anchors, but inject transcript errors.
+    book_tokens = [
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+        "quebec", "romeo", "sierra", "tango",
+    ]
+    transcript_tokens = [
+        "alpha", "bravo", "charli", "delta", "echo", "foxtrot", "golf", "EXTRA",
+        "hotel", "india", "juliet", "kilo", "lima", "mike", "november", "oscar",
+        "papa", "quebec", "romeo", "sierr", "tango",
+    ]
+    full_text = " ".join(book_tokens)
+    segments = [{"start": float(i), "end": float(i + 1), "text": w} for i, w in enumerate(transcript_tokens)]
+
+    # Measure legacy path by forcing error-align path to return None.
+    legacy_map = service._generate_alignment_map_error_align
+    monkeypatch.setattr(service, "_generate_alignment_map_error_align", lambda *args, **kwargs: None)
+    legacy_result = service._generate_alignment_map(segments, full_text)
+    legacy_anchor_count = max(0, len(legacy_result) - 2)  # strip forced start/end points
+
+    # Restore method and inject a deterministic fake error_align module.
+    monkeypatch.setattr(service, "_generate_alignment_map_error_align", legacy_map)
+
+    class FakeAlignment:
+        def __init__(self, typ, ref="", hyp=""):
+            self.type = typ
+            self.ref = ref
+            self.hyp = hyp
+
+    fake_mod = types.ModuleType("error_align")
+    fake_mod.error_align = lambda ref, hyp: [
+        FakeAlignment("match", "alpha", "alpha"),
+        FakeAlignment("match", "bravo", "bravo"),
+        FakeAlignment("substitute", "charlie", "charli"),
+        FakeAlignment("match", "delta", "delta"),
+        FakeAlignment("match", "echo", "echo"),
+        FakeAlignment("match", "foxtrot", "foxtrot"),
+        FakeAlignment("match", "golf", "golf"),
+        FakeAlignment("insert", "", "extra"),
+        FakeAlignment("match", "hotel", "hotel"),
+        FakeAlignment("match", "india", "india"),
+        FakeAlignment("match", "juliet", "juliet"),
+        FakeAlignment("match", "kilo", "kilo"),
+        FakeAlignment("match", "lima", "lima"),
+        FakeAlignment("match", "mike", "mike"),
+        FakeAlignment("match", "november", "november"),
+        FakeAlignment("match", "oscar", "oscar"),
+        FakeAlignment("match", "papa", "papa"),
+        FakeAlignment("match", "quebec", "quebec"),
+        FakeAlignment("match", "romeo", "romeo"),
+        FakeAlignment("substitute", "sierra", "sierr"),
+        FakeAlignment("match", "tango", "tango"),
+    ]
+    monkeypatch.setitem(sys.modules, "error_align", fake_mod)
+
+    improved_map = service._generate_alignment_map(segments, full_text)
+    improved_anchor_count = max(0, len(improved_map) - 2)
+
+    assert improved_anchor_count > legacy_anchor_count
+
+
+def test_word_edit_distance_fallback_matches_expected(monkeypatch):
+    # Force fallback DP implementation path (no rapidfuzz).
+    monkeypatch.setattr(alignment_service_module, "Levenshtein", None)
+    assert AlignmentService._word_edit_distance("wizard", "lizard") == 1
+    assert AlignmentService._word_edit_distance("can't", "cant") == 1
+    assert AlignmentService._word_edit_distance("going", "gonna") >= 2
+
+
+def test_error_align_low_density_rejected(service, monkeypatch):
+    # Large token streams but only a handful of matches should fail density gating.
+    book_tokens = [f"token{i}" for i in range(1200)]
+    transcript_tokens = list(book_tokens)
+    full_text = " ".join(book_tokens)
+    segments = [{"start": float(i), "end": float(i + 1), "text": w} for i, w in enumerate(transcript_tokens)]
+
+    class FakeAlignment:
+        def __init__(self, typ):
+            self.type = typ
+
+    sparse = [FakeAlignment("match") for _ in range(6)] + [FakeAlignment("insert") for _ in range(1194)]
+    fake_mod = types.ModuleType("error_align")
+    fake_mod.error_align = lambda ref, hyp: sparse
+    monkeypatch.setitem(sys.modules, "error_align", fake_mod)
+
+    # Directly call new method: low token-anchor ratio should reject.
+    transcript_words = [{"word": w, "ts": float(i), "orig_index": i} for i, w in enumerate(transcript_tokens)]
+    book_words = [{"word": w, "char": i * 7, "orig_index": i} for i, w in enumerate(book_tokens)]
+    result = service._generate_alignment_map_error_align(transcript_words, book_words, segments, full_text)
+    assert result is None

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -7,6 +7,7 @@ import unittest
 import tempfile
 import os
 import json
+import types
 from pathlib import Path
 from unittest.mock import Mock, patch
 import sys
@@ -964,6 +965,53 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         self.assertTrue(data['ok'])
         self.assertIn('credentials are valid', data['message'])
         self.assertEqual(mock_get.call_count, 2)
+
+    def test_smart_refresh_can_include_whisper(self):
+        book = types.SimpleNamespace(
+            abs_id='abs-1',
+            status='active',
+            ebook_filename='book.epub',
+            transcript_source='whisper',
+            transcript_file='DB_MANAGED',
+            audio_source='ABS',
+            audio_source_id='abs-1',
+        )
+        self.mock_database_service.get_all_books.return_value = [book]
+        self.mock_database_service.save_book = Mock()
+
+        self.mock_manager._get_non_story_ebook_filename.return_value = 'book.epub'
+        self.mock_manager._get_storyteller_ebook_filename.return_value = None
+        self.mock_manager._get_local_epub.return_value = Path(self.temp_dir) / 'book.epub'
+        self.mock_manager._get_storyteller_manifest_path.return_value = None
+        self.mock_manager._get_audio_source_name.return_value = 'ABS'
+
+        adapter = Mock()
+        adapter.get_audio_files.return_value = [{'stream_url': 'http://audio.example/file.mp3'}]
+        adapter.get_chapters.return_value = []
+        self.mock_manager._get_audio_source_adapter.return_value = adapter
+
+        transcriber = Mock()
+        transcriber.transcribe_from_smil.return_value = None
+        transcriber.process_audio.return_value = [{'start': 0.0, 'end': 1.0, 'text': 'hello'}]
+        self.mock_manager.transcriber = transcriber
+
+        alignment_service = Mock()
+        alignment_service.align_and_store.return_value = True
+        alignment_service.align_storyteller_and_store.return_value = False
+        self.mock_manager.alignment_service = alignment_service
+
+        self.mock_container.mock_ebook_parser.extract_text_and_map.return_value = ('full text', [])
+        self.mock_abs_client.get_item_details.return_value = {'media': {'chapters': []}}
+
+        response = self.client.post('/api/alignment/smart-refresh', json={'include_whisper': True})
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload.get('success'))
+        self.assertTrue(payload.get('include_whisper'))
+        self.assertEqual(payload.get('aligned'), 1)
+        self.assertEqual(payload.get('skipped'), 0)
+        transcriber.process_audio.assert_called_once()
+        alignment_service.align_and_store.assert_called_once()
 
     @patch('src.web_server.requests.post')
     def test_test_connection_storyteller_uses_post_payload_not_saved_env(self, mock_post):


### PR DESCRIPTION
### Motivation
- Improve alignment robustness and accuracy by using the `error-align` library to create word-level anchors when available and fall back to the proven n-gram LIS approach when it's not. 
- Provide a safe substitution filter using `rapidfuzz.distance.Levenshtein` when installed and a tiny DP fallback when it isn't. 
- Allow operators to re-run improved alignment logic across already-matched books (optionally re-transcribing with Whisper) via a new backend routine and settings UI control.

### Description
- Added `error-align` to `requirements.txt` and made `Levenshtein` an optional import with a fallback DP implementation in `AlignmentService._word_edit_distance`.
- Implemented `AlignmentService._generate_alignment_map_error_align` to consume `error_align.error_align` output, build anchors, apply monotonic filtering, and enforce density/coverage gates before accepting results.
- Modified `_generate_alignment_map` to prefer the `error-align` anchors and fall back to the existing legacy n-gram + LIS + backfill logic when `error-align` is unavailable or low-confidence. 
- Added a new smart refresh backend routine ` _run_smart_alignment_refresh` and HTTP handler `api_alignment_smart_refresh`, plus a settings page UI button and checkbox to trigger the refresh with optional Whisper re-transcription. 
- Added safe logging and graceful degradation throughout when dependencies or components (ABS, transcriber, ebook parser) are missing.
- Updated/added tests: expanded `tests/test_alignment_service.py` with tests covering `error-align` vs legacy anchors, the fallback edit-distance behavior, and low-density rejection, and added `tests/test_webserver.py` coverage for the smart-refresh endpoint.

### Testing
- Ran unit tests with `pytest` including `tests/test_alignment_service.py` and `tests/test_webserver.py`, and the new tests executed and passed. 
- Exercised the new endpoint via the Flask test client in `tests/test_webserver.py` which confirmed the `include_whisper` flow and that `transcriber.process_audio` and `alignment_service.align_and_store` were invoked. 
- Verified fallback behavior in unit tests for the DP edit-distance implementation when `Levenshtein` is not present and for the legacy n-gram path when `error-align` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8344724048333bada63960c51b9fe)