### PR TITLE
Always send sentence-level KoSync XPaths for progress updates

### DIFF
--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -106,28 +106,26 @@ class KoSyncSyncClient(SyncClient):
 
     def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
         pct = request.locator_result.percentage
-        locator = request.locator_result
         ko_id = book.kosync_doc_id if book else None
-        # use perfect_ko_xpath if available
-        xpath = locator.perfect_ko_xpath if locator and locator.perfect_ko_xpath else locator.xpath
-        safe_xpath = self._sanitize_kosync_xpath(xpath, pct)
 
         epub = (
             (getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None))
             if book
             else None
         )
-        if safe_xpath is None and epub and pct is not None and pct > 0:
-            regenerated_xpath = self.ebook_parser.get_sentence_level_ko_xpath(epub, pct)
-            safe_xpath = self._sanitize_kosync_xpath(regenerated_xpath, pct)
-            if safe_xpath:
-                logger.info(f"Recovered malformed KoSync XPath using sentence-level fallback for '{book.abs_title}'")
+        # Always use sentence-level XPaths for KOSync.
+        # Character-level offsets don't survive cross-engine rendering differences
+        # between our parser and KOReader's CREngine.
+        safe_xpath = None
+        if epub and pct is not None and pct > 0:
+            sentence_xpath = self.ebook_parser.get_sentence_level_ko_xpath(epub, pct)
+            safe_xpath = self._sanitize_kosync_xpath(sentence_xpath, pct)
 
         if safe_xpath is None and pct is not None and pct <= 0:
             safe_xpath = ""
 
         if safe_xpath is None and pct is not None and pct > 0:
-            logger.warning(f"Skipping KoSync update due to malformed XPath for '{book.abs_title if book else 'unknown'}'")
+            logger.warning(f"Skipping KoSync update due to unresolvable XPath for '{book.abs_title if book else 'unknown'}'")
             return SyncResult(
                 location=pct,
                 success=False,
@@ -140,4 +138,3 @@ class KoSyncSyncClient(SyncClient):
             'xpath': safe_xpath
         }
         return SyncResult(pct, success, updated_state)
-

--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -747,7 +747,13 @@ class EbookParser:
             pct = float(percentage if percentage is not None else 0.0)
             pct = max(0.0, min(1.0, pct))
             position = int((len(full_text) - 1) * pct) if len(full_text) > 1 else 0
-            return self.get_perfect_ko_xpath(filename, position)
+            xpath = self.get_perfect_ko_xpath(filename, position)
+
+            # Truncate character offsets to node start for sentence-level syncing.
+            if xpath:
+                xpath = re.sub(r'(text\(\)(?:\[\d+\])?)\.\d+$', r'\1.0', xpath)
+
+            return xpath
         except Exception as e:
             logger.error(f"Error generating sentence-level KOReader XPath: {e}")
             return None


### PR DESCRIPTION
### Motivation

- Character-level KOReader XPaths (e.g., `text().142`) produced by the bridge can be rejected by KOReader's CREngine because DOM/layout differs between parsers, causing KOReader to fall back to 0% and creating a sync loop. 
- The robust approach is to always send sentence-level XPaths that point to node starts (`.0`) so KOReader will land at the correct paragraph rather than an unrecoverable character offset.

### Description

- Changed `KoSyncSyncClient.update_progress()` to always derive a sentence-level XPath from percentage via `ebook_parser.get_sentence_level_ko_xpath()` and then sanitize it before sending, removing reliance on locator-provided character-level XPaths; clear-progress behavior (`pct <= 0` → empty xpath) is preserved. (`src/sync_clients/kosync_sync_client.py`)
- Adjusted the failure log text to indicate an "unresolvable XPath" when sentence-level sanitization cannot produce a safe xpath. (`src/sync_clients/kosync_sync_client.py`)
- Fixed `EbookParser.get_sentence_level_ko_xpath()` to actually return node-start offsets by truncating any trailing character offset (matching `text().<n>`) to `text().0` after calling `get_perfect_ko_xpath()`. (`src/utils/ebook_utils.py`)
- Left `_sanitize_kosync_xpath()` and the existing chapter-fallback logic intact so fragile-inline stripping and fallback-to-chapter-start remain unchanged.

### Testing

- Compiled the modified modules with `python -m compileall src/sync_clients/kosync_sync_client.py src/utils/ebook_utils.py`, which succeeded.
- Verified diffs and committed the changes to local repository (no additional automated unit tests were present or executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be066ba4788333893b3938b6b80485)