### PR TITLE
[Fix] Prevent Forge double-trigger in Storyteller by staging outside …

### DIFF
--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -1099,6 +1099,43 @@ class BookloreClient:
                 return self._book_id_cache.get(book_id)
         return None
 
+    def _get_cached_book_by_id(self, book_id):
+        target_id = str(book_id)
+        with self._cache_lock:
+            direct = self._book_id_cache.get(book_id)
+            if isinstance(direct, dict):
+                return direct
+
+            for cache_key, book_info in self._book_id_cache.items():
+                if not isinstance(book_info, dict):
+                    continue
+                cache_book_id = book_info.get("id")
+                if str(cache_key) == target_id or str(cache_book_id) == target_id:
+                    return book_info
+        return None
+
+    @staticmethod
+    def _has_hydrated_file_metadata(book):
+        if not isinstance(book, dict):
+            return False
+
+        if isinstance(book.get("primaryFile"), dict):
+            return True
+
+        if any(isinstance(book.get(key), list) for key in ("bookFiles", "alternativeFormats", "supplementaryFiles")):
+            return True
+
+        return bool(book.get("filePath"))
+
+    def get_book_by_id(self, book_id, allow_refresh=True):
+        """Return a hydrated BookLore book detail by ID."""
+        cached = self._get_cached_book_by_id(book_id)
+        if cached and self._has_hydrated_file_metadata(cached):
+            return cached
+        if not allow_refresh:
+            return cached
+        return self._fetch_and_cache_detail(book_id, force_refresh=True)
+
     def _normalize_string(self, s):
         """Remove non-alphanumeric characters and lowercase."""
         import re

--- a/src/api/storyteller_api.py
+++ b/src/api/storyteller_api.py
@@ -715,6 +715,9 @@ class StorytellerAPIClient:
             log_fn = logger.debug if polling else logger.warning
             log_fn(f"⚠️ API download raised exception: {e}")
 
+        if polling:
+            return False
+
         # Fallback: Local File Copy
         try:
             # 1. Get Book Details for Filepath

--- a/src/services/alignment_service.py
+++ b/src/services/alignment_service.py
@@ -532,6 +532,32 @@ def _normalize_title_key(title: str) -> str:
     return re.sub(r"\s+", " ", collapsed).strip()
 
 
+def _strip_storyteller_instance_suffix(name: str) -> str:
+    stripped = str(name or "").strip()
+    return re.sub(r"\s+\[[^\[\]]+\]\s*$", "", stripped).strip()
+
+
+def _storyteller_dir_has_transcriptions(title_dir: Path) -> bool:
+    transcriptions_dir = Path(title_dir) / "transcriptions"
+    return transcriptions_dir.is_dir() and any(transcriptions_dir.glob("*.json"))
+
+
+def _iter_storyteller_title_dir_candidates(assets_dir: Path, target_title: str) -> list[Path]:
+    target_key = _normalize_title_key(target_title)
+    if not target_key:
+        return []
+
+    candidates = []
+    for child in assets_dir.iterdir():
+        if not child.is_dir():
+            continue
+        child_key = _normalize_title_key(child.name)
+        base_key = _normalize_title_key(_strip_storyteller_instance_suffix(child.name))
+        if child.name == target_title or child_key == target_key or base_key == target_key:
+            candidates.append(child)
+    return candidates
+
+
 def _storyteller_filename_for_abs_chapter(chapter_index: int, prefix: str = "00000") -> str:
     """
     Build the bridge-managed canonical chapter filename for ABS chapter index N (0-based).
@@ -548,48 +574,64 @@ def _resolve_storyteller_title_dir(
     storyteller_title: str = None,
 ) -> Optional[Path]:
     """
-    Resolve the Storyteller title directory using exact match first,
-    then normalized exact match (must be unique).
+    Resolve the Storyteller title directory, preferring transcript-ready
+    directories and supporting Storyteller's `Title [id]` suffix pattern.
     """
     assets_dir = assets_root / "assets"
     if not assets_dir.exists() or not assets_dir.is_dir():
         return None
 
+    candidates: list[Path] = []
+    seen = set()
+    raw_titles = []
     if storyteller_title:
-        exact_storyteller_dir = assets_dir / storyteller_title
-        if exact_storyteller_dir.exists() and exact_storyteller_dir.is_dir():
-            return exact_storyteller_dir
+        raw_titles.append(storyteller_title)
+    if abs_title and abs_title not in raw_titles:
+        raw_titles.append(abs_title)
 
-        storyteller_key = _normalize_title_key(storyteller_title)
-        if storyteller_key:
-            storyteller_candidates = [
-                child
-                for child in assets_dir.iterdir()
-                if child.is_dir() and _normalize_title_key(child.name) == storyteller_key
-            ]
-            if len(storyteller_candidates) == 1:
-                return storyteller_candidates[0]
+    for target_title in raw_titles:
+        for candidate in _iter_storyteller_title_dir_candidates(assets_dir, target_title):
+            resolved = str(candidate.resolve())
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            candidates.append(candidate)
 
-    exact_dir = assets_dir / abs_title
-    if exact_dir.exists() and exact_dir.is_dir():
-        return exact_dir
-
-    target_key = _normalize_title_key(abs_title)
-    if not target_key:
+    if not candidates:
         return None
 
-    candidates = []
-    for child in assets_dir.iterdir():
-        if child.is_dir() and _normalize_title_key(child.name) == target_key:
-            candidates.append(child)
+    transcript_ready = [candidate for candidate in candidates if _storyteller_dir_has_transcriptions(candidate)]
+    if transcript_ready:
+        ignored = [candidate for candidate in candidates if candidate not in transcript_ready]
+        for candidate in ignored:
+            logger.info(
+                "Storyteller transcript resolver: ignoring stale non-transcription dir '%s'",
+                candidate,
+            )
+        candidates = transcript_ready
 
     if len(candidates) == 1:
-        return candidates[0]
+        selected = candidates[0]
+        if _strip_storyteller_instance_suffix(selected.name) != selected.name:
+            logger.info(
+                "Storyteller transcript resolver: selected suffixed assets dir '%s' for '%s'",
+                selected,
+                _sanitize_log_data(storyteller_title or abs_title),
+            )
+        return selected
+
+    for target_title in [storyteller_title, abs_title]:
+        if not target_title:
+            continue
+        exact_matches = [candidate for candidate in candidates if candidate.name == target_title]
+        if len(exact_matches) == 1:
+            return exact_matches[0]
 
     if len(candidates) > 1:
         logger.warning(
-            f"Storyteller assets match is ambiguous for '{_sanitize_log_data(abs_title)}' "
-            f"({len(candidates)} directories)"
+            "Storyteller transcript resolver: ambiguous transcript-ready matches for '%s' (%d directories)",
+            _sanitize_log_data(storyteller_title or abs_title),
+            len(candidates),
         )
     return None
 
@@ -776,6 +818,77 @@ def _read_storyteller_chapter_metrics(chapter_file_path: Path) -> tuple[int, int
     return text_len, text_len_utf16, local_duration
 
 
+def probe_storyteller_transcripts(
+    abs_title: str,
+    chapters: list,
+    storyteller_title: str = None,
+) -> dict:
+    """
+    Non-mutating readiness probe for Storyteller transcript assets.
+    """
+    result = {
+        "ready": False,
+        "reason": "unknown",
+        "transcriptions_dir": None,
+        "expected_count": 0,
+        "found_count": 0,
+        "source_files": [],
+        "expected_files": [],
+        "chapterless_mode": False,
+    }
+
+    assets_dir_raw = os.environ.get("STORYTELLER_ASSETS_DIR", "").strip()
+    if not assets_dir_raw:
+        result["ready"] = True
+        result["reason"] = "assets_not_configured"
+        return result
+
+    chapter_list = chapters if isinstance(chapters, list) else []
+    assets_root = Path(assets_dir_raw)
+    title_dir = _resolve_storyteller_title_dir(
+        assets_root,
+        abs_title or "",
+        storyteller_title=storyteller_title,
+    )
+    if not title_dir:
+        result["reason"] = "title_dir_missing"
+        return result
+
+    transcriptions_dir = title_dir / "transcriptions"
+    result["transcriptions_dir"] = transcriptions_dir
+    if not transcriptions_dir.exists() or not transcriptions_dir.is_dir():
+        result["reason"] = "transcriptions_dir_missing"
+        return result
+
+    numeric_pattern = re.compile(r"^\d{5}-\d{5}\.json$")
+    numeric_files = [p.name for p in transcriptions_dir.glob("*.json") if numeric_pattern.match(p.name)]
+    result["found_count"] = len(numeric_files)
+
+    expected_count = len(chapter_list)
+    chapterless_mode = expected_count <= 0
+    result["chapterless_mode"] = chapterless_mode
+    if chapterless_mode:
+        expected_count = len(numeric_files)
+        if expected_count <= 0:
+            result["reason"] = "chapter_set_incomplete"
+            return result
+
+    result["expected_count"] = expected_count
+
+    is_valid, source_files, expected_files = _validate_storyteller_chapters(
+        transcriptions_dir, expected_count
+    )
+    result["source_files"] = source_files
+    result["expected_files"] = expected_files
+    if not is_valid:
+        result["reason"] = "chapter_set_incomplete"
+        return result
+
+    result["ready"] = True
+    result["reason"] = "validated"
+    return result
+
+
 def ingest_storyteller_transcripts(
     abs_id: str,
     abs_title: str,
@@ -786,51 +899,41 @@ def ingest_storyteller_transcripts(
     Copy Storyteller chapter JSON files into bridge-managed data storage and write a manifest.
     Returns manifest path on success.
     """
-    assets_dir_raw = os.environ.get("STORYTELLER_ASSETS_DIR", "").strip()
-    if not assets_dir_raw:
-        return None
-
-    chapter_list = chapters if isinstance(chapters, list) else []
-
-    assets_root = Path(assets_dir_raw)
-    title_dir = _resolve_storyteller_title_dir(
-        assets_root,
-        abs_title or "",
+    probe = probe_storyteller_transcripts(
+        abs_title,
+        chapters,
         storyteller_title=storyteller_title,
     )
-    if not title_dir:
+    if probe["reason"] == "assets_not_configured":
+        return None
+    if probe["reason"] == "title_dir_missing":
         logger.info(f"Storyteller transcripts not found for '{abs_id}' (title='{_sanitize_log_data(abs_title)}')")
         return None
-
-    transcriptions_dir = title_dir / "transcriptions"
-    if not transcriptions_dir.exists() or not transcriptions_dir.is_dir():
+    if probe["reason"] == "transcriptions_dir_missing":
+        transcriptions_dir = probe["transcriptions_dir"]
         logger.info(f"Storyteller transcriptions directory missing for '{abs_id}' at '{transcriptions_dir}'")
         return None
-
-    expected_count = len(chapter_list)
-    chapterless_mode = expected_count <= 0
-    if chapterless_mode:
-        numeric_pattern = re.compile(r"^\d{5}-\d{5}\.json$")
-        numeric_files = [p.name for p in transcriptions_dir.glob("*.json") if numeric_pattern.match(p.name)]
-        expected_count = len(numeric_files)
-        if expected_count <= 0:
-            logger.info(
-                f"Storyteller ingest skipped for '{abs_id}': no ABS chapters and no storyteller chapter files at "
-                f"'{transcriptions_dir}'"
-            )
-            return None
-        logger.info(
-            f"Storyteller ingest chapterless mode for '{abs_id}': deriving {expected_count} chapters from "
-            f"'{transcriptions_dir}'"
-        )
-
-    is_valid, source_files, expected_files = _validate_storyteller_chapters(transcriptions_dir, expected_count)
-    if not is_valid:
+    if not probe["ready"]:
+        transcriptions_dir = probe["transcriptions_dir"]
+        expected_count = probe["expected_count"]
         logger.info(
             f"Storyteller transcripts rejected for '{abs_id}': expected {expected_count} chapter files at "
             f"'{transcriptions_dir}'"
         )
         return None
+
+    chapter_list = chapters if isinstance(chapters, list) else []
+    transcriptions_dir = probe["transcriptions_dir"]
+    expected_count = probe["expected_count"]
+    source_files = probe["source_files"]
+    expected_files = probe["expected_files"]
+    chapterless_mode = probe["chapterless_mode"]
+
+    if chapterless_mode:
+        logger.info(
+            f"Storyteller ingest chapterless mode for '{abs_id}': deriving {expected_count} chapters from "
+            f"'{transcriptions_dir}'"
+        )
 
     data_dir = Path(os.environ.get("DATA_DIR", "/data"))
     target_dir = data_dir / "transcripts" / "storyteller" / abs_id

--- a/src/services/forge_service.py
+++ b/src/services/forge_service.py
@@ -1,15 +1,17 @@
 import logging
 import threading
 import shutil
+import tempfile
 import time
 import os
 import html
 import re
+import uuid
 from pathlib import Path
 from urllib.parse import urljoin
 import requests
 
-from src.services.alignment_service import ingest_storyteller_transcripts
+from src.services.alignment_service import ingest_storyteller_transcripts, probe_storyteller_transcripts
 from src.utils.storyteller_transcript import StorytellerTranscript
 
 logger = logging.getLogger(__name__)
@@ -70,6 +72,181 @@ class ForgeService:
         if normalized not in VALID_STAGE_MODES:
             return DEFAULT_STAGE_MODE
         return normalized
+
+    @staticmethod
+    def _path_is_within(child: Path, parent: Path) -> bool:
+        try:
+            child.resolve().relative_to(parent.resolve())
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _existing_anchor(path: Path) -> Path:
+        current = Path(path)
+        while not current.exists() and current != current.parent:
+            current = current.parent
+        return current
+
+    @staticmethod
+    def _same_device(path_a: Path, path_b: Path) -> bool:
+        try:
+            anchor_a = ForgeService._existing_anchor(path_a)
+            anchor_b = ForgeService._existing_anchor(path_b)
+            return anchor_a.resolve().stat().st_dev == anchor_b.resolve().stat().st_dev
+        except Exception:
+            return False
+
+    def _resolve_storyteller_paths(self, safe_title: str) -> dict:
+        watch_root = Path(os.environ.get("STORYTELLER_LIBRARY_DIR", "/storyteller_library"))
+        sibling_incoming_root = watch_root.with_name(f".{watch_root.name}_incoming")
+        sibling_backup_root = watch_root.with_name(f".{watch_root.name}_replaced")
+        configured_incoming_raw = os.environ.get("STORYTELLER_STAGING_DIR", "").strip()
+        incoming_root = Path(configured_incoming_raw) if configured_incoming_raw else sibling_incoming_root
+        backup_root = sibling_backup_root
+        cross_device = False
+
+        def _choose_roots() -> tuple[Path, Path, bool]:
+            """Return (incoming_root, backup_root, cross_device)."""
+            if self._same_device(sibling_incoming_root, watch_root):
+                return sibling_incoming_root, sibling_backup_root, False
+            # Sibling dir is cross-device (common with Docker volume mounts).
+            # Never fall back to a child of watch_root — Storyteller watches it
+            # recursively and would trigger scans during staging.  Use a system
+            # temp directory instead; the reveal step will use shutil.copytree.
+            tmp_root = Path(tempfile.mkdtemp(prefix=".forge_stage_"))
+            logger.info(
+                "Forge: sibling staging root '%s' is cross-device from watched root '%s'; "
+                "using temp dir '%s'",
+                sibling_incoming_root,
+                watch_root,
+                tmp_root,
+            )
+            return tmp_root, tmp_root, True
+
+        if configured_incoming_raw:
+            invalid_location = (
+                incoming_root.resolve() == watch_root.resolve()
+                or self._path_is_within(incoming_root, watch_root)
+            )
+            if invalid_location:
+                incoming_root, backup_root, cross_device = _choose_roots()
+                logger.warning(
+                    "Forge: STORYTELLER_STAGING_DIR '%s' is inside watched root '%s'; using '%s' instead",
+                    configured_incoming_raw,
+                    watch_root,
+                    incoming_root,
+                )
+            elif not self._same_device(incoming_root, watch_root):
+                incoming_root, backup_root, cross_device = _choose_roots()
+                logger.warning(
+                    "Forge: STORYTELLER_STAGING_DIR '%s' is cross-device from '%s'; using '%s' instead",
+                    configured_incoming_raw,
+                    watch_root,
+                    incoming_root,
+                )
+        else:
+            incoming_root, backup_root, cross_device = _choose_roots()
+
+        run_suffix = uuid.uuid4().hex[:8]
+        staging_course_dir = incoming_root / f"{safe_title}.{run_suffix}"
+        final_course_dir = watch_root / safe_title
+        backup_course_dir = backup_root / f"{safe_title}.{run_suffix}"
+        return {
+            "watch_root": watch_root,
+            "incoming_root": incoming_root,
+            "backup_root": backup_root,
+            "final_course_dir": final_course_dir,
+            "staging_course_dir": staging_course_dir,
+            "backup_course_dir": backup_course_dir,
+            "cross_device": cross_device,
+        }
+
+    @staticmethod
+    def _prepare_storyteller_stage_dir(staging_course_dir: Path) -> Path:
+        staging_course_dir.mkdir(parents=True, exist_ok=True)
+        return staging_course_dir
+
+    @staticmethod
+    def _prepare_storyteller_stage_permissions(staging_course_dir: Path) -> None:
+        if hasattr(staging_course_dir, "_mock_name"):
+            return
+        for path in [staging_course_dir] + [p for p in staging_course_dir.rglob("*") if p.is_dir()]:
+            try:
+                os.chmod(str(path), 0o777)
+            except Exception:
+                pass
+
+    def _reveal_storyteller_stage_dir(
+        self,
+        staging_course_dir: Path,
+        final_course_dir: Path,
+        backup_course_dir: Path,
+        cross_device: bool = False,
+    ) -> Path:
+        staging_course_dir = Path(staging_course_dir)
+        final_course_dir = Path(final_course_dir)
+        backup_course_dir = Path(backup_course_dir)
+        final_course_dir.parent.mkdir(parents=True, exist_ok=True)
+        if not cross_device:
+            backup_course_dir.parent.mkdir(parents=True, exist_ok=True)
+
+        backup_created = False
+        if not cross_device and backup_course_dir.exists():
+            shutil.rmtree(backup_course_dir)
+
+        try:
+            if final_course_dir.exists():
+                if cross_device:
+                    logger.info(
+                        "Forge: removing existing watched folder '%s' (cross-device, no backup)",
+                        final_course_dir,
+                    )
+                    shutil.rmtree(final_course_dir)
+                else:
+                    logger.info(
+                        "Forge: replacing existing watched folder '%s' via backup '%s'",
+                        final_course_dir,
+                        backup_course_dir,
+                    )
+                    final_course_dir.rename(backup_course_dir)
+                    backup_created = True
+
+            if cross_device:
+                logger.info("Forge: revealing staged folder into watched root with copytree")
+                shutil.copytree(str(staging_course_dir), str(final_course_dir))
+                shutil.rmtree(staging_course_dir)
+            else:
+                logger.info("Forge: revealing staged folder into watched root with single rename")
+                staging_course_dir.rename(final_course_dir)
+        except Exception:
+            if backup_created and not final_course_dir.exists() and backup_course_dir.exists():
+                try:
+                    backup_course_dir.rename(final_course_dir)
+                except Exception as rollback_err:
+                    logger.error(
+                        "Forge: failed to restore backup '%s' -> '%s': %s",
+                        backup_course_dir,
+                        final_course_dir,
+                        rollback_err,
+                    )
+            raise
+
+        if backup_created and backup_course_dir.exists():
+            shutil.rmtree(backup_course_dir)
+
+        return final_course_dir
+
+    @staticmethod
+    def _cleanup_temp_staging_root(incoming_root: Path, cross_device: bool) -> None:
+        """Remove the temp directory created by mkdtemp when cross-device staging was used."""
+        if not cross_device:
+            return
+        try:
+            if incoming_root.exists():
+                shutil.rmtree(incoming_root, ignore_errors=True)
+        except Exception:
+            pass
 
     def _should_cleanup_staged_sources(self, stage_mode: str) -> bool:
         return self._normalize_stage_mode(stage_mode) == DEFAULT_STAGE_MODE
@@ -285,22 +462,26 @@ class ForgeService:
         safe_title: str,
         epub_filename: str,
         title: str,
+        chapters: list,
         course_dir: Path,
         epub_cache: Path,
         found_uuid: str,
         processing_triggered: bool,
         poll_count: int,
+        existing_probe_download_path: Path = None,
     ):
         """
         Execute one completion-poll cycle for auto-forge.
         """
         completion_method = None
         readaloud_path = None
-        probe_download_path = None
+        probe_download_path = existing_probe_download_path if existing_probe_download_path else None
         api_ready_seen = False
         details = None
         processing_ready = False
         processing_state = "not_checked"
+        transcript_probe = probe_storyteller_transcripts(title, chapters, storyteller_title=None)
+        transcripts_ready = bool(transcript_probe.get("ready"))
 
         if not found_uuid:
             recovered_uuid = self._discover_storyteller_uuid(st_client, safe_title, epub_filename, title)
@@ -312,6 +493,12 @@ class ForgeService:
             details, processing_ready, processing_state = self._get_storyteller_processing_state(
                 st_client, found_uuid
             )
+            transcript_probe = probe_storyteller_transcripts(
+                title,
+                chapters,
+                storyteller_title=details.get("title") if isinstance(details, dict) else None,
+            )
+            transcripts_ready = bool(transcript_probe.get("ready"))
 
         if found_uuid and not processing_triggered and processing_ready:
             try:
@@ -326,16 +513,16 @@ class ForgeService:
             )
 
         readaloud_path = self._find_processed_epub(course_dir)
-        if readaloud_path:
-            completion_method = "local_readaloud"
-            return {
-                "found_uuid": found_uuid,
-                "processing_triggered": processing_triggered,
-                "readaloud_path": readaloud_path,
-                "completion_method": completion_method,
-                "probe_download_path": probe_download_path,
-                "api_ready_seen": api_ready_seen,
-            }
+        if readaloud_path and poll_count % 4 == 0:
+            logger.info(
+                "Auto-Forge: Local readaloud candidate seen at %s, not yet considered complete",
+                readaloud_path,
+            )
+        if not transcripts_ready and transcript_probe.get("reason") != "assets_not_configured" and poll_count % 4 == 0:
+            logger.info(
+                "Auto-Forge: Transcript assets not ready yet (reason=%s)",
+                transcript_probe.get("reason"),
+            )
 
         if found_uuid:
             readaloud_meta = details.get("readaloud", {}) if isinstance(details, dict) else {}
@@ -345,6 +532,11 @@ class ForgeService:
                 # Track readiness for diagnostics, but do not mark completion yet.
                 api_ready_seen = True
 
+            if probe_download_path and Path(probe_download_path).exists():
+                api_ready_seen = True
+                if transcripts_ready:
+                    completion_method = "api_download"
+
             if poll_count % 4 == 0:
                 probe_path = epub_cache / f".storyteller_probe_{found_uuid}.epub"
                 try:
@@ -352,11 +544,19 @@ class ForgeService:
                         if probe_path.exists() and probe_path.stat().st_size > 0:
                             probe_download_path = probe_path
                             api_ready_seen = True
-                            completion_method = "api_download"
+                            if transcripts_ready:
+                                completion_method = "api_download"
+                            else:
+                                logger.info(
+                                    "Auto-Forge: API readaloud downloadable for %s, waiting for transcript assets",
+                                    found_uuid,
+                                )
+                    elif poll_count % 8 == 0:
+                        logger.info("Auto-Forge: API readaloud still not downloadable for %s", found_uuid)
                 except Exception as probe_err:
                     logger.debug(f"Auto-Forge: probe download not ready for {found_uuid}: {probe_err}")
                 finally:
-                    if completion_method != "api_download" and probe_path.exists():
+                    if probe_download_path != probe_path and probe_path.exists():
                         try:
                             probe_path.unlink()
                         except Exception:
@@ -369,6 +569,7 @@ class ForgeService:
             "completion_method": completion_method,
             "probe_download_path": probe_download_path,
             "api_ready_seen": api_ready_seen,
+            "transcript_probe": transcript_probe,
         }
 
     def _copy_audio_files(self, abs_id: str, dest_folder: Path, stage_mode: str = DEFAULT_STAGE_MODE):
@@ -443,8 +644,110 @@ class ForgeService:
             logger.error(f"❌ Failed to copy ABS '{abs_id}': {e}", exc_info=True)
             return False
 
-    def _copy_booklore_audio_files(self, book_id: str, dest_folder: Path) -> bool:
-        """Download audiobook tracks from Booklore into dest_folder."""
+    def _iter_booklore_audio_candidates(self, book_detail) -> list[dict]:
+        if not isinstance(book_detail, dict):
+            return []
+
+        candidates = []
+        for entry in [book_detail.get("primaryFile")]:
+            if isinstance(entry, dict):
+                candidates.append(entry)
+
+        for key in ("bookFiles", "alternativeFormats", "supplementaryFiles"):
+            entries = book_detail.get(key) or []
+            if isinstance(entries, list):
+                candidates.extend(entry for entry in entries if isinstance(entry, dict))
+
+        audio_candidates = []
+        for candidate in candidates:
+            file_name = str(candidate.get("fileName") or candidate.get("filename") or "").strip()
+            file_path = str(candidate.get("filePath") or candidate.get("filepath") or "").strip()
+            suffix = Path(file_name or file_path).suffix.lower()
+            book_type = str(candidate.get("bookType") or "").upper()
+            if book_type != "AUDIOBOOK" and suffix not in AUDIO_EXTENSIONS:
+                continue
+            audio_candidates.append(
+                {
+                    **candidate,
+                    "fileName": file_name,
+                    "filePath": file_path,
+                }
+            )
+        return audio_candidates
+
+    def _resolve_booklore_local_path(self, file_info: dict) -> Path | None:
+        if not isinstance(file_info, dict):
+            return None
+
+        raw_path = str(file_info.get("filePath") or file_info.get("filepath") or "").strip()
+        file_name = str(file_info.get("fileName") or file_info.get("filename") or "").strip()
+
+        if raw_path:
+            candidate = Path(raw_path)
+            if candidate.exists():
+                return candidate
+
+            parts = Path(raw_path).parts
+            for i in range(4, 0, -1):
+                if len(parts) < i:
+                    continue
+                suffix = Path(*parts[-i:])
+                candidate = self.ABS_AUDIO_ROOT / suffix
+                if candidate.exists():
+                    return candidate
+
+        if file_name:
+            matches = list(self.ABS_AUDIO_ROOT.glob(f"**/{Path(file_name).name}"))
+            if matches:
+                return matches[0]
+
+        return None
+
+    def _resolve_booklore_local_audio_files(self, book_id: str, info: dict) -> list[dict]:
+        book_detail = self.booklore_client.get_book_by_id(book_id)
+        candidates = self._iter_booklore_audio_candidates(book_detail)
+        resolved = []
+        seen = set()
+
+        for candidate in candidates:
+            local_path = self._resolve_booklore_local_path(candidate)
+            if not local_path:
+                continue
+
+            resolved_path = self._safe_resolve(local_path)
+            if resolved_path in seen:
+                continue
+            seen.add(resolved_path)
+
+            resolved.append(
+                {
+                    **candidate,
+                    "local_path": local_path,
+                    "resolved_name": Path(local_path).name,
+                }
+            )
+
+        return resolved
+
+    @staticmethod
+    def _track_sort_key(idx: int, track: dict):
+        raw_index = track.get("index")
+        if isinstance(raw_index, int):
+            return (raw_index, idx)
+        return (idx, idx)
+
+    def _stage_booklore_local_file(self, src_path: Path, dest_path: Path, stage_mode: str) -> str:
+        result = self._stage_local_file(src_path, dest_path, stage_mode, "BookLore audio")
+        if result == HARDLINK_STAGE_MODE:
+            logger.info("BookLore audio: staged local file via hardlink '%s' -> '%s'", src_path.name, dest_path.name)
+        elif result == "copy":
+            logger.info("BookLore audio: staged local file via copy '%s' -> '%s'", src_path.name, dest_path.name)
+        else:
+            logger.info("BookLore audio: staged local file already present '%s'", dest_path.name)
+        return result
+
+    def _copy_booklore_audio_files(self, book_id: str, dest_folder: Path, stage_mode: str = DEFAULT_STAGE_MODE) -> bool:
+        """Stage audiobook tracks from BookLore into dest_folder."""
         def infer_ext(track: dict, info: dict) -> str:
             allowed = {"mp3", "m4a", "m4b", "flac", "ogg", "opus", "aac", "wav"}
             raw_ext = str(track.get("extension") or track.get("ext") or "").lower().strip().lstrip(".")
@@ -465,6 +768,7 @@ class ForgeService:
             return "mp3"
 
         try:
+            normalized_stage_mode = self._normalize_stage_mode(stage_mode)
             info = self.booklore_client.get_audiobook_info(book_id)
             if not info:
                 logger.warning(f"No audiobook info found for Booklore book '{book_id}'")
@@ -499,6 +803,90 @@ class ForgeService:
             )
 
             dest_folder.mkdir(parents=True, exist_ok=True)
+            local_files = self._resolve_booklore_local_audio_files(book_id, info)
+            book_detail = self.booklore_client.get_book_by_id(book_id, allow_refresh=False)
+            local_candidate_count = len(self._iter_booklore_audio_candidates(book_detail))
+
+            if local_files:
+                should_use_single_stream_local = (
+                    track_mode == "chapter_markers_single_stream"
+                    or local_candidate_count == 1
+                    or (len(local_files) == 1 and len(tracks) <= 1)
+                )
+                if should_use_single_stream_local:
+                    local_file = local_files[0]
+                    local_path = Path(local_file["local_path"])
+                    ext = local_path.suffix.lstrip(".").lower() or infer_ext({}, info)
+                    dest_path = dest_folder / f"track_000.{ext}"
+                    logger.info("BookLore audio: using single-stream local file '%s'", local_path.name)
+                    self._stage_booklore_local_file(local_path, dest_path, normalized_stage_mode)
+                    return True
+
+                track_names_present = all(
+                    str(track.get("fileName") or track.get("filename") or "").strip()
+                    for track in tracks
+                )
+                if track_names_present:
+                    by_name = {}
+                    by_name_lower = {}
+                    for local_file in local_files:
+                        for name in {
+                            str(local_file.get("fileName") or "").strip(),
+                            str(local_file.get("resolved_name") or "").strip(),
+                        }:
+                            if not name:
+                                continue
+                            by_name.setdefault(name, local_file)
+                            by_name_lower.setdefault(name.lower(), local_file)
+
+                    matched_files = []
+                    used_paths = set()
+                    ordered_tracks = sorted(enumerate(tracks), key=lambda item: self._track_sort_key(item[0], item[1]))
+                    for _, track in ordered_tracks:
+                        track_name = str(track.get("fileName") or track.get("filename") or "").strip()
+                        local_file = by_name.get(track_name) or by_name_lower.get(track_name.lower())
+                        local_path = Path(local_file["local_path"]) if local_file else None
+                        resolved_key = self._safe_resolve(local_path) if local_path else None
+                        if not local_file or resolved_key in used_paths:
+                            matched_files = []
+                            break
+                        used_paths.add(resolved_key)
+                        matched_files.append((track, local_file))
+
+                    if matched_files and len(matched_files) == len(tracks):
+                        logger.info("BookLore audio: using filename-based local track mapping")
+                        for idx, (track, local_file) in enumerate(matched_files):
+                            local_path = Path(local_file["local_path"])
+                            ext = local_path.suffix.lstrip(".").lower() or infer_ext(track, info)
+                            dest_path = dest_folder / f"track_{idx:03d}.{ext}"
+                            self._stage_booklore_local_file(local_path, dest_path, normalized_stage_mode)
+                        return True
+
+                if len(local_files) == len(tracks):
+                    logger.info("BookLore audio: using positional track mapping")
+                    ordered_tracks = [track for _, track in sorted(
+                        enumerate(tracks), key=lambda item: self._track_sort_key(item[0], item[1])
+                    )]
+                    ordered_local_files = sorted(
+                        local_files,
+                        key=lambda item: str(
+                            item.get("fileName") or item.get("resolved_name") or ""
+                        ).lower(),
+                    )
+                    for idx, (track, local_file) in enumerate(zip(ordered_tracks, ordered_local_files)):
+                        local_path = Path(local_file["local_path"])
+                        ext = local_path.suffix.lstrip(".").lower() or infer_ext(track, info)
+                        dest_path = dest_folder / f"track_{idx:03d}.{ext}"
+                        self._stage_booklore_local_file(local_path, dest_path, normalized_stage_mode)
+                    return True
+
+                logger.info(
+                    "BookLore audio: local resolution incomplete, falling back to download "
+                    "(resolved=%s expected=%s)",
+                    len(local_files),
+                    len(tracks),
+                )
+
             downloaded = 0
 
             for idx, track in enumerate(tracks):
@@ -546,14 +934,79 @@ class ForgeService:
             logger.error(f"Failed to copy Booklore audio for book '{book_id}': {e}", exc_info=True)
             return False
 
-    def start_manual_forge(self, abs_id, text_item, title, author, stage_mode: str = DEFAULT_STAGE_MODE):
+    @staticmethod
+    def _collect_audio_files(root_dir: Path) -> list[Path]:
+        root_dir = Path(root_dir)
+        if not root_dir.exists():
+            return []
+        audio_files = []
+        for candidate in sorted(root_dir.rglob("*")):
+            if candidate.is_file() and candidate.suffix.lower() in AUDIO_EXTENSIONS:
+                audio_files.append(candidate)
+        return audio_files
+
+    @staticmethod
+    def _build_local_audio_inputs(audio_files: list[Path]) -> list[dict]:
+        return [
+            {
+                "local_path": str(path),
+                "ext": path.suffix.lstrip("."),
+            }
+            for path in audio_files
+        ]
+
+    def _get_whisper_audio_inputs(
+        self,
+        course_dir: Path,
+        abs_id: str,
+        audio_source: str | None,
+        audio_source_id: str | None,
+    ) -> list[dict]:
+        staged_audio = self._collect_audio_files(course_dir)
+        if staged_audio:
+            logger.info("Auto-Forge: Whisper fallback using staged source audio")
+            return self._build_local_audio_inputs(staged_audio)
+
+        if audio_source == "BookLore" and audio_source_id:
+            cache_root = self.ebook_parser.epub_cache_dir / "whisper_source_audio" / str(audio_source_id)
+            cache_root.mkdir(parents=True, exist_ok=True)
+            cached_audio = self._collect_audio_files(cache_root)
+            if not cached_audio:
+                if not self._copy_booklore_audio_files(audio_source_id, cache_root, stage_mode=DEFAULT_STAGE_MODE):
+                    return []
+                cached_audio = self._collect_audio_files(cache_root)
+            if cached_audio:
+                logger.info("Auto-Forge: Whisper fallback using BookLore audio source")
+                return self._build_local_audio_inputs(cached_audio)
+            return []
+
+        logger.info("Auto-Forge: Whisper fallback using ABS audio source")
+        return self.abs_client.get_audio_files(abs_id) or []
+
+    def start_manual_forge(
+        self,
+        abs_id,
+        text_item,
+        title,
+        author,
+        audio_source: str = None,
+        audio_source_id: str = None,
+        stage_mode: str = DEFAULT_STAGE_MODE,
+    ):
         """
         Start manual forge process in background thread.
         """
         normalized_stage_mode = self._normalize_stage_mode(stage_mode)
         thread_kwargs = {}
+        thread_options = {}
+        if audio_source:
+            thread_options["audio_source"] = audio_source
+        if audio_source_id:
+            thread_options["audio_source_id"] = audio_source_id
         if normalized_stage_mode != DEFAULT_STAGE_MODE:
-            thread_kwargs["kwargs"] = {"stage_mode": normalized_stage_mode}
+            thread_options["stage_mode"] = normalized_stage_mode
+        if thread_options:
+            thread_kwargs["kwargs"] = thread_options
         thread = threading.Thread(
             target=self._forge_background_task,
             args=(abs_id, text_item, title, author),
@@ -562,7 +1015,16 @@ class ForgeService:
         )
         thread.start()
 
-    def _forge_background_task(self, abs_id, text_item, title, author, stage_mode: str = DEFAULT_STAGE_MODE):
+    def _forge_background_task(
+        self,
+        abs_id,
+        text_item,
+        title,
+        author,
+        audio_source: str = None,
+        audio_source_id: str = None,
+        stage_mode: str = DEFAULT_STAGE_MODE,
+    ):
         """
         Background thread: copy files to Storyteller library, trigger processing, cleanup.
         """
@@ -576,33 +1038,31 @@ class ForgeService:
         try:
             safe_author = self.safe_folder_name(author) if author else "Unknown"
             safe_title = self.safe_folder_name(title) if title else "Unknown"
-            
-            st_lib_path = Path(os.environ.get("STORYTELLER_LIBRARY_DIR", "/storyteller_library"))
-            dest_base = Path(os.environ.get("PROCESSING_DIR", "/tmp"))
-
-            final_course_dir = st_lib_path / safe_title
-            hidden_staging_dir = st_lib_path / f".staging_{safe_title}"
-            processing_dir = dest_base / f"forge_staging_{safe_title}"
-
-            if final_course_dir.exists():
-                logger.warning(f"⚠️ Target directory '{final_course_dir}' already exists. Using it directly")
-                course_dir = final_course_dir
-            else:
-                course_dir = processing_dir
-                course_dir.mkdir(parents=True, exist_ok=True)
+            storyteller_paths = self._resolve_storyteller_paths(safe_title)
+            final_course_dir = storyteller_paths["final_course_dir"]
+            staging_course_dir = storyteller_paths["staging_course_dir"]
+            backup_course_dir = storyteller_paths["backup_course_dir"]
+            cross_device = storyteller_paths["cross_device"]
+            course_dir = self._prepare_storyteller_stage_dir(staging_course_dir)
 
             audio_dest = course_dir
-            
-            logger.info(f"⚡ Forge: Staging files for '{title}' in '{course_dir}' (Atomic)")
+
+            logger.info("Forge: staging in %s dir '%s'",
+                        "temp (cross-device)" if cross_device else "sibling",
+                        course_dir)
 
             # Step 1: Copy audio files
-            audio_ok = self._copy_audio_files(abs_id, audio_dest, stage_mode=stage_mode)
+            if audio_source == "BookLore" and audio_source_id:
+                audio_ok = self._copy_booklore_audio_files(audio_source_id, audio_dest, stage_mode=stage_mode)
+            else:
+                audio_ok = self._copy_audio_files(abs_id, audio_dest, stage_mode=stage_mode)
             if not audio_ok:
                 logger.error(f"❌ Forge: Failed to copy audio files for '{abs_id}'")
                 try:
-                    if course_dir.exists() and course_dir != final_course_dir: 
-                        shutil.rmtree(course_dir) 
+                    if course_dir.exists():
+                        shutil.rmtree(course_dir)
                 except: pass
+                self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
                 return
             logger.info(f"⚡ Forge: Audio files copied for '{title}'")
 
@@ -669,47 +1129,32 @@ class ForgeService:
             if not text_success:
                 logger.error(f"❌ Forge: Text acquisition failed — Aborting")
                 try:
-                    if course_dir.exists() and course_dir != final_course_dir:
+                    if course_dir.exists():
                         shutil.rmtree(course_dir)
                 except: pass
+                self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
                 return
 
-            # TWO-STEP ATOMIC TRANSFER
-            if course_dir != final_course_dir:
+            try:
+                logger.info("Forge: preparing Storyteller directory permissions before reveal")
+                self._prepare_storyteller_stage_permissions(course_dir)
+                course_dir = self._reveal_storyteller_stage_dir(
+                    staging_course_dir=course_dir,
+                    final_course_dir=final_course_dir,
+                    backup_course_dir=backup_course_dir,
+                    cross_device=cross_device,
+                )
+            except Exception as e:
+                logger.error(f"❌ Forge: Atomic transfer failed: {e}")
                 try:
-                    logger.info(f"⚡ Forge: Transferring to Storyteller volume as hidden folder...")
-                    if hidden_staging_dir.exists():
-                        shutil.rmtree(hidden_staging_dir)
-                    if final_course_dir.exists():
-                        shutil.rmtree(final_course_dir)
+                    if course_dir.exists():
+                        shutil.rmtree(course_dir)
+                except Exception:
+                    pass
+                self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
+                raise Exception(f"Atomic move failed: {e}")
 
-                    # Step 1: Cross-device move to hidden folder inside Storyteller library
-                    shutil.move(str(course_dir), str(hidden_staging_dir))
-                                        # Fix permissions for Storyteller (node uid 1000)
-                    try:
-                        if not hasattr(hidden_staging_dir, '_mock_name'):
-                            for chmod_root, chmod_dirs, chmod_files in os.walk(str(hidden_staging_dir)):
-                                for d in chmod_dirs: 
-                                    try: os.chmod(os.path.join(chmod_root, d), 0o777)
-                                    except: pass
-                                for f in chmod_files: 
-                                    try: os.chmod(os.path.join(chmod_root, f), 0o666)
-                                    except: pass
-                            try: os.chmod(str(hidden_staging_dir), 0o777)
-                            except: pass
-                    except Exception as chmod_err:
-                        pass
-                    logger.info(f"⚡ Forge: Atomically revealing folder to Storyteller scanner...")
-                    hidden_staging_dir.rename(final_course_dir)
-                    course_dir = final_course_dir
-                except Exception as e:
-                    logger.error(f"❌ Forge: Atomic transfer failed: {e}")
-                    try: shutil.rmtree(course_dir)
-                    except: pass
-                    try: shutil.rmtree(hidden_staging_dir)
-                    except: pass
-                    raise Exception(f"Atomic move failed: {e}")
-
+            self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
             logger.info(f"⚡ Forge: Files staged. Waiting for Storyteller to detect '{title}'...")
 
             # Trigger Storyteller Processing via API
@@ -817,8 +1262,10 @@ class ForgeService:
                         completed_epub_path = processed_epub
                         try:
                             logger.info(f"⚡ Forge: Extracting SMIL transcript from {completed_epub_path.name}...")
-                            item_details = self.abs_client.get_item_details(abs_id)
-                            chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
+                            chapters = []
+                            if audio_source != "BookLore":
+                                item_details = self.abs_client.get_item_details(abs_id)
+                                chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
                             book_text, _ = self.ebook_parser.extract_text_and_map(completed_epub_path)
                             raw_transcript = self.transcriber.transcribe_from_smil(
                                 abs_id, completed_epub_path, chapters, full_book_text=book_text
@@ -905,6 +1352,8 @@ class ForgeService:
         epub_dest = None
         cleanup_requested = False
         cleanup_preserve_paths = []
+        storyteller_paths = None
+        cross_device = False
 
         try:
             original_ebook_filename = self._extract_original_filename(text_item, original_filename)
@@ -912,23 +1361,19 @@ class ForgeService:
             # --- STAGING & TRIGGER ---
             safe_author = self.safe_folder_name(author) if author else "Unknown"
             safe_title = self.safe_folder_name(title) if title else "Unknown"
-            st_lib_path = Path(os.environ.get("STORYTELLER_LIBRARY_DIR", "/storyteller_library"))
-            dest_base = Path(os.environ.get("PROCESSING_DIR", "/tmp"))
+            storyteller_paths = self._resolve_storyteller_paths(safe_title)
+            final_course_dir = storyteller_paths["final_course_dir"]
+            staging_course_dir = storyteller_paths["staging_course_dir"]
+            backup_course_dir = storyteller_paths["backup_course_dir"]
+            cross_device = storyteller_paths["cross_device"]
+            course_dir = self._prepare_storyteller_stage_dir(staging_course_dir)
+            logger.info("Forge: staging in %s dir '%s'",
+                        "temp (cross-device)" if cross_device else "sibling",
+                        course_dir)
 
-            final_course_dir = st_lib_path / safe_title
-            hidden_staging_dir = st_lib_path / f".staging_{safe_title}"
-            processing_dir = dest_base / f"forge_staging_{safe_title}"
-
-            if final_course_dir.exists():
-                logger.warning(f"⚠️ Target directory '{final_course_dir}' already exists. Using it directly")
-                course_dir = final_course_dir
-            else:
-                course_dir = processing_dir
-                course_dir.mkdir(parents=True, exist_ok=True)
-            
             # Copy Audio
             if audio_source == 'BookLore' and audio_source_id:
-                if not self._copy_booklore_audio_files(audio_source_id, course_dir):
+                if not self._copy_booklore_audio_files(audio_source_id, course_dir, stage_mode=stage_mode):
                     raise Exception("Failed to copy Booklore audio files")
             else:
                 if not self._copy_audio_files(abs_id, course_dir, stage_mode=stage_mode):
@@ -964,48 +1409,40 @@ class ForgeService:
             if not epub_dest.exists():
                 raise Exception("Failed to acquire text source")
 
-            # TWO-STEP ATOMIC TRANSFER
-            if course_dir != final_course_dir:
+            try:
+                logger.info("Forge: preparing Storyteller directory permissions before reveal")
+                self._prepare_storyteller_stage_permissions(course_dir)
+                course_dir = self._reveal_storyteller_stage_dir(
+                    staging_course_dir=course_dir,
+                    final_course_dir=final_course_dir,
+                    backup_course_dir=backup_course_dir,
+                    cross_device=cross_device,
+                )
+            except Exception as e:
+                logger.error(f"❌ Forge: Atomic transfer failed: {e}")
                 try:
-                    logger.info(f"⚡ Forge: Transferring to Storyteller volume as hidden folder...")
-                    if hidden_staging_dir.exists():
-                        shutil.rmtree(hidden_staging_dir)
-                    if final_course_dir.exists():
-                        shutil.rmtree(final_course_dir)
+                    if course_dir.exists():
+                        shutil.rmtree(course_dir)
+                except Exception:
+                    pass
+                self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
+                raise Exception(f"Atomic move failed: {e}")
 
-                    # Step 1: Cross-device move to hidden folder inside Storyteller library
-                    shutil.move(str(course_dir), str(hidden_staging_dir))
-                                        # Fix permissions for Storyteller (node uid 1000)
-                    try:
-                        if not hasattr(hidden_staging_dir, '_mock_name'):
-                            for chmod_root, chmod_dirs, chmod_files in os.walk(str(hidden_staging_dir)):
-                                for d in chmod_dirs: 
-                                    try: os.chmod(os.path.join(chmod_root, d), 0o777)
-                                    except: pass
-                                for f in chmod_files: 
-                                    try: os.chmod(os.path.join(chmod_root, f), 0o666)
-                                    except: pass
-                            try: os.chmod(str(hidden_staging_dir), 0o777)
-                            except: pass
-                    except Exception as chmod_err:
-                        pass
-                    logger.info(f"⚡ Forge: Atomically revealing folder to Storyteller scanner...")
-                    hidden_staging_dir.rename(final_course_dir)
-                    course_dir = final_course_dir
-                except Exception as e:
-                    logger.error(f"❌ Forge: Atomic transfer failed: {e}")
-                    try: shutil.rmtree(course_dir)
-                    except: pass
-                    try: shutil.rmtree(hidden_staging_dir)
-                    except: pass
-                    raise Exception(f"Atomic move failed: {e}")
-
+            self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
             logger.info("⚡ Auto-Forge: Files staged. Waiting for Storyteller detection...")
 
             # Trigger Storyteller
             st_client = self.storyteller_client
             found_uuid = None
             epub_filename = f"{safe_title}.epub"
+            item_details = None
+            chapters = []
+            try:
+                item_details = self.abs_client.get_item_details(abs_id)
+            except Exception as item_err:
+                logger.debug(f"Auto-Forge: failed to fetch item details for chapters ({abs_id}): {item_err}")
+            if item_details:
+                chapters = item_details.get("media", {}).get("chapters", []) or []
 
             processing_triggered = False
             ready = False
@@ -1065,6 +1502,7 @@ class ForgeService:
             completion_method = None
             api_ready_seen = False
             probe_download_path = None
+            transcript_probe = probe_storyteller_transcripts(title, chapters)
 
             epub_cache = self.ebook_parser.epub_cache_dir
             if not epub_cache.exists():
@@ -1080,17 +1518,20 @@ class ForgeService:
                     safe_title=safe_title,
                     epub_filename=epub_filename,
                     title=title,
+                    chapters=chapters,
                     course_dir=course_dir,
                     epub_cache=epub_cache,
                     found_uuid=found_uuid,
                     processing_triggered=processing_triggered,
                     poll_count=poll_count,
+                    existing_probe_download_path=probe_download_path,
                 )
                 found_uuid = poll_result["found_uuid"]
                 processing_triggered = poll_result["processing_triggered"]
                 readaloud_path = poll_result["readaloud_path"] or readaloud_path
                 probe_download_path = poll_result["probe_download_path"] or probe_download_path
                 api_ready_seen = api_ready_seen or poll_result["api_ready_seen"]
+                transcript_probe = poll_result["transcript_probe"]
                 completion_method = poll_result["completion_method"]
                 if completion_method:
                     break
@@ -1103,6 +1544,8 @@ class ForgeService:
                     timeout_reason.append("no_artifact_local")
                 if found_uuid and not api_ready_seen:
                     timeout_reason.append("api_not_ready")
+                if transcript_probe and not transcript_probe.get("ready"):
+                    timeout_reason.append(f"transcripts_{transcript_probe.get('reason')}")
                 reason_str = ",".join(timeout_reason) if timeout_reason else "unknown"
 
                 logger.warning(
@@ -1129,17 +1572,20 @@ class ForgeService:
                         safe_title=safe_title,
                         epub_filename=epub_filename,
                         title=title,
+                        chapters=chapters,
                         course_dir=course_dir,
                         epub_cache=epub_cache,
                         found_uuid=found_uuid,
                         processing_triggered=processing_triggered,
                         poll_count=poll_count,
+                        existing_probe_download_path=probe_download_path,
                     )
                     found_uuid = poll_result["found_uuid"]
                     processing_triggered = poll_result["processing_triggered"]
                     readaloud_path = poll_result["readaloud_path"] or readaloud_path
                     probe_download_path = poll_result["probe_download_path"] or probe_download_path
                     api_ready_seen = api_ready_seen or poll_result["api_ready_seen"]
+                    transcript_probe = poll_result["transcript_probe"]
                     completion_method = poll_result["completion_method"]
 
                 if not completion_method:
@@ -1149,7 +1595,9 @@ class ForgeService:
                     )
                     return
 
-            completion_msg = f"Auto-Forge: Completion detected via {completion_method}"
+            completion_msg = f"Auto-Forge: Completion confirmed via {completion_method}"
+            if transcript_probe.get("reason") == "validated":
+                completion_msg += " + validated_transcripts"
             if readaloud_path:
                 completion_msg += f" ({readaloud_path})"
             logger.info(completion_msg)
@@ -1173,13 +1621,15 @@ class ForgeService:
                     if not st_client.download_book(found_uuid, target_path):
                         raise Exception("API download returned False")
                 except Exception as api_err:
-                    if readaloud_path and readaloud_path.exists():
-                        logger.warning(f"Auto-Forge: API download failed ({api_err}). Using local file: {readaloud_path}")
+                    if completion_method == "api_download" and readaloud_path and readaloud_path.exists():
+                        logger.warning(
+                            "Auto-Forge: API download failed after confirmed readiness (%s). Using local file fallback: %s",
+                            api_err,
+                            readaloud_path,
+                        )
                         shutil.copy2(readaloud_path, target_path)
                     else:
                         raise Exception(f"Failed to download Storyteller artifact and no local fallback available: {api_err}")
-            elif readaloud_path and readaloud_path.exists():
-                shutil.copy2(readaloud_path, target_path)
             else:
                 raise Exception("Auto-Forge completion detected but no downloadable artifact source was available")
 
@@ -1198,8 +1648,6 @@ class ForgeService:
                  logger.info(f"⚡ Auto-Forge: Generated New Hash (Artifact): {new_hash}")
 
             # --- EXTRACT TEXT ---
-            item_details = self.abs_client.get_item_details(abs_id)
-            chapters = item_details.get('media', {}).get('chapters', []) if item_details else []
             text_source_path = target_path
             if original_filename:
                 original_candidates = []
@@ -1256,9 +1704,12 @@ class ForgeService:
                     transcript_source = "smil"
                 if not raw_transcript:
                     logger.info("Auto-Forge: SMIL unavailable/rejected. Falling back to Whisper transcription...")
-                    audio_files = self.abs_client.get_audio_files(abs_id)
+                    audio_files = self._get_whisper_audio_inputs(course_dir, abs_id, audio_source, audio_source_id)
                     if not audio_files:
-                        raise Exception("Auto-Forge: ABS returned no audio files for Whisper fallback.")
+                        source_name = "BookLore" if audio_source == "BookLore" and audio_source_id else "ABS"
+                        raise Exception(
+                            f"Auto-Forge: no audio files available for Whisper fallback (source={source_name})."
+                        )
                     raw_transcript = self.transcriber.process_audio(
                         abs_id, audio_files, full_book_text=book_text
                     )
@@ -1335,6 +1786,9 @@ class ForgeService:
                     )
             except Exception as cleanup_err:
                 logger.warning(f"Auto-Forge: Final cleanup failed: {cleanup_err}")
+
+            if cross_device and storyteller_paths:
+                self._cleanup_temp_staging_root(storyteller_paths["incoming_root"], cross_device)
 
             with self.lock:
                 self.active_tasks.discard(title)

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1811,15 +1811,54 @@ def forge():
 
 
 def forge_search_audio():
-    """API: Search ABS audiobooks for Forge (returns JSON)."""
+    """API: Search ABS and BookLore audiobooks for Forge (returns JSON)."""
     query = request.args.get('q', '').strip()
     if not query:
         return jsonify([])
 
     try:
-        all_audiobooks = get_audiobooks_conditionally()
         query_lower = query.lower()
         results = []
+        found_ids = set()
+
+        if container.booklore_client().is_configured():
+            try:
+                for book in container.booklore_client().search_audiobooks(query, include_info=True) or []:
+                    book_id = str(book.get("id") or "").strip()
+                    if not book_id:
+                        continue
+                    bridge_key = _build_bridge_key("BookLore", book_id)
+                    if bridge_key in found_ids:
+                        continue
+                    found_ids.add(bridge_key)
+                    info = book.get("audiobookInfo") or {}
+                    tracks = info.get("tracks") if isinstance(info.get("tracks"), list) else []
+                    num_files = len(tracks) or 1
+                    total_size_bytes = 0
+                    for track in tracks:
+                        try:
+                            total_size_bytes += int(
+                                track.get("sizeBytes")
+                                or track.get("size")
+                                or track.get("metadata", {}).get("size")
+                                or 0
+                            )
+                        except Exception:
+                            continue
+                    results.append({
+                        "id": bridge_key,
+                        "audio_source": "BookLore",
+                        "audio_source_id": book_id,
+                        "title": book.get("title") or book.get("fileName") or f"BookLore {book_id}",
+                        "author": _coerce_author_display(book.get("authors")),
+                        "file_size_mb": round(total_size_bytes / (1024 * 1024), 2) if total_size_bytes else 0,
+                        "num_files": num_files,
+                        "cover_url": f"/api/booklore/audiobook-cover/{book_id}",
+                    })
+            except Exception as e:
+                logger.warning(f"⚠️ Forge audio BookLore search failed: {e}")
+
+        all_audiobooks = get_audiobooks_conditionally()
 
         for ab in all_audiobooks:
             if audiobook_matches_search(ab, query_lower):
@@ -1843,8 +1882,13 @@ def forge_search_audio():
                 if abs_server:
                     cover_url = f"/api/cover-proxy/{ab.get('id')}"
 
+                if str(ab.get("id")) in found_ids:
+                    continue
+                found_ids.add(str(ab.get("id")))
                 results.append({
                     "id": ab.get("id"),
+                    "audio_source": "ABS",
+                    "audio_source_id": ab.get("id"),
                     "title": title,
                     "author": metadata.get('authorName') or get_abs_author(ab),
                     "file_size_mb": round(size_mb, 2),
@@ -1970,34 +2014,67 @@ def forge_process():
     if not data:
         return jsonify({"error": "Missing JSON payload"}), 400
 
-    abs_id = data.get('abs_id')
+    requested_abs_id = data.get('abs_id')
+    audio_source = (data.get('audio_source') or ('BookLore' if str(requested_abs_id or '').startswith('booklore:') else 'ABS')).strip()
+    audio_source_id = str(data.get('audio_source_id') or requested_abs_id or '').strip()
+    if audio_source == "BookLore" and audio_source_id.lower().startswith("booklore:"):
+        audio_source_id = audio_source_id.split(":", 1)[1].strip()
     text_item = data.get('text_item')
     forge_stage_mode = data.get('forge_stage_mode')
 
-    if not abs_id or not text_item:
-        return jsonify({"error": "Missing abs_id or text_item"}), 400
+    if not text_item:
+        return jsonify({"error": "Missing text_item"}), 400
+    if audio_source == "ABS" and not requested_abs_id:
+        return jsonify({"error": "Missing abs_id"}), 400
+    if audio_source == "BookLore" and not audio_source_id:
+        return jsonify({"error": "Missing audio_source_id"}), 400
+
+    abs_id = requested_abs_id if audio_source == "ABS" else _build_bridge_key("BookLore", audio_source_id)
 
     # Get title/author from ABS for folder naming
     title = "Unknown"
     author = "Unknown"
     try:
-        item_details = container.abs_client().get_item_details(abs_id)
-        if item_details:
-            metadata = item_details.get('media', {}).get('metadata', {})
-            title = metadata.get('title', 'Unknown')
-            author = metadata.get('authorName', '') or get_abs_author(item_details) or 'Unknown'
+        if audio_source == "BookLore":
+            book_detail = container.booklore_client().get_book_by_id(audio_source_id)
+            if book_detail:
+                metadata = book_detail.get("metadata") or {}
+                title = (
+                    metadata.get("title")
+                    or book_detail.get("title")
+                    or book_detail.get("fileName")
+                    or f"BookLore {audio_source_id}"
+                )
+                author = (
+                    _coerce_author_display(book_detail.get("authors"))
+                    or _coerce_author_display(metadata.get("authors"))
+                    or "Unknown"
+                )
+        else:
+            item_details = container.abs_client().get_item_details(abs_id)
+            if item_details:
+                metadata = item_details.get('media', {}).get('metadata', {})
+                title = metadata.get('title', 'Unknown')
+                author = metadata.get('authorName', '') or get_abs_author(item_details) or 'Unknown'
     except Exception as e:
-        logger.warning(f"⚠️ Forge: Could not get ABS metadata for '{abs_id}': {e}")
+        logger.warning(f"⚠️ Forge: Could not get audio metadata for '{abs_id}': {e}")
 
     # Start manual forge in service
     try:
+        forge_kwargs = {}
+        if audio_source == "BookLore":
+            forge_kwargs["audio_source"] = "BookLore"
+            forge_kwargs["audio_source_id"] = audio_source_id
         if forge_stage_mode:
+            forge_kwargs["stage_mode"] = forge_stage_mode
+
+        if forge_kwargs:
             container.forge_service().start_manual_forge(
                 abs_id,
                 text_item,
                 title,
                 author,
-                stage_mode=forge_stage_mode,
+                **forge_kwargs,
             )
         else:
             container.forge_service().start_manual_forge(abs_id, text_item, title, author)

--- a/templates/forge.html
+++ b/templates/forge.html
@@ -774,7 +774,7 @@
 
         function searchAudio(q) {
             const container = document.getElementById('audioResults');
-            container.innerHTML = '<div class="loading-spinner"><div class="spinner"></div><p style="color: rgba(255,255,255,0.5)">Searching ABS...</p></div>';
+            container.innerHTML = '<div class="loading-spinner"><div class="spinner"></div><p style="color: rgba(255,255,255,0.5)">Searching audio sources...</p></div>';
 
             fetch(`/api/forge/search_audio?q=${encodeURIComponent(q)}`)
                 .then(r => r.json())
@@ -796,13 +796,18 @@
                         const coverHtml = item.cover_url
                             ? `<div class="card-cover"><img src="${item.cover_url}" alt="" onerror="this.parentElement.innerHTML='🎧'"></div>`
                             : `<div class="card-cover">🎧</div>`;
+                        const badgeClass = ((item.audio_source || 'ABS').toLowerCase() === 'booklore') ? 'booklore' : 'abs';
 
                         card.innerHTML = `
                             ${coverHtml}
                             <div class="card-info">
                                 <div class="card-title">${escapeHtml(item.title)}</div>
                                 <div class="card-author">${escapeHtml(item.author || '')}</div>
-                                <div class="card-meta">${item.num_files} file${item.num_files !== 1 ? 's' : ''} · ${item.file_size_mb} MB</div>
+                                <div class="card-meta">
+                                    <span class="source-badge ${badgeClass}">${escapeHtml(item.audio_source || 'ABS')}</span>
+                                    · ${item.num_files} file${item.num_files !== 1 ? 's' : ''}
+                                    · ${item.file_size_mb} MB
+                                </div>
                             </div>
                         `;
                         container.appendChild(card);
@@ -926,6 +931,8 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     abs_id: selectedAudio.id,
+                    audio_source: selectedAudio.audio_source || 'ABS',
+                    audio_source_id: selectedAudio.audio_source_id || selectedAudio.id,
                     text_item: selectedText,
                     forge_stage_mode: stageMode
                 })

--- a/tests/test_alignment_service.py
+++ b/tests/test_alignment_service.py
@@ -1,7 +1,14 @@
 import pytest
 import json
+import os
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock
-from src.services.alignment_service import AlignmentService
+from src.services.alignment_service import (
+    AlignmentService,
+    _resolve_storyteller_title_dir,
+    probe_storyteller_transcripts,
+)
 from src.utils.polisher import Polisher
 from src.db.models import BookAlignment
 
@@ -88,3 +95,138 @@ def test_get_time_for_text(service, mock_db):
     # Test Interpolation (50 chars -> 5.0s)
     ts = service.get_time_for_text("test_id", "query", char_offset_hint=50)
     assert ts == 5.0
+
+
+def test_probe_storyteller_transcripts_returns_ready_when_assets_not_configured():
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("STORYTELLER_ASSETS_DIR", raising=False)
+        result = probe_storyteller_transcripts("Auto Book", [])
+
+    assert result["ready"] is True
+    assert result["reason"] == "assets_not_configured"
+
+
+def test_probe_storyteller_transcripts_returns_not_ready_when_transcriptions_dir_missing():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        (assets_root / "assets" / "Auto Book").mkdir(parents=True, exist_ok=True)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("STORYTELLER_ASSETS_DIR", str(assets_root))
+            result = probe_storyteller_transcripts("Auto Book", [{"start": 0.0, "end": 1.0}])
+
+    assert result["ready"] is False
+    assert result["reason"] == "transcriptions_dir_missing"
+
+
+def test_probe_storyteller_transcripts_returns_not_ready_when_chapter_files_incomplete():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        transcriptions_dir = assets_root / "assets" / "Auto Book" / "transcriptions"
+        transcriptions_dir.mkdir(parents=True, exist_ok=True)
+        (transcriptions_dir / "00000-00001.json").write_text(
+            json.dumps({"transcript": "hello", "wordTimeline": []}),
+            encoding="utf-8",
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("STORYTELLER_ASSETS_DIR", str(assets_root))
+            result = probe_storyteller_transcripts(
+                "Auto Book",
+                [{"start": 0.0, "end": 1.0}, {"start": 1.0, "end": 2.0}],
+            )
+
+    assert result["ready"] is False
+    assert result["reason"] == "chapter_set_incomplete"
+
+
+def test_probe_storyteller_transcripts_returns_ready_when_validated():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        transcriptions_dir = assets_root / "assets" / "Auto Book" / "transcriptions"
+        transcriptions_dir.mkdir(parents=True, exist_ok=True)
+        for idx in range(2):
+            (transcriptions_dir / f"00000-{idx + 1:05d}.json").write_text(
+                json.dumps({"transcript": "hello", "wordTimeline": [{"endTime": 1.0}]}),
+                encoding="utf-8",
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("STORYTELLER_ASSETS_DIR", str(assets_root))
+            result = probe_storyteller_transcripts(
+                "Auto Book",
+                [{"start": 0.0, "end": 1.0}, {"start": 1.0, "end": 2.0}],
+            )
+
+    assert result["ready"] is True
+    assert result["reason"] == "validated"
+
+
+def test_resolve_storyteller_title_dir_prefers_suffixed_dir_with_transcriptions_over_bare_dir_without_transcriptions():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        bare_dir = assets_root / "assets" / "Trad Wife"
+        suffixed_dir = assets_root / "assets" / "Trad Wife [5j7RKcRZ]"
+        bare_dir.mkdir(parents=True, exist_ok=True)
+        transcriptions_dir = suffixed_dir / "transcriptions"
+        transcriptions_dir.mkdir(parents=True, exist_ok=True)
+        (transcriptions_dir / "00001-00001.json").write_text(
+            json.dumps({"transcript": "hello", "wordTimeline": []}),
+            encoding="utf-8",
+        )
+
+        result = _resolve_storyteller_title_dir(assets_root, "Trad Wife")
+
+    assert result == suffixed_dir
+
+
+def test_probe_storyteller_transcripts_uses_suffixed_storyteller_assets_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        (assets_root / "assets" / "Trad Wife").mkdir(parents=True, exist_ok=True)
+        transcriptions_dir = assets_root / "assets" / "Trad Wife [5j7RKcRZ]" / "transcriptions"
+        transcriptions_dir.mkdir(parents=True, exist_ok=True)
+        for idx in range(2):
+            (transcriptions_dir / f"00001-{idx + 1:05d}.json").write_text(
+                json.dumps({"transcript": "hello", "wordTimeline": [{"endTime": 1.0}]}),
+                encoding="utf-8",
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("STORYTELLER_ASSETS_DIR", str(assets_root))
+            result = probe_storyteller_transcripts(
+                "Trad Wife",
+                [{"start": 0.0, "end": 1.0}, {"start": 1.0, "end": 2.0}],
+            )
+
+    assert result["ready"] is True
+    assert result["transcriptions_dir"] == transcriptions_dir
+
+
+def test_resolve_storyteller_title_dir_matches_title_with_bracket_suffix_when_only_suffixed_dir_exists():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        suffixed_dir = assets_root / "assets" / "Trad Wife [5j7RKcRZ]"
+        suffixed_dir.mkdir(parents=True, exist_ok=True)
+
+        result = _resolve_storyteller_title_dir(assets_root, "Trad Wife")
+
+    assert result == suffixed_dir
+
+
+def test_resolve_storyteller_title_dir_returns_none_when_multiple_transcript_ready_suffix_variants_exist():
+    with tempfile.TemporaryDirectory() as tmp:
+        assets_root = Path(tmp)
+        first_dir = assets_root / "assets" / "Trad Wife [5j7RKcRZ]"
+        second_dir = assets_root / "assets" / "Trad Wife [ABCD1234]"
+        for folder in (first_dir, second_dir):
+            transcriptions_dir = folder / "transcriptions"
+            transcriptions_dir.mkdir(parents=True, exist_ok=True)
+            (transcriptions_dir / "00001-00001.json").write_text(
+                json.dumps({"transcript": "hello", "wordTimeline": []}),
+                encoding="utf-8",
+            )
+
+        result = _resolve_storyteller_title_dir(assets_root, "Trad Wife")
+
+    assert result is None

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -194,6 +194,42 @@ def test_save_to_db_on_fetch(mock_db):
              assert saved_book.filename == "newbook.epub"
 
 
+def test_get_book_by_id_returns_cached_hydrated_detail(booklore_client):
+    cached = make_detail("cached-1", title="Cached Book", filename="cached-book.epub")
+    booklore_client._book_id_cache = {"cached-1": cached}
+
+    with patch.object(booklore_client, "_fetch_and_cache_detail") as mock_fetch:
+        result = booklore_client.get_book_by_id("cached-1")
+
+    assert result == cached
+    mock_fetch.assert_not_called()
+
+
+def test_get_book_by_id_refreshes_missing_or_unhydrated_detail(booklore_client):
+    lightweight = {
+        "id": "cached-2",
+        "title": "Thin Entry",
+        "fileName": "thin-entry.epub",
+        "_needs_detail": True,
+    }
+    refreshed = make_detail("cached-2", title="Hydrated Book", filename="hydrated-book.epub")
+    booklore_client._book_id_cache = {"cached-2": lightweight}
+
+    with patch.object(booklore_client, "_fetch_and_cache_detail", return_value=refreshed) as mock_fetch:
+        result = booklore_client.get_book_by_id("cached-2")
+
+    assert result == refreshed
+    mock_fetch.assert_called_once_with("cached-2", force_refresh=True)
+
+
+def test_get_book_by_id_returns_none_for_unknown_id(booklore_client):
+    with patch.object(booklore_client, "_fetch_and_cache_detail", return_value=None) as mock_fetch:
+        result = booklore_client.get_book_by_id("missing-id")
+
+    assert result is None
+    mock_fetch.assert_called_once_with("missing-id", force_refresh=True)
+
+
 def test_get_fresh_token_retries_duplicate_refresh_token_conflict(booklore_client):
     conflict_response = MagicMock()
     conflict_response.status_code = 400

--- a/tests/test_forge_service.py
+++ b/tests/test_forge_service.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch, ANY
 import json
 import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -85,6 +86,28 @@ class TestForgeService(unittest.TestCase):
             )
             mock_thread_instance.start.assert_called_once()
 
+    def test_start_manual_forge_booklore_audio_passes_audio_kwargs(self):
+        with patch('threading.Thread') as mock_thread_cls:
+            mock_thread_instance = MagicMock()
+            mock_thread_cls.return_value = mock_thread_instance
+
+            self.service.start_manual_forge(
+                abs_id="booklore:42",
+                text_item={"path": "other.epub"},
+                title="BookLore Audio",
+                author="Test Author 2",
+                audio_source="BookLore",
+                audio_source_id="42",
+            )
+
+            mock_thread_cls.assert_called_with(
+                target=self.service._forge_background_task,
+                args=("booklore:42", {"path": "other.epub"}, "BookLore Audio", "Test Author 2"),
+                kwargs={"audio_source": "BookLore", "audio_source_id": "42"},
+                daemon=True
+            )
+            mock_thread_instance.start.assert_called_once()
+
     def test_start_auto_forge_match(self):
         """Test starting auto forge match."""
         # Using mock threading
@@ -164,6 +187,454 @@ class TestForgeService(unittest.TestCase):
             self.assertEqual(result, "copy")
             mock_copy.assert_called_once_with(str(source), dest)
 
+    def test_booklore_hardlink_uses_local_exact_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = tmp_path / "exact.m4b"
+            source.write_bytes(b"audio")
+            dest_folder = tmp_path / "dest"
+            self.service.ABS_AUDIO_ROOT = tmp_path
+            self.mock_booklore.get_audiobook_info.return_value = {
+                "tracks": [{"index": 0, "fileName": source.name, "extension": "m4b"}]
+            }
+            self.mock_booklore.get_book_by_id.return_value = {
+                "id": "bl-1",
+                "alternativeFormats": [
+                    {"bookType": "AUDIOBOOK", "fileName": source.name, "filePath": str(source)}
+                ],
+            }
+
+            with patch.object(self.service, "_stage_local_file", return_value="hardlink") as mock_stage:
+                result = self.service._copy_booklore_audio_files("bl-1", dest_folder, stage_mode="hardlink")
+
+            self.assertTrue(result)
+            mock_stage.assert_called_once_with(
+                source,
+                dest_folder / "track_000.m4b",
+                "hardlink",
+                "BookLore audio",
+            )
+            self.mock_booklore.download_book_to_path.assert_not_called()
+            self.mock_booklore.download_audiobook_track.assert_not_called()
+
+    def test_booklore_hardlink_uses_suffix_matched_local_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            local_root = tmp_path / "audiobooks"
+            source = local_root / "Author" / "Series" / "suffix.m4b"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_bytes(b"audio")
+            dest_folder = tmp_path / "dest"
+            self.service.ABS_AUDIO_ROOT = local_root
+            self.mock_booklore.get_audiobook_info.return_value = {
+                "tracks": [{"index": 0, "fileName": source.name, "extension": "m4b"}]
+            }
+            self.mock_booklore.get_book_by_id.return_value = {
+                "id": "bl-1",
+                "alternativeFormats": [
+                    {
+                        "bookType": "AUDIOBOOK",
+                        "fileName": source.name,
+                        "filePath": "/srv/booklore/Author/Series/suffix.m4b",
+                    }
+                ],
+            }
+
+            with patch.object(self.service, "_stage_local_file", return_value="hardlink") as mock_stage:
+                result = self.service._copy_booklore_audio_files("bl-1", dest_folder, stage_mode="hardlink")
+
+            self.assertTrue(result)
+            mock_stage.assert_called_once_with(
+                source,
+                dest_folder / "track_000.m4b",
+                "hardlink",
+                "BookLore audio",
+            )
+            self.mock_booklore.download_audiobook_track.assert_not_called()
+
+    def test_booklore_hardlink_uses_filename_glob_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            local_root = tmp_path / "audiobooks"
+            source = local_root / "nested" / "globbed.m4b"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_bytes(b"audio")
+            dest_folder = tmp_path / "dest"
+            self.service.ABS_AUDIO_ROOT = local_root
+            self.mock_booklore.get_audiobook_info.return_value = {
+                "tracks": [{"index": 0, "fileName": source.name, "extension": "m4b"}]
+            }
+            self.mock_booklore.get_book_by_id.return_value = {
+                "id": "bl-1",
+                "alternativeFormats": [
+                    {
+                        "bookType": "AUDIOBOOK",
+                        "fileName": source.name,
+                        "filePath": "/missing/location/not-the-same.m4b",
+                    }
+                ],
+            }
+
+            with patch.object(self.service, "_stage_local_file", return_value="hardlink") as mock_stage:
+                result = self.service._copy_booklore_audio_files("bl-1", dest_folder, stage_mode="hardlink")
+
+            self.assertTrue(result)
+            mock_stage.assert_called_once_with(
+                source,
+                dest_folder / "track_000.m4b",
+                "hardlink",
+                "BookLore audio",
+            )
+            self.mock_booklore.download_audiobook_track.assert_not_called()
+
+    def test_booklore_hardlink_falls_back_to_copy_when_link_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = tmp_path / "copy-fallback.m4b"
+            source.write_bytes(b"audio")
+            dest_folder = tmp_path / "dest"
+            self.service.ABS_AUDIO_ROOT = tmp_path
+            self.mock_booklore.get_audiobook_info.return_value = {
+                "tracks": [{"index": 0, "fileName": source.name, "extension": "m4b"}]
+            }
+            self.mock_booklore.get_book_by_id.return_value = {
+                "id": "bl-1",
+                "alternativeFormats": [
+                    {"bookType": "AUDIOBOOK", "fileName": source.name, "filePath": str(source)}
+                ],
+            }
+
+            with patch("src.services.forge_service.os.link", side_effect=OSError("no hardlink")), patch(
+                "src.services.forge_service.shutil.copy2"
+            ) as mock_copy:
+                result = self.service._copy_booklore_audio_files("bl-1", dest_folder, stage_mode="hardlink")
+
+            self.assertTrue(result)
+            mock_copy.assert_called_once_with(str(source), dest_folder / "track_000.m4b")
+            self.mock_booklore.download_book_to_path.assert_not_called()
+            self.mock_booklore.download_audiobook_track.assert_not_called()
+
+    def test_booklore_hardlink_falls_back_to_download_when_local_resolution_incomplete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            local_root = tmp_path / "audiobooks"
+            existing = local_root / "track_a.m4b"
+            existing.parent.mkdir(parents=True, exist_ok=True)
+            existing.write_bytes(b"a")
+            dest_folder = tmp_path / "dest"
+            self.service.ABS_AUDIO_ROOT = local_root
+            self.mock_booklore.get_audiobook_info.return_value = {
+                "tracks": [
+                    {"index": 0, "fileName": "track_a.m4b", "extension": "m4b"},
+                    {"index": 1, "fileName": "track_b.m4b", "extension": "m4b"},
+                ]
+            }
+            self.mock_booklore.get_book_by_id.return_value = {
+                "id": "bl-1",
+                "alternativeFormats": [
+                    {"bookType": "AUDIOBOOK", "fileName": "track_a.m4b", "filePath": str(existing)},
+                    {"bookType": "AUDIOBOOK", "fileName": "track_b.m4b", "filePath": "/missing/track_b.m4b"},
+                ],
+            }
+            self.mock_booklore.download_audiobook_track.return_value = True
+
+            result = self.service._copy_booklore_audio_files("bl-1", dest_folder, stage_mode="hardlink")
+
+            self.assertTrue(result)
+            self.assertEqual(self.mock_booklore.download_audiobook_track.call_count, 2)
+
+    def test_booklore_single_stream_local_file_stages_as_track_000(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = tmp_path / "single-stream.m4b"
+            source.write_bytes(b"audio")
+            dest_folder = tmp_path / "dest"
+            self.service.ABS_AUDIO_ROOT = tmp_path
+            self.mock_booklore.get_audiobook_info.return_value = {
+                "chapters": [{"title": "Chapter 1"}],
+                "mimeType": "audio/mp4",
+            }
+            self.mock_booklore.get_book_by_id.return_value = {
+                "id": "bl-1",
+                "alternativeFormats": [
+                    {"bookType": "AUDIOBOOK", "fileName": source.name, "filePath": str(source)}
+                ],
+            }
+
+            result = self.service._copy_booklore_audio_files("bl-1", dest_folder, stage_mode="cleanup")
+
+            self.assertTrue(result)
+            self.assertEqual((dest_folder / "track_000.m4b").read_bytes(), b"audio")
+            self.mock_booklore.download_book_to_path.assert_not_called()
+
+    def test_manual_forge_stages_in_unwatched_sibling_dir_before_reveal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_root = tmp_path / "storyteller_library"
+            source_epub = tmp_path / "source.epub"
+            source_epub.write_bytes(b"ebook")
+            captured = {}
+
+            def _copy_audio(_abs_id, dest_path, stage_mode="cleanup"):
+                dest = Path(dest_path)
+                dest.mkdir(parents=True, exist_ok=True)
+                (dest / "audio.mp3").write_bytes(b"audio")
+                return True
+
+            def _capture_reveal(staging_course_dir, final_course_dir, backup_course_dir, cross_device=False):
+                captured["staging"] = Path(staging_course_dir)
+                captured["final"] = Path(final_course_dir)
+                captured["backup"] = Path(backup_course_dir)
+                raise RuntimeError("stop-after-staging")
+
+            with patch.dict(
+                os.environ,
+                {"STORYTELLER_LIBRARY_DIR": str(watch_root)},
+                clear=False,
+            ), patch.object(self.service, "_copy_audio_files", side_effect=_copy_audio), patch.object(
+                self.service, "_reveal_storyteller_stage_dir", side_effect=_capture_reveal
+            ), patch("src.services.forge_service.time.sleep", return_value=None):
+                self.service._forge_background_task(
+                    abs_id="abs-1",
+                    text_item={"source": "Local File", "path": str(source_epub)},
+                    title="Auto Book",
+                    author="Author",
+                )
+
+            self.assertIn(".storyteller_library_incoming", str(captured["staging"].parent))
+            self.assertFalse(self.service._path_is_within(captured["staging"], watch_root))
+            self.assertEqual(captured["final"], watch_root / "Auto Book")
+
+    def test_manual_forge_uses_booklore_audio_staging_for_booklore_jobs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_root = tmp_path / "storyteller_library"
+            source_epub = tmp_path / "source.epub"
+            source_epub.write_bytes(b"ebook")
+
+            with patch.dict(
+                os.environ,
+                {"STORYTELLER_LIBRARY_DIR": str(watch_root)},
+                clear=False,
+            ), patch.object(self.service, "_copy_booklore_audio_files", return_value=False) as mock_booklore_copy, patch.object(
+                self.service, "_copy_audio_files", return_value=True
+            ) as mock_abs_copy, patch("src.services.forge_service.time.sleep", return_value=None):
+                self.service._forge_background_task(
+                    abs_id="booklore:42",
+                    text_item={"source": "Local File", "path": str(source_epub)},
+                    title="Auto Book",
+                    author="Author",
+                    audio_source="BookLore",
+                    audio_source_id="42",
+                )
+
+            mock_booklore_copy.assert_called_once()
+            mock_abs_copy.assert_not_called()
+
+    def test_auto_forge_stages_in_unwatched_sibling_dir_before_reveal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_root = tmp_path / "storyteller_library"
+            source_epub = tmp_path / "source.epub"
+            source_epub.write_bytes(b"ebook")
+            captured = {}
+
+            def _copy_audio(_abs_id, dest_path, stage_mode="cleanup"):
+                dest = Path(dest_path)
+                dest.mkdir(parents=True, exist_ok=True)
+                (dest / "audio.mp3").write_bytes(b"audio")
+                return True
+
+            def _capture_reveal(staging_course_dir, final_course_dir, backup_course_dir, cross_device=False):
+                captured["staging"] = Path(staging_course_dir)
+                captured["final"] = Path(final_course_dir)
+                captured["backup"] = Path(backup_course_dir)
+                raise RuntimeError("stop-after-staging")
+
+            self.mock_abs.get_item_details.return_value = {"media": {"chapters": []}}
+
+            with patch.dict(
+                os.environ,
+                {"STORYTELLER_LIBRARY_DIR": str(watch_root)},
+                clear=False,
+            ), patch.object(self.service, "_copy_audio_files", side_effect=_copy_audio), patch.object(
+                self.service, "_reveal_storyteller_stage_dir", side_effect=_capture_reveal
+            ), patch("src.services.forge_service.time.sleep", return_value=None):
+                self.service._auto_forge_background_task(
+                    abs_id="abs-1",
+                    text_item={"source": "Local File", "path": str(source_epub)},
+                    title="Auto Book",
+                    author="Author",
+                    original_filename="orig.epub",
+                    original_hash="hash123",
+                )
+
+            self.assertIn(".storyteller_library_incoming", str(captured["staging"].parent))
+            self.assertFalse(self.service._path_is_within(captured["staging"], watch_root))
+            self.assertEqual(captured["final"], watch_root / "Auto Book")
+
+    def test_reveal_storyteller_stage_dir_atomic_replace_moves_existing_final_out_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            staging_dir = tmp_path / "incoming" / "Auto Book.1234"
+            final_dir = tmp_path / "library" / "Auto Book"
+            backup_dir = tmp_path / "backup" / "Auto Book.1234"
+            staging_dir.mkdir(parents=True, exist_ok=True)
+            final_dir.mkdir(parents=True, exist_ok=True)
+            (staging_dir / "new.epub").write_bytes(b"new")
+            (final_dir / "old.epub").write_bytes(b"old")
+
+            result = self.service._reveal_storyteller_stage_dir(staging_dir, final_dir, backup_dir)
+
+            self.assertEqual(result, final_dir)
+            self.assertTrue((final_dir / "new.epub").exists())
+            self.assertFalse((final_dir / "old.epub").exists())
+            self.assertFalse(backup_dir.exists())
+
+    def test_reveal_storyteller_stage_dir_rolls_back_backup_if_final_rename_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            staging_dir = tmp_path / "incoming" / "Auto Book.1234"
+            final_dir = tmp_path / "library" / "Auto Book"
+            backup_dir = tmp_path / "backup" / "Auto Book.1234"
+            staging_dir.mkdir(parents=True, exist_ok=True)
+            final_dir.mkdir(parents=True, exist_ok=True)
+            (staging_dir / "new.epub").write_bytes(b"new")
+            (final_dir / "old.epub").write_bytes(b"old")
+
+            original_rename = Path.rename
+
+            def _rename_with_failure(path_obj, target):
+                if path_obj == staging_dir:
+                    raise OSError("rename failed")
+                return original_rename(path_obj, target)
+
+            with patch("pathlib.Path.rename", autospec=True, side_effect=_rename_with_failure):
+                with self.assertRaises(OSError):
+                    self.service._reveal_storyteller_stage_dir(staging_dir, final_dir, backup_dir)
+
+            self.assertTrue(final_dir.exists())
+            self.assertTrue((final_dir / "old.epub").exists())
+            self.assertTrue(staging_dir.exists())
+            self.assertFalse(backup_dir.exists())
+
+    def test_reveal_storyteller_stage_dir_cross_device_uses_copytree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            staging_dir = tmp_path / "tempstage" / "Auto Book.1234"
+            final_dir = tmp_path / "library" / "Auto Book"
+            backup_dir = tmp_path / "backup" / "Auto Book.1234"
+            staging_dir.mkdir(parents=True, exist_ok=True)
+            (staging_dir / "book.epub").write_bytes(b"epub")
+            (staging_dir / "track_000.m4b").write_bytes(b"audio")
+
+            result = self.service._reveal_storyteller_stage_dir(
+                staging_dir, final_dir, backup_dir, cross_device=True,
+            )
+
+            self.assertEqual(result, final_dir)
+            self.assertTrue((final_dir / "book.epub").exists())
+            self.assertTrue((final_dir / "track_000.m4b").exists())
+            self.assertFalse(staging_dir.exists())
+
+    def test_reveal_storyteller_stage_dir_cross_device_replaces_existing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            staging_dir = tmp_path / "tempstage" / "Auto Book.1234"
+            final_dir = tmp_path / "library" / "Auto Book"
+            backup_dir = tmp_path / "backup" / "Auto Book.1234"
+            staging_dir.mkdir(parents=True, exist_ok=True)
+            final_dir.mkdir(parents=True, exist_ok=True)
+            (staging_dir / "new.epub").write_bytes(b"new")
+            (final_dir / "old.epub").write_bytes(b"old")
+
+            result = self.service._reveal_storyteller_stage_dir(
+                staging_dir, final_dir, backup_dir, cross_device=True,
+            )
+
+            self.assertEqual(result, final_dir)
+            self.assertTrue((final_dir / "new.epub").exists())
+            self.assertFalse((final_dir / "old.epub").exists())
+            self.assertFalse(staging_dir.exists())
+
+    def test_storyteller_staging_dir_config_inside_watch_root_falls_back_to_hidden_sibling(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_root = tmp_path / "storyteller_library"
+            watch_root.mkdir(parents=True, exist_ok=True)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "STORYTELLER_LIBRARY_DIR": str(watch_root),
+                    "STORYTELLER_STAGING_DIR": str(watch_root / "incoming"),
+                },
+                clear=False,
+            ):
+                paths = self.service._resolve_storyteller_paths("Auto Book")
+
+            self.assertEqual(paths["incoming_root"], watch_root.with_name(".storyteller_library_incoming"))
+            self.assertFalse(paths["cross_device"])
+
+    def test_storyteller_staging_dir_cross_device_falls_back_to_temp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_root = tmp_path / "storyteller_library"
+            configured_root = tmp_path / "external_incoming"
+            watch_root.mkdir(parents=True, exist_ok=True)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "STORYTELLER_LIBRARY_DIR": str(watch_root),
+                    "STORYTELLER_STAGING_DIR": str(configured_root),
+                },
+                clear=False,
+            ), patch.object(self.service, "_same_device", return_value=False):
+                paths = self.service._resolve_storyteller_paths("Auto Book")
+
+            self.assertTrue(paths["cross_device"])
+            self.assertTrue(str(paths["incoming_root"]).startswith(tempfile.gettempdir()))
+            # Clean up the temp dir created by mkdtemp
+            if paths["incoming_root"].exists():
+                shutil.rmtree(paths["incoming_root"])
+
+    def test_storyteller_default_staging_dir_cross_device_falls_back_to_temp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_root = tmp_path / "storyteller_library"
+            watch_root.mkdir(parents=True, exist_ok=True)
+
+            with patch.dict(
+                os.environ,
+                {"STORYTELLER_LIBRARY_DIR": str(watch_root)},
+                clear=False,
+            ), patch.object(self.service, "_same_device", return_value=False):
+                paths = self.service._resolve_storyteller_paths("Auto Book")
+
+            self.assertTrue(paths["cross_device"])
+            self.assertTrue(str(paths["incoming_root"]).startswith(tempfile.gettempdir()))
+            # Clean up the temp dir created by mkdtemp
+            if paths["incoming_root"].exists():
+                shutil.rmtree(paths["incoming_root"])
+
+    def test_prepare_storyteller_stage_permissions_chmods_directories_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            stage_dir = tmp_path / "incoming" / "Auto Book.1234"
+            nested_dir = stage_dir / "nested"
+            nested_dir.mkdir(parents=True, exist_ok=True)
+            file_path = nested_dir / "audio.mp3"
+            file_path.write_bytes(b"audio")
+
+            with patch("src.services.forge_service.os.chmod") as mock_chmod:
+                self.service._prepare_storyteller_stage_permissions(stage_dir)
+
+            chmod_targets = [Path(call.args[0]) for call in mock_chmod.call_args_list]
+            self.assertIn(stage_dir, chmod_targets)
+            self.assertIn(nested_dir, chmod_targets)
+            self.assertNotIn(file_path, chmod_targets)
+
     def test_discover_storyteller_uuid_ignores_fuzzy_non_exact_title_match(self):
         """Forge UUID discovery should not accept unrelated fuzzy Storyteller search hits."""
         st_client = MagicMock()
@@ -239,6 +710,9 @@ class TestForgeService(unittest.TestCase):
         storyteller_alignment_ok: bool = False,
         smil_transcript=None,
         whisper_transcript=None,
+        audio_source: str = None,
+        audio_source_id: str = None,
+        staged_audio: bool = True,
     ):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -258,7 +732,8 @@ class TestForgeService(unittest.TestCase):
             def _copy_audio(_abs_id, dest_path, stage_mode="cleanup"):
                 dest = Path(dest_path)
                 dest.mkdir(parents=True, exist_ok=True)
-                (dest / "part_001.mp3").write_bytes(b"audio")
+                if staged_audio:
+                    (dest / "part_001.mp3").write_bytes(b"audio")
                 return True
 
             self.service._copy_audio_files = MagicMock(side_effect=_copy_audio)
@@ -289,7 +764,7 @@ class TestForgeService(unittest.TestCase):
             self.mock_storyteller.add_to_collection_by_uuid.return_value = True
             self.mock_storyteller.add_to_collection.return_value = True
 
-            def _download_storyteller_book(_uuid, output_path):
+            def _download_storyteller_book(_uuid, output_path, polling=False):
                 output = Path(output_path)
                 output.parent.mkdir(parents=True, exist_ok=True)
                 output.write_bytes(b"artifact")
@@ -312,6 +787,9 @@ class TestForgeService(unittest.TestCase):
             ), patch("src.services.forge_service.time.sleep", return_value=None), patch(
                 "src.services.forge_service.ingest_storyteller_transcripts",
                 return_value=ingest_manifest,
+            ), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": True, "reason": "assets_not_configured"},
             ):
                 self.service._auto_forge_background_task(
                     abs_id="abs-1",
@@ -320,6 +798,8 @@ class TestForgeService(unittest.TestCase):
                     author="Auto Author",
                     original_filename="orig.epub",
                     original_hash="hash123",
+                    audio_source=audio_source,
+                    audio_source_id=audio_source_id,
                     stage_mode=stage_mode,
                 )
 
@@ -378,7 +858,7 @@ class TestForgeService(unittest.TestCase):
             whisper_transcript=[{"start": 0.0, "end": 1.0, "text": "hello"}],
         )
 
-        self.mock_abs.get_audio_files.assert_called_once_with("abs-1")
+        self.mock_abs.get_audio_files.assert_not_called()
         self.mock_transcriber.process_audio.assert_called_once()
         self.mock_alignment.align_and_store.assert_called_once()
 
@@ -420,6 +900,24 @@ class TestForgeService(unittest.TestCase):
 
         mock_cleanup.assert_not_called()
 
+    def test_auto_forge_booklore_hardlink_mode_forwards_to_booklore_staging(self):
+        with patch.object(self.service, "_copy_booklore_audio_files", return_value=True) as mock_copy_booklore, patch.object(
+            self.service, "_copy_audio_files", return_value=True
+        ) as mock_copy_abs:
+            self._run_auto_forge_pipeline(
+                text_item={"source": "Local File"},
+                stage_mode="hardlink",
+                ingest_manifest=None,
+                storyteller_alignment_ok=False,
+                audio_source="BookLore",
+                audio_source_id="bl-1",
+            )
+
+        mock_copy_booklore.assert_called_once()
+        self.assertEqual(mock_copy_booklore.call_args.args[0], "bl-1")
+        self.assertEqual(mock_copy_booklore.call_args.kwargs["stage_mode"], "hardlink")
+        mock_copy_abs.assert_not_called()
+
     def test_poll_auto_forge_completion_api_metadata_does_not_mark_complete(self):
         """Metadata readiness alone should not mark auto-forge complete."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -435,12 +933,16 @@ class TestForgeService(unittest.TestCase):
             }
             st_client.download_book.return_value = False
 
-            with patch.object(self.service, "_find_processed_epub", return_value=None):
+            with patch.object(self.service, "_find_processed_epub", return_value=None), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": True, "reason": "assets_not_configured"},
+            ):
                 result = self.service._poll_auto_forge_completion(
                     st_client=st_client,
                     safe_title="Auto Book",
                     epub_filename="Auto Book.epub",
                     title="Auto Book",
+                    chapters=[],
                     course_dir=course_dir,
                     epub_cache=epub_cache,
                     found_uuid="uuid-1",
@@ -466,12 +968,16 @@ class TestForgeService(unittest.TestCase):
             }
             st_client.download_book.return_value = False
 
-            with patch.object(self.service, "_find_processed_epub", return_value=None):
+            with patch.object(self.service, "_find_processed_epub", return_value=None), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": True, "reason": "assets_not_configured"},
+            ):
                 result = self.service._poll_auto_forge_completion(
                     st_client=st_client,
                     safe_title="Auto Book",
                     epub_filename="Auto Book.epub",
                     title="Auto Book",
+                    chapters=[],
                     course_dir=course_dir,
                     epub_cache=epub_cache,
                     found_uuid="uuid-1",
@@ -498,12 +1004,16 @@ class TestForgeService(unittest.TestCase):
             }
             st_client.download_book.return_value = False
 
-            with patch.object(self.service, "_find_processed_epub", return_value=None):
+            with patch.object(self.service, "_find_processed_epub", return_value=None), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": True, "reason": "assets_not_configured"},
+            ):
                 result = self.service._poll_auto_forge_completion(
                     st_client=st_client,
                     safe_title="Auto Book",
                     epub_filename="Auto Book.epub",
                     title="Auto Book",
+                    chapters=[],
                     course_dir=course_dir,
                     epub_cache=epub_cache,
                     found_uuid="uuid-1",
@@ -513,6 +1023,170 @@ class TestForgeService(unittest.TestCase):
 
             st_client.trigger_processing.assert_called_once_with("uuid-1")
             self.assertTrue(result["processing_triggered"])
+
+    def test_poll_auto_forge_completion_local_readaloud_does_not_mark_complete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            course_dir = tmp_path / "course"
+            course_dir.mkdir(parents=True, exist_ok=True)
+            epub_cache = tmp_path / "epub_cache"
+            epub_cache.mkdir(parents=True, exist_ok=True)
+            local_readaloud = course_dir / "Auto Book (readaloud).epub"
+            local_readaloud.write_bytes(b"artifact")
+
+            st_client = MagicMock()
+            st_client.get_book_details.return_value = {
+                "ebook": {"filepath": "/storyteller/library/Auto Book/Auto Book.epub", "missing": 0},
+                "audiobook": {"filepath": "/storyteller/library/Auto Book", "missing": 0},
+                "readaloud": {"filepath": str(local_readaloud)},
+            }
+            st_client.download_book.return_value = False
+
+            with patch.object(self.service, "_find_processed_epub", return_value=local_readaloud), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": False, "reason": "chapter_set_incomplete"},
+            ):
+                result = self.service._poll_auto_forge_completion(
+                    st_client=st_client,
+                    safe_title="Auto Book",
+                    epub_filename="Auto Book.epub",
+                    title="Auto Book",
+                    chapters=[],
+                    course_dir=course_dir,
+                    epub_cache=epub_cache,
+                    found_uuid="uuid-1",
+                    processing_triggered=True,
+                    poll_count=4,
+                )
+
+            self.assertIsNone(result["completion_method"])
+            self.assertEqual(result["readaloud_path"], local_readaloud)
+
+    def test_poll_auto_forge_completion_api_probe_requires_transcripts_when_assets_configured(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            course_dir = tmp_path / "course"
+            course_dir.mkdir(parents=True, exist_ok=True)
+            epub_cache = tmp_path / "epub_cache"
+            epub_cache.mkdir(parents=True, exist_ok=True)
+
+            st_client = MagicMock()
+            st_client.get_book_details.return_value = {
+                "ebook": {"filepath": "/storyteller/library/Auto Book/Auto Book.epub", "missing": 0},
+                "audiobook": {"filepath": "/storyteller/library/Auto Book", "missing": 0},
+                "readaloud": {"filepath": "/storyteller/library/Auto Book/Auto Book (readaloud).epub"},
+            }
+
+            def _probe_download(_uuid, output_path, polling=False):
+                if polling:
+                    Path(output_path).write_bytes(b"artifact")
+                    return True
+                return False
+
+            st_client.download_book.side_effect = _probe_download
+
+            with patch.object(self.service, "_find_processed_epub", return_value=None), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": False, "reason": "chapter_set_incomplete"},
+            ):
+                result = self.service._poll_auto_forge_completion(
+                    st_client=st_client,
+                    safe_title="Auto Book",
+                    epub_filename="Auto Book.epub",
+                    title="Auto Book",
+                    chapters=[],
+                    course_dir=course_dir,
+                    epub_cache=epub_cache,
+                    found_uuid="uuid-1",
+                    processing_triggered=True,
+                    poll_count=4,
+                )
+
+            self.assertIsNone(result["completion_method"])
+            self.assertIsNotNone(result["probe_download_path"])
+
+    def test_poll_auto_forge_completion_api_probe_marks_complete_when_transcripts_ready(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            course_dir = tmp_path / "course"
+            course_dir.mkdir(parents=True, exist_ok=True)
+            epub_cache = tmp_path / "epub_cache"
+            epub_cache.mkdir(parents=True, exist_ok=True)
+
+            st_client = MagicMock()
+            st_client.get_book_details.return_value = {
+                "ebook": {"filepath": "/storyteller/library/Auto Book/Auto Book.epub", "missing": 0},
+                "audiobook": {"filepath": "/storyteller/library/Auto Book", "missing": 0},
+            }
+
+            def _probe_download(_uuid, output_path, polling=False):
+                if polling:
+                    Path(output_path).write_bytes(b"artifact")
+                    return True
+                return False
+
+            st_client.download_book.side_effect = _probe_download
+
+            with patch.object(self.service, "_find_processed_epub", return_value=None), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": True, "reason": "validated"},
+            ):
+                result = self.service._poll_auto_forge_completion(
+                    st_client=st_client,
+                    safe_title="Auto Book",
+                    epub_filename="Auto Book.epub",
+                    title="Auto Book",
+                    chapters=[],
+                    course_dir=course_dir,
+                    epub_cache=epub_cache,
+                    found_uuid="uuid-1",
+                    processing_triggered=True,
+                    poll_count=4,
+                )
+
+            self.assertEqual(result["completion_method"], "api_download")
+            self.assertTrue(result["probe_download_path"].exists())
+
+    def test_poll_auto_forge_completion_assets_unconfigured_allows_api_probe_completion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            course_dir = tmp_path / "course"
+            course_dir.mkdir(parents=True, exist_ok=True)
+            epub_cache = tmp_path / "epub_cache"
+            epub_cache.mkdir(parents=True, exist_ok=True)
+
+            st_client = MagicMock()
+            st_client.get_book_details.return_value = {
+                "ebook": {"filepath": "/storyteller/library/Auto Book/Auto Book.epub", "missing": 0},
+                "audiobook": {"filepath": "/storyteller/library/Auto Book", "missing": 0},
+            }
+
+            def _probe_download(_uuid, output_path, polling=False):
+                if polling:
+                    Path(output_path).write_bytes(b"artifact")
+                    return True
+                return False
+
+            st_client.download_book.side_effect = _probe_download
+
+            with patch.object(self.service, "_find_processed_epub", return_value=None), patch(
+                "src.services.forge_service.probe_storyteller_transcripts",
+                return_value={"ready": True, "reason": "assets_not_configured"},
+            ):
+                result = self.service._poll_auto_forge_completion(
+                    st_client=st_client,
+                    safe_title="Auto Book",
+                    epub_filename="Auto Book.epub",
+                    title="Auto Book",
+                    chapters=[],
+                    course_dir=course_dir,
+                    epub_cache=epub_cache,
+                    found_uuid="uuid-1",
+                    processing_triggered=True,
+                    poll_count=4,
+                )
+
+            self.assertEqual(result["completion_method"], "api_download")
 
     def test_auto_forge_waits_for_storyteller_processing_readiness_before_trigger(self):
         """Auto-forge should poll readiness instead of triggering immediately on UUID discovery."""
@@ -542,6 +1216,127 @@ class TestForgeService(unittest.TestCase):
 
         self.assertGreaterEqual(self.mock_storyteller.get_book_details.call_count, 3)
         self.mock_storyteller.trigger_processing.assert_called_once_with("uuid-1")
+
+    def test_auto_forge_uses_local_fallback_only_after_confirmed_api_probe_completion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            local_readaloud = Path(tmp) / "confirmed-readaloud.epub"
+            local_readaloud.write_bytes(b"readaloud")
+
+            def _final_download(_uuid, _output_path, polling=False):
+                if polling:
+                    return False
+                raise Exception("not ready")
+
+            self.mock_storyteller.download_book.side_effect = _final_download
+
+            with patch.object(
+                self.service,
+                "_poll_auto_forge_completion",
+                return_value={
+                    "found_uuid": "uuid-1",
+                    "processing_triggered": True,
+                    "readaloud_path": local_readaloud,
+                    "completion_method": "api_download",
+                    "probe_download_path": None,
+                    "api_ready_seen": True,
+                    "transcript_probe": {"ready": True, "reason": "validated"},
+                },
+            ):
+                db_book = self._run_auto_forge_pipeline(
+                    text_item={"source": "Local File"},
+                    ingest_manifest=None,
+                    storyteller_alignment_ok=False,
+                    smil_transcript=[{"start": 0.0, "end": 1.0, "text": "from smil"}],
+                )
+
+        self.assertEqual(db_book.status, "active")
+
+    def test_auto_forge_does_not_use_local_fallback_when_completion_was_never_confirmed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            local_readaloud = Path(tmp) / "unconfirmed-readaloud.epub"
+            local_readaloud.write_bytes(b"readaloud")
+
+            with patch.object(
+                self.service,
+                "_poll_auto_forge_completion",
+                return_value={
+                    "found_uuid": "uuid-1",
+                    "processing_triggered": True,
+                    "readaloud_path": local_readaloud,
+                    "completion_method": None,
+                    "probe_download_path": None,
+                    "api_ready_seen": False,
+                    "transcript_probe": {"ready": False, "reason": "chapter_set_incomplete"},
+                },
+            ), patch.dict(
+                os.environ,
+                {"STORYTELLER_RECOVERY_MAX_WAIT_SECONDS": "0"},
+                clear=False,
+            ):
+                self.service.storyteller_recovery_max_wait_seconds = 0
+                db_book = self._run_auto_forge_pipeline(
+                    text_item={"source": "Local File"},
+                    ingest_manifest=None,
+                    storyteller_alignment_ok=False,
+                    smil_transcript=[],
+                    whisper_transcript=[],
+                )
+
+        self.assertNotEqual(db_book.status, "active")
+        self.mock_transcriber.process_audio.assert_not_called()
+
+    def test_auto_forge_whisper_fallback_prefers_staged_audio(self):
+        self._run_auto_forge_pipeline(
+            text_item={"source": "Local File"},
+            ingest_manifest=None,
+            storyteller_alignment_ok=False,
+            smil_transcript=[],
+            whisper_transcript=[{"start": 0.0, "end": 1.0, "text": "hello"}],
+        )
+
+        audio_inputs = self.mock_transcriber.process_audio.call_args.args[1]
+        self.assertTrue(audio_inputs)
+        self.assertIn("local_path", audio_inputs[0])
+        self.mock_abs.get_audio_files.assert_not_called()
+
+    def test_auto_forge_whisper_fallback_uses_booklore_source_for_booklore_jobs(self):
+        def _copy_booklore(_book_id, dest_path, stage_mode="cleanup"):
+            dest = Path(dest_path)
+            dest.mkdir(parents=True, exist_ok=True)
+            if "whisper_source_audio" in str(dest):
+                (dest / "part_001.m4b").write_bytes(b"audio")
+            return True
+
+        with patch.object(self.service, "_copy_booklore_audio_files", side_effect=_copy_booklore):
+            self._run_auto_forge_pipeline(
+                text_item={"source": "Local File"},
+                ingest_manifest=None,
+                storyteller_alignment_ok=False,
+                smil_transcript=[],
+                whisper_transcript=[{"start": 0.0, "end": 1.0, "text": "hello"}],
+                audio_source="BookLore",
+                audio_source_id="bl-1",
+                staged_audio=False,
+            )
+
+        audio_inputs = self.mock_transcriber.process_audio.call_args.args[1]
+        self.assertTrue(audio_inputs)
+        self.assertIn("local_path", audio_inputs[0])
+        self.mock_abs.get_audio_files.assert_not_called()
+
+    def test_auto_forge_whisper_fallback_uses_abs_audio_for_abs_jobs(self):
+        self.mock_abs.get_audio_files.return_value = [{"stream_url": "http://audio.test/1.mp3", "ext": "mp3"}]
+
+        self._run_auto_forge_pipeline(
+            text_item={"source": "Local File"},
+            ingest_manifest=None,
+            storyteller_alignment_ok=False,
+            smil_transcript=[],
+            whisper_transcript=[{"start": 0.0, "end": 1.0, "text": "hello"}],
+            staged_audio=False,
+        )
+
+        self.mock_abs.get_audio_files.assert_called_once_with("abs-1")
 
 
 if __name__ == '__main__':

--- a/tests/test_match_paths_regression.py
+++ b/tests/test_match_paths_regression.py
@@ -354,6 +354,57 @@ class TestMatchPathsRegression(unittest.TestCase):
             stage_mode="hardlink",
         )
 
+    def test_forge_search_audio_includes_booklore_results(self):
+        self.mock_container.mock_booklore_client.search_audiobooks.return_value = [
+            {
+                "id": "42",
+                "title": "BookLore Audio",
+                "authors": "BookLore Author",
+                "audiobookInfo": {
+                    "tracks": [{"sizeBytes": 1048576}, {"sizeBytes": 1048576}],
+                },
+            }
+        ]
+        self.mock_container.mock_abs_client.get_all_audiobooks.return_value = []
+
+        response = self.client.get("/api/forge/search_audio?q=booklore")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["audio_source"], "BookLore")
+        self.assertEqual(payload[0]["audio_source_id"], "42")
+        self.assertEqual(payload[0]["id"], "booklore:42")
+
+    def test_forge_process_booklore_audio_uses_bridge_key_and_audio_kwargs(self):
+        self.mock_container.mock_booklore_client.get_book_by_id.return_value = {
+            "id": "42",
+            "title": "BookLore Audio",
+            "authors": "BookLore Author",
+        }
+
+        response = self.client.post(
+            "/api/forge/process",
+            json={
+                "abs_id": "booklore:42",
+                "audio_source": "BookLore",
+                "audio_source_id": "42",
+                "text_item": {"source": "Booklore", "booklore_id": "77"},
+                "forge_stage_mode": "hardlink",
+            },
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.mock_container.mock_forge_service.start_manual_forge.assert_called_once_with(
+            "booklore:42",
+            {"source": "Booklore", "booklore_id": "77"},
+            "BookLore Audio",
+            "BookLore Author",
+            audio_source="BookLore",
+            audio_source_id="42",
+            stage_mode="hardlink",
+        )
+
     @patch("src.web_server.get_kosync_id_for_ebook", return_value="hash-forge-booklore")
     def test_match_forge_booklore_uses_bridge_key_identity(self, _mock_kosync):
         response = self.client.post(

--- a/tests/test_trilink.py
+++ b/tests/test_trilink.py
@@ -181,6 +181,75 @@ class TestStorytellerAPIClientDownload(unittest.TestCase):
             self.assertTrue(result)
             self.assertTrue(output_path.exists())
 
+    @patch.dict(os.environ, {
+        'STORYTELLER_API_URL': 'http://test-storyteller:8001',
+        'STORYTELLER_USER': 'testuser',
+        'STORYTELLER_PASSWORD': 'testpass'
+    })
+    def test_download_book_polling_mode_does_not_use_local_fallback(self):
+        from src.api.storyteller_api import StorytellerAPIClient
+
+        client = StorytellerAPIClient()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / 'downloaded.epub'
+            local_readaloud = Path(tmpdir) / 'local-readaloud.epub'
+            local_readaloud.write_bytes(b'local artifact')
+
+            api_response = Mock()
+            api_response.status_code = 404
+            api_response.text = 'could not open readaloud'
+            api_response.__enter__ = Mock(return_value=api_response)
+            api_response.__exit__ = Mock(return_value=False)
+
+            details_response = Mock(status_code=200)
+            details_response.json.return_value = {
+                'readaloud': {'filepath': str(local_readaloud)}
+            }
+
+            with patch.object(client, '_get_fresh_token', return_value='test-token'):
+                with patch.object(client.session, 'get', return_value=api_response):
+                    with patch.object(client, '_make_request', return_value=details_response) as mock_details:
+                        result = client.download_book('test-uuid', output_path, polling=True)
+
+            self.assertFalse(result)
+            self.assertFalse(output_path.exists())
+            mock_details.assert_not_called()
+
+    @patch.dict(os.environ, {
+        'STORYTELLER_API_URL': 'http://test-storyteller:8001',
+        'STORYTELLER_USER': 'testuser',
+        'STORYTELLER_PASSWORD': 'testpass'
+    })
+    def test_download_book_non_polling_mode_can_still_use_local_fallback(self):
+        from src.api.storyteller_api import StorytellerAPIClient
+
+        client = StorytellerAPIClient()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / 'downloaded.epub'
+            local_readaloud = Path(tmpdir) / 'local-readaloud.epub'
+            local_readaloud.write_bytes(b'local artifact')
+
+            api_response = Mock()
+            api_response.status_code = 404
+            api_response.text = 'could not open readaloud'
+            api_response.__enter__ = Mock(return_value=api_response)
+            api_response.__exit__ = Mock(return_value=False)
+
+            details_response = Mock(status_code=200)
+            details_response.json.return_value = {
+                'readaloud': {'filepath': str(local_readaloud)}
+            }
+
+            with patch.object(client, '_get_fresh_token', return_value='test-token'):
+                with patch.object(client.session, 'get', return_value=api_response):
+                    with patch.object(client, '_make_request', return_value=details_response):
+                        result = client.download_book('test-uuid', output_path, polling=False)
+
+            self.assertTrue(result)
+            self.assertTrue(output_path.exists())
+
 
 class TestStorytellerAPIClientCollectionRemoval(unittest.TestCase):
     """Test Storyteller collection removal by UUID."""


### PR DESCRIPTION
…watched root

When the sibling staging directory is cross-device (Docker volume mounts), use a system temp directory instead of falling back to .incoming inside the watched root. Storyteller was scanning .incoming recursively, causing duplicate scan triggers and ENOENT errors during staging.

- Replace child .incoming fallback with tempfile.mkdtemp in _resolve_storyteller_paths
- Add cross_device flag and shutil.copytree reveal path in _reveal_storyteller_stage_dir
- Clean up temp staging root in all success/failure paths
- Update tests for new cross-device staging behavior