### PR TITLE
Use Storyteller-internal title (resolved by UUID) for transcript directory lookup

### DIFF
--- a/src/api/storyteller_api.py
+++ b/src/api/storyteller_api.py
@@ -150,6 +150,32 @@ class StorytellerAPIClient:
                 return book_info
         return None
 
+    def _find_book_by_uuid(self, book_uuid: str) -> Optional[Dict]:
+        """Find a Storyteller book entry by UUID."""
+        if not book_uuid:
+            return None
+
+        response = self._make_request("GET", "/api/v2/books")
+        if not response or response.status_code != 200:
+            return None
+
+        for book in response.json():
+            candidate_uuid = book.get("uuid") or book.get("id")
+            if candidate_uuid == book_uuid:
+                return book
+
+        return None
+
+    def get_book_title_by_uuid(self, book_uuid: str) -> Optional[str]:
+        """Get Storyteller's internal title for a book by UUID."""
+        if not book_uuid:
+            return None
+
+        book = self._find_book_by_uuid(book_uuid)
+        if not book:
+            return None
+        return book.get("title")
+
     def get_position_details_payload(self, book_uuid: str) -> Optional[dict]:
         response = self._make_request("GET", f"/api/v2/books/{book_uuid}/positions")
         if response and response.status_code == 200:
@@ -485,13 +511,28 @@ class StorytellerAPIClient:
                 return True
 
         return False
-    def _has_transcript_on_disk(self, title: str) -> bool:
+    def _has_transcript_on_disk(self, title: str, storyteller_uuid: str = None) -> bool:
         """Check if a Storyteller book has transcription files in the assets directory."""
         assets_dir_raw = os.environ.get("STORYTELLER_ASSETS_DIR", "").strip()
         if not assets_dir_raw:
             return False
-        transcriptions_dir = Path(assets_dir_raw) / "assets" / title / "transcriptions"
-        return transcriptions_dir.is_dir() and any(transcriptions_dir.glob("*.json"))
+
+        lookup_title = title
+        if storyteller_uuid:
+            storyteller_title = self.get_book_title_by_uuid(storyteller_uuid)
+            if storyteller_title:
+                lookup_title = storyteller_title
+
+        transcriptions_dir = Path(assets_dir_raw) / "assets" / lookup_title / "transcriptions"
+        if transcriptions_dir.is_dir() and any(transcriptions_dir.glob("*.json")):
+            return True
+
+        if lookup_title != title:
+            fallback_dir = Path(assets_dir_raw) / "assets" / title / "transcriptions"
+            if fallback_dir.is_dir() and any(fallback_dir.glob("*.json")):
+                return True
+
+        return False
 
     def search_books(self, query: str) -> list:
         """Search for books in Storyteller."""
@@ -520,12 +561,13 @@ class StorytellerAPIClient:
                     matched = overlap >= min(len(query_set), len(searchable_tokens)) * 0.5
 
                 if matched:
+                    book_uuid = book.get('uuid') or book.get('id')
                     results.append({
-                        'uuid': book.get('uuid') or book.get('id'),
+                        'uuid': book_uuid,
                         'title': title,
                         'authors': [a.get('name') for a in book.get('authors', [])],
-                        'cover_url': f"/api/v2/books/{book.get('uuid') or book.get('id')}/cover",
-                        'has_transcript': self._has_transcript_on_disk(title),
+                        'cover_url': f"/api/v2/books/{book_uuid}/cover",
+                        'has_transcript': self._has_transcript_on_disk(title, book_uuid),
                     })
             return results
         return []

--- a/src/services/alignment_service.py
+++ b/src/services/alignment_service.py
@@ -542,7 +542,11 @@ def _storyteller_filename_for_abs_chapter(chapter_index: int, prefix: str = "000
     return f"{prefix}-{chapter_index + 1:05d}.json"
 
 
-def _resolve_storyteller_title_dir(assets_root: Path, abs_title: str) -> Optional[Path]:
+def _resolve_storyteller_title_dir(
+    assets_root: Path,
+    abs_title: str,
+    storyteller_title: str = None,
+) -> Optional[Path]:
     """
     Resolve the Storyteller title directory using exact match first,
     then normalized exact match (must be unique).
@@ -550,6 +554,21 @@ def _resolve_storyteller_title_dir(assets_root: Path, abs_title: str) -> Optiona
     assets_dir = assets_root / "assets"
     if not assets_dir.exists() or not assets_dir.is_dir():
         return None
+
+    if storyteller_title:
+        exact_storyteller_dir = assets_dir / storyteller_title
+        if exact_storyteller_dir.exists() and exact_storyteller_dir.is_dir():
+            return exact_storyteller_dir
+
+        storyteller_key = _normalize_title_key(storyteller_title)
+        if storyteller_key:
+            storyteller_candidates = [
+                child
+                for child in assets_dir.iterdir()
+                if child.is_dir() and _normalize_title_key(child.name) == storyteller_key
+            ]
+            if len(storyteller_candidates) == 1:
+                return storyteller_candidates[0]
 
     exact_dir = assets_dir / abs_title
     if exact_dir.exists() and exact_dir.is_dir():
@@ -757,7 +776,12 @@ def _read_storyteller_chapter_metrics(chapter_file_path: Path) -> tuple[int, int
     return text_len, text_len_utf16, local_duration
 
 
-def ingest_storyteller_transcripts(abs_id: str, abs_title: str, chapters: list) -> Optional[str]:
+def ingest_storyteller_transcripts(
+    abs_id: str,
+    abs_title: str,
+    chapters: list,
+    storyteller_title: str = None,
+) -> Optional[str]:
     """
     Copy Storyteller chapter JSON files into bridge-managed data storage and write a manifest.
     Returns manifest path on success.
@@ -769,7 +793,11 @@ def ingest_storyteller_transcripts(abs_id: str, abs_title: str, chapters: list) 
     chapter_list = chapters if isinstance(chapters, list) else []
 
     assets_root = Path(assets_dir_raw)
-    title_dir = _resolve_storyteller_title_dir(assets_root, abs_title or "")
+    title_dir = _resolve_storyteller_title_dir(
+        assets_root,
+        abs_title or "",
+        storyteller_title=storyteller_title,
+    )
     if not title_dir:
         logger.info(f"Storyteller transcripts not found for '{abs_id}' (title='{_sanitize_log_data(abs_title)}')")
         return None

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -1300,7 +1300,24 @@ class SyncManager:
                 storyteller_manifest = self._get_storyteller_manifest_path(book)
                 if not storyteller_manifest:
                     try:
-                        ingested_manifest = ingest_storyteller_transcripts(abs_id, abs_title, chapters)
+                        storyteller_title = None
+                        if getattr(book, "storyteller_uuid", None):
+                            try:
+                                storyteller_title = self.storyteller_client.get_book_title_by_uuid(book.storyteller_uuid)
+                            except Exception as storyteller_title_err:
+                                logger.debug(
+                                    "Unable to resolve Storyteller title for '%s' (%s): %s",
+                                    abs_id,
+                                    book.storyteller_uuid,
+                                    storyteller_title_err,
+                                )
+
+                        ingested_manifest = ingest_storyteller_transcripts(
+                            abs_id,
+                            abs_title,
+                            chapters,
+                            storyteller_title=storyteller_title,
+                        )
                         if ingested_manifest:
                             storyteller_manifest = self._get_storyteller_manifest_path(book) or Path(ingested_manifest)
                     except Exception as storyteller_ingest_err:


### PR DESCRIPTION
### Motivation
- Storyteller names asset directories using the ebook’s internal title, which can differ from the bridge `abs_title`, causing false misses and unnecessary fallbacks to SMIL/Whisper.
- When a book is linked via `storyteller_uuid`, the bridge should resolve Storyteller’s canonical title and use that for filesystem lookups to reliably find transcript assets.

### Description
- Added `StorytellerAPIClient._find_book_by_uuid()` and `get_book_title_by_uuid()` to fetch Storyteller’s internal title for a UUID and expose it to callers (`src/api/storyteller_api.py`).
- Updated `_has_transcript_on_disk()` to accept an optional `storyteller_uuid`, prefer the UUID-resolved Storyteller title for asset path checks, and fall back to the bridge `title` if needed (`src/api/storyteller_api.py`).
- Made `search_books()` include the book UUID and pass the UUID into `_has_transcript_on_disk()` so dashboard/search badges reflect actual asset availability (`src/api/storyteller_api.py`).
- Extended `_resolve_storyteller_title_dir()` to accept and prioritize a `storyteller_title` (UUID-resolved) before falling back to `abs_title`, and made `ingest_storyteller_transcripts()` accept an optional `storyteller_title` parameter for the same reason (`src/services/alignment_service.py`).
- Updated the background ingestion flow to resolve Storyteller title from `book.storyteller_uuid` using the API client and pass it into `ingest_storyteller_transcripts()` to reduce false negatives during ingestion (`src/sync_manager.py`).
- All signature changes are backward-compatible: new parameters are optional so existing callers continue to work.

### Testing
- Compiled the modified modules with `python -m py_compile src/api/storyteller_api.py src/services/alignment_service.py src/sync_manager.py` and the files compiled without syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be0647c0948333a52abf06a00fc5d3)