### PR TITLE
[Feature] Remove chapter-count gating from Storyteller transcript val…

### DIFF
--- a/src/services/alignment_service.py
+++ b/src/services/alignment_service.py
@@ -653,12 +653,14 @@ def _validate_storyteller_chapters(
     transcriptions_dir: Path, expected_count: int
 ) -> tuple[bool, list[str], list[str]]:
     """
-    Validate Storyteller chapter files by expected naming and exact count.
+    Validate Storyteller chapter files by naming pattern and structural validity.
     Accept known source layouts:
       1) 00000-00001 ... 00000-N
       2) 00001-00001 ... 00001-N
       3) 00000-00001, 00001-00001 ... (N-1)-00001
       4) 00001-00001, 00002-00001 ... N-00001
+    Works with whatever matching files are present; does not require the file
+    count to equal expected_count.
     Returns (is_valid, source_filenames, destination_filenames).
     """
     if expected_count <= 0:
@@ -667,7 +669,6 @@ def _validate_storyteller_chapters(
         )
         return False, [], []
 
-    expected_files = [_storyteller_filename_for_abs_chapter(i, "00000") for i in range(expected_count)]
     pattern = re.compile(r"^(\d{5})-(\d{5})\.json$")
     numeric_matches = []
     for p in transcriptions_dir.glob("*.json"):
@@ -675,17 +676,13 @@ def _validate_storyteller_chapters(
         if match:
             numeric_matches.append((p.name, int(match.group(1)), int(match.group(2))))
 
-    if len(numeric_matches) != expected_count:
+    actual_count = len(numeric_matches)
+    if actual_count <= 0:
         all_json = sorted([p.name for p in transcriptions_dir.glob("*.json")])
-        numeric_names = sorted(name for name, _, _ in numeric_matches)
-        first_slot_values = [first for _, first, _ in numeric_matches]
-        second_slot_values = [second for _, _, second in numeric_matches]
         logger.info(
-            "Storyteller validation failed at '%s': expected %d chapter files, found %d matching "
-            "pattern '^\\d{5}-\\d{5}\\.json$' (total json=%d)",
+            "Storyteller validation failed at '%s': no files matching pattern '^\\d{5}-\\d{5}\\.json$' found "
+            "(total json=%d)",
             transcriptions_dir,
-            expected_count,
-            len(numeric_matches),
             len(all_json),
         )
         if all_json:
@@ -696,40 +693,34 @@ def _validate_storyteller_chapters(
                 sample,
                 " ..." if len(all_json) > 10 else "",
             )
-        if numeric_names:
-            numeric_sample = ", ".join(numeric_names[:10])
-            logger.info(
-                "Storyteller validation numeric sample at '%s': %s%s",
-                transcriptions_dir,
-                numeric_sample,
-                " ..." if len(numeric_names) > 10 else "",
-            )
-            logger.info(
-                "Storyteller validation slot ranges at '%s': first_slot=%d..%d second_slot=%d..%d",
-                transcriptions_dir,
-                min(first_slot_values),
-                max(first_slot_values),
-                min(second_slot_values),
-                max(second_slot_values),
-            )
         return False, [], []
+
+    if actual_count != expected_count:
+        logger.info(
+            "Storyteller validation at '%s': found %d files, expected %d — proceeding with found count",
+            transcriptions_dir,
+            actual_count,
+            expected_count,
+        )
+
+    dest_files = [_storyteller_filename_for_abs_chapter(i, "00000") for i in range(actual_count)]
 
     candidate_layouts: list[tuple[str, list[str]]] = [
         (
             "prefix_00000",
-            [f"00000-{i + 1:05d}.json" for i in range(expected_count)],
+            [f"00000-{i + 1:05d}.json" for i in range(actual_count)],
         ),
         (
             "prefix_00001",
-            [f"00001-{i + 1:05d}.json" for i in range(expected_count)],
+            [f"00001-{i + 1:05d}.json" for i in range(actual_count)],
         ),
         (
             "chapter_first_zero_based",
-            [f"{i:05d}-00001.json" for i in range(expected_count)],
+            [f"{i:05d}-00001.json" for i in range(actual_count)],
         ),
         (
             "chapter_first_one_based",
-            [f"{i + 1:05d}-00001.json" for i in range(expected_count)],
+            [f"{i + 1:05d}-00001.json" for i in range(actual_count)],
         ),
     ]
 
@@ -741,7 +732,7 @@ def _validate_storyteller_chapters(
             if not _is_storyteller_wordtimeline_chapter(transcriptions_dir / name)
         ]
         if not invalid_files:
-            return True, source_files, expected_files
+            return True, source_files, dest_files
         logger.info(
             "Storyteller validation failed at '%s': layout '%s' has %d chapter file(s) without storyteller "
             "timeline format ('wordTimeline' or 'timeline'); first invalid='%s'",
@@ -756,9 +747,9 @@ def _validate_storyteller_chapters(
     first_slot_values = [first for _, first, _ in numeric_matches]
     second_slot_values = [second for _, _, second in numeric_matches]
     logger.info(
-        "Storyteller validation failed at '%s': no supported filename layout matched expected_count=%d",
+        "Storyteller validation failed at '%s': no supported filename layout matched actual_count=%d",
         transcriptions_dir,
-        expected_count,
+        actual_count,
     )
     if all_json:
         sample = ", ".join(all_json[:10])
@@ -835,6 +826,7 @@ def probe_storyteller_transcripts(
         "source_files": [],
         "expected_files": [],
         "chapterless_mode": False,
+        "audio_aligned": False,
     }
 
     assets_dir_raw = os.environ.get("STORYTELLER_ASSETS_DIR", "").strip()
@@ -914,6 +906,8 @@ def probe_storyteller_transcripts(
 
     result["ready"] = True
     result["reason"] = "validated"
+    if len(source_files) != expected_count:
+        result["audio_aligned"] = True
     return result
 
 
@@ -956,11 +950,17 @@ def ingest_storyteller_transcripts(
     source_files = probe["source_files"]
     expected_files = probe["expected_files"]
     chapterless_mode = probe["chapterless_mode"]
+    audio_aligned = probe.get("audio_aligned", False)
 
     if chapterless_mode:
         logger.info(
             f"Storyteller ingest chapterless mode for '{abs_id}': deriving {expected_count} chapters from "
             f"'{transcriptions_dir}'"
+        )
+    elif audio_aligned:
+        logger.info(
+            f"Storyteller ingest audio_aligned mode for '{abs_id}': file count ({len(source_files)}) differs "
+            f"from ABS chapter count ({len(chapter_list)}), deriving timing from file contents"
         )
 
     data_dir = Path(os.environ.get("DATA_DIR", "/data"))
@@ -999,7 +999,7 @@ def ingest_storyteller_transcripts(
         )
 
     chapter_entries = []
-    if chapterless_mode:
+    if chapterless_mode or audio_aligned:
         cumulative_start = 0.0
         for idx, chapter_file_name in enumerate(expected_files):
             chapter_file_path = target_dir / chapter_file_name

--- a/tests/test_alignment_service.py
+++ b/tests/test_alignment_service.py
@@ -146,13 +146,15 @@ def test_probe_storyteller_transcripts_logs_search_root_and_available_dirs_on_ti
     assert "The Fellowship of the Ring" in caplog.text
 
 
-def test_probe_storyteller_transcripts_returns_not_ready_when_chapter_files_incomplete():
+def test_probe_storyteller_transcripts_accepts_count_mismatch_with_audio_aligned():
+    # 1 valid file with 2 ABS chapters — validation now accepts the found count
+    # and flags audio_aligned=True so ingest derives timing from file contents.
     with tempfile.TemporaryDirectory() as tmp:
         assets_root = Path(tmp)
         transcriptions_dir = assets_root / "assets" / "Auto Book" / "transcriptions"
         transcriptions_dir.mkdir(parents=True, exist_ok=True)
         (transcriptions_dir / "00000-00001.json").write_text(
-            json.dumps({"transcript": "hello", "wordTimeline": []}),
+            json.dumps({"transcript": "hello", "wordTimeline": [{"endTime": 5.0}]}),
             encoding="utf-8",
         )
 
@@ -163,8 +165,9 @@ def test_probe_storyteller_transcripts_returns_not_ready_when_chapter_files_inco
                 [{"start": 0.0, "end": 1.0}, {"start": 1.0, "end": 2.0}],
             )
 
-    assert result["ready"] is False
-    assert result["reason"] == "chapter_set_incomplete"
+    assert result["ready"] is True
+    assert result["reason"] == "validated"
+    assert result["audio_aligned"] is True
 
 
 def test_probe_storyteller_transcripts_returns_ready_when_validated():

--- a/tests/test_storyteller_transcript.py
+++ b/tests/test_storyteller_transcript.py
@@ -129,7 +129,9 @@ def test_storyteller_validation_accepts_chapter_first_one_based(tmp_path):
     assert destination_files == ["00000-00001.json", "00000-00002.json"]
 
 
-def test_storyteller_validation_rejects_count_mismatch(tmp_path):
+def test_storyteller_validation_accepts_count_mismatch(tmp_path):
+    # 3 valid files with expected_count=2 — the count check is removed;
+    # validation works with the actual file count.
     transcriptions_dir = tmp_path / "transcriptions_count_mismatch"
     transcriptions_dir.mkdir(parents=True, exist_ok=True)
     _write_wordtimeline_file(transcriptions_dir, "00001-00001.json")
@@ -137,9 +139,9 @@ def test_storyteller_validation_rejects_count_mismatch(tmp_path):
     _write_wordtimeline_file(transcriptions_dir, "00003-00001.json")
 
     is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 2)
-    assert is_valid is False
-    assert source_files == []
-    assert destination_files == []
+    assert is_valid is True
+    assert source_files == ["00001-00001.json", "00002-00001.json", "00003-00001.json"]
+    assert destination_files == ["00000-00001.json", "00000-00002.json", "00000-00003.json"]
 
 
 def test_storyteller_validation_rejects_non_wordtimeline_format(tmp_path):


### PR DESCRIPTION
…idation

_validate_storyteller_chapters no longer rejects files when the file count differs from expected_count. It now works with whatever valid ^\d{5}-\d{5}\.json$ files are present, builds candidate layouts from the actual file count, and returns destination names sized to match.

probe_storyteller_transcripts gains an audio_aligned flag (True when the accepted file count differs from the ABS chapter count), so callers can distinguish count-mismatch cases from chapterless mode.

ingest_storyteller_transcripts uses the cumulative-duration path when audio_aligned is True, deriving chapter start/end times from each file's wordTimeline rather than ABS chapter boundaries — identical to the existing chapterless_mode path.

Tests updated accordingly: the count-mismatch test now asserts acceptance rather than rejection, and the probe test for a partial file set now asserts ready=True with audio_aligned=True.

https://claude.ai/code/session_01My5THhhZKFzQCoaSnk2oxM