### PR TITLE
Dev

### DIFF
--- a/templates/match.html
+++ b/templates/match.html
@@ -1051,6 +1051,10 @@
                 }
             });
             showMatchSubmitFeedback('');
+            const forgeActionInput = document.getElementById('input_forge_action');
+            if (forgeActionInput) {
+                forgeActionInput.remove();
+            }
             validateForm();
         }
 
@@ -1216,6 +1220,15 @@
                 );
                 openForgeStageModal((mode) => {
                     document.getElementById('input_forge_stage_mode').value = mode;
+                    let forgeActionInput = document.getElementById('input_forge_action');
+                    if (!forgeActionInput) {
+                        forgeActionInput = document.createElement('input');
+                        forgeActionInput.type = 'hidden';
+                        forgeActionInput.name = 'action';
+                        forgeActionInput.id = 'input_forge_action';
+                        mappingForm.appendChild(forgeActionInput);
+                    }
+                    forgeActionInput.value = 'forge_match';
                     allowForgeSubmit = true;
                     mappingForm.requestSubmit(forgeBtn);
                 });


### PR DESCRIPTION
Fix] Inject hidden action input so forge_match survives button disable
When the forge stage modal callback calls requestSubmit(forgeBtn),
startMatchSubmitState disables all action buttons including forgeBtn.
A disabled button's name/value is excluded from form submission, so
action=forge_match was never sent and the server fell through to the
standard transcription path.

Fix: inject a hidden <input name="action" value="forge_match"> into the
form before requestSubmit, so the action field is always submitted
regardless of button state. Clear it in restoreMatchPreviewState so it
doesn't leak into a subsequent non-forge submission.
