### PR TITLE
[Fix] Settings persistence: bool_keys, load_settings, cache headers

### DIFF
--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -35,12 +35,12 @@ ALL_SETTINGS = [
     'TELEGRAM_ENABLED', 'TELEGRAM_BOT_TOKEN', 'TELEGRAM_CHAT_ID', 'TELEGRAM_LOG_LEVEL',
     
     # Shelfmark
-    'SHELFMARK_URL',
+    'SHELFMARK_URL', 'SHELFMARK_ENABLED',
     
     # Sync Behavior
     'SYNC_PERIOD_MINS', 'SYNC_DELTA_ABS_SECONDS', 'SYNC_DELTA_KOSYNC_PERCENT',
     'SYNC_DELTA_BETWEEN_CLIENTS_PERCENT', 'SYNC_DELTA_KOSYNC_WORDS',
-    'XPATH_FALLBACK_TO_PREVIOUS_SEGMENT', 'SYNC_ABS_EBOOK',
+    'XPATH_FALLBACK_TO_PREVIOUS_SEGMENT', 'SYNC_ABS_EBOOK', 'REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT',
     'FUZZY_MATCH_THRESHOLD', 'SUGGESTIONS_ENABLED',
     'INSTANT_SYNC_ENABLED',
     'STORYTELLER_POLL_MODE', 'STORYTELLER_POLL_SECONDS',
@@ -52,7 +52,8 @@ ALL_SETTINGS = [
     'EBOOK_CACHE_SIZE',
     'JOB_MAX_RETRIES', 'JOB_RETRY_DELAY_MINS', 'WHISPER_MODEL',
     'WHISPER_DEVICE', 'WHISPER_COMPUTE_TYPE',
-    'TRANSCRIPTION_PROVIDER', 'DEEPGRAM_API_KEY', 'DEEPGRAM_MODEL', 'WHISPER_CPP_URL'
+    'TRANSCRIPTION_PROVIDER', 'DEEPGRAM_API_KEY', 'DEEPGRAM_MODEL', 'WHISPER_CPP_URL',
+    'SMIL_VALIDATION_THRESHOLD',
 ]
 
 # Default values
@@ -87,6 +88,7 @@ DEFAULT_CONFIG = {
     'KOSYNC_HASH_METHOD': 'content',
     'TELEGRAM_LOG_LEVEL': 'ERROR',
     'SHELFMARK_URL': '',
+    'SHELFMARK_ENABLED': 'false',
     'KOSYNC_ENABLED': 'false',
     'STORYTELLER_ENABLED': 'false',
     'BOOKLORE_ENABLED': 'false',
@@ -101,6 +103,7 @@ DEFAULT_CONFIG = {
     'SUGGESTIONS_ENABLED': 'false',
     'KOSYNC_USE_PERCENTAGE_FROM_SERVER': 'false',
     'SYNC_ABS_EBOOK': 'false',
+    'REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT': 'true',
     'XPATH_FALLBACK_TO_PREVIOUS_SEGMENT': 'false',
     'ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID': 'false',
     'ABS_SOCKET_ENABLED': 'true',
@@ -110,6 +113,7 @@ DEFAULT_CONFIG = {
     'STORYTELLER_POLL_SECONDS': '45',
     'BOOKLORE_POLL_MODE': 'global',
     'BOOKLORE_POLL_SECONDS': '300',
+    'SMIL_VALIDATION_THRESHOLD': '60',
 }
 
 class ConfigLoader:
@@ -167,13 +171,8 @@ class ConfigLoader:
                 # Apply validation or type conversion if needed (mostly string for env vars)
                 val_str = str(value) if value is not None else ""
                 
-                # Preserve existing non-empty env vars when DB value is blank.
-                if val_str != "":
-                    os.environ[key] = val_str
-                else:
-                    existing_env = os.environ.get(key, "")
-                    if not existing_env:
-                        os.environ[key] = ""
+                # DB values always win — if the user cleared a field, honor it
+                os.environ[key] = val_str
                 
                 # Mask secrets in logs
                 log_val = "******" if any(s in key for s in ['KEY', 'PASSWORD', 'TOKEN']) else val_str

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -18,7 +18,7 @@ from urllib.parse import urljoin
 import requests
 import schedule
 from dependency_injector import providers
-from flask import Flask, render_template, render_template_string, request, redirect, url_for, jsonify, session, send_from_directory
+from flask import Flask, render_template, render_template_string, request, redirect, url_for, jsonify, session, send_from_directory, make_response
 
 from src.utils.config_loader import ConfigLoader
 from src.utils.logging_utils import memory_log_handler, LOG_PATH
@@ -1323,6 +1323,7 @@ def settings():
             'ABS_ONLY_SEARCH_IN_ABS_LIBRARY_ID',
             'REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT',
             'INSTANT_SYNC_ENABLED',
+            'SHELFMARK_ENABLED',
         ]
 
         # Current settings in DB
@@ -1414,9 +1415,11 @@ def settings():
     message = session.pop('message', None)
     is_error = session.pop('is_error', False)
 
-    return render_template('settings.html',
+    response = make_response(render_template('settings.html',
                          message=message,
-                         is_error=is_error)
+                         is_error=is_error))
+    response.headers['Cache-Control'] = 'no-store, max-age=0'
+    return response
 
 def get_abs_author(ab):
 


### PR DESCRIPTION
- Add SHELFMARK_ENABLED to bool_keys so it can be toggled off
- load_settings() now honors empty DB values over Docker env vars
- Add SHELFMARK_ENABLED, REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT, SMIL_VALIDATION_THRESHOLD to ALL_SETTINGS/DEFAULT_CONFIG
- Add Cache-Control: no-store to GET /settings to prevent stale pages