### PR TITLE
[Simplify] Remove polling probe and count expectation from Storytelle…

### DIFF
--- a/src/services/alignment_service.py
+++ b/src/services/alignment_service.py
@@ -650,7 +650,7 @@ def _is_storyteller_wordtimeline_chapter(chapter_path: Path) -> bool:
 
 
 def _validate_storyteller_chapters(
-    transcriptions_dir: Path, expected_count: int
+    transcriptions_dir: Path,
 ) -> tuple[bool, list[str], list[str]]:
     """
     Validate Storyteller chapter files by naming pattern and structural validity.
@@ -659,16 +659,9 @@ def _validate_storyteller_chapters(
       2) 00001-00001 ... 00001-N
       3) 00000-00001, 00001-00001 ... (N-1)-00001
       4) 00001-00001, 00002-00001 ... N-00001
-    Works with whatever matching files are present; does not require the file
-    count to equal expected_count.
+    Works with whatever valid files are present — no count expectation.
     Returns (is_valid, source_filenames, destination_filenames).
     """
-    if expected_count <= 0:
-        logger.info(
-            f"Storyteller validation failed at '{transcriptions_dir}': expected_count={expected_count} (must be > 0)"
-        )
-        return False, [], []
-
     pattern = re.compile(r"^(\d{5})-(\d{5})\.json$")
     numeric_matches = []
     for p in transcriptions_dir.glob("*.json"):
@@ -694,14 +687,6 @@ def _validate_storyteller_chapters(
                 " ..." if len(all_json) > 10 else "",
             )
         return False, [], []
-
-    if actual_count != expected_count:
-        logger.info(
-            "Storyteller validation at '%s': found %d files, expected %d — proceeding with found count",
-            transcriptions_dir,
-            actual_count,
-            expected_count,
-        )
 
     dest_files = [_storyteller_filename_for_abs_chapter(i, "00000") for i in range(actual_count)]
 
@@ -884,20 +869,15 @@ def probe_storyteller_transcripts(
     numeric_files = [p.name for p in transcriptions_dir.glob("*.json") if numeric_pattern.match(p.name)]
     result["found_count"] = len(numeric_files)
 
-    expected_count = len(chapter_list)
-    chapterless_mode = expected_count <= 0
+    chapterless_mode = len(chapter_list) <= 0
     result["chapterless_mode"] = chapterless_mode
-    if chapterless_mode:
-        expected_count = len(numeric_files)
-        if expected_count <= 0:
-            result["reason"] = "chapter_set_incomplete"
-            return result
+    if chapterless_mode and len(numeric_files) <= 0:
+        result["reason"] = "chapter_set_incomplete"
+        return result
 
-    result["expected_count"] = expected_count
+    result["expected_count"] = len(chapter_list) if not chapterless_mode else len(numeric_files)
 
-    is_valid, source_files, expected_files = _validate_storyteller_chapters(
-        transcriptions_dir, expected_count
-    )
+    is_valid, source_files, expected_files = _validate_storyteller_chapters(transcriptions_dir)
     result["source_files"] = source_files
     result["expected_files"] = expected_files
     if not is_valid:
@@ -906,7 +886,7 @@ def probe_storyteller_transcripts(
 
     result["ready"] = True
     result["reason"] = "validated"
-    if len(source_files) != expected_count:
+    if not chapterless_mode and len(source_files) != len(chapter_list):
         result["audio_aligned"] = True
     return result
 

--- a/src/services/forge_service.py
+++ b/src/services/forge_service.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from urllib.parse import urljoin
 import requests
 
-from src.services.alignment_service import ingest_storyteller_transcripts, probe_storyteller_transcripts
+from src.services.alignment_service import ingest_storyteller_transcripts
 from src.utils.storyteller_transcript import StorytellerTranscript
 
 logger = logging.getLogger(__name__)
@@ -314,12 +314,6 @@ class ForgeService:
             st_client, book_uuid
         )
         readaloud_state = self._normalize_storyteller_readaloud_state(details)
-        transcript_probe = probe_storyteller_transcripts(
-            title,
-            chapters,
-            storyteller_title=details.get("title") if isinstance(details, dict) else None,
-        )
-        transcripts_ready = bool(transcript_probe.get("ready"))
 
         if not processing_triggered and processing_ready:
             try:
@@ -331,12 +325,6 @@ class ForgeService:
             logger.debug(
                 f"Auto-Forge: delaying processing trigger for {book_uuid} "
                 f"(Storyteller state={processing_state})"
-            )
-
-        if not transcripts_ready and transcript_probe.get("reason") != "assets_not_configured" and poll_count % 4 == 0:
-            logger.info(
-                "Auto-Forge: Transcript assets not ready yet (reason=%s)",
-                transcript_probe.get("reason"),
             )
 
         if readaloud_state["errored"]:
@@ -352,19 +340,17 @@ class ForgeService:
         elif poll_count % 4 == 0:
             logger.info(
                 "Auto-Forge: waiting for Storyteller alignment for %s "
-                "(status=%s stage=%s progress=%s alignedAt=%s transcript_reason=%s)",
+                "(status=%s stage=%s progress=%s alignedAt=%s)",
                 book_uuid,
                 readaloud_state["status"],
                 readaloud_state["current_stage"],
                 readaloud_state["stage_progress"],
                 readaloud_state["aligned_at"],
-                transcript_probe.get("reason"),
             )
 
         return {
             "processing_triggered": processing_triggered,
             "completion_method": completion_method,
-            "transcript_probe": transcript_probe,
             "readaloud_status": readaloud_state["status"],
             "aligned_at": readaloud_state["aligned_at"],
             "terminal_error": readaloud_state["errored"],
@@ -1163,7 +1149,6 @@ class ForgeService:
             elapsed = 0
             poll_count = 0
             completion_method = None
-            transcript_probe = probe_storyteller_transcripts(title, chapters)
             last_readaloud_status = None
             last_aligned_at = None
             storyteller_title = None
@@ -1187,7 +1172,6 @@ class ForgeService:
                     poll_count=poll_count,
                 )
                 processing_triggered = poll_result["processing_triggered"]
-                transcript_probe = poll_result["transcript_probe"]
                 completion_method = poll_result["completion_method"]
                 last_readaloud_status = poll_result["readaloud_status"]
                 last_aligned_at = poll_result["aligned_at"]
@@ -1215,8 +1199,6 @@ class ForgeService:
                     timeout_reason.append(f"readaloud_{last_readaloud_status}")
                 else:
                     timeout_reason.append("readaloud_unknown")
-                if transcript_probe and not transcript_probe.get("ready"):
-                    timeout_reason.append(f"transcripts_{transcript_probe.get('reason')}")
                 reason_str = ",".join(timeout_reason) if timeout_reason else "unknown"
 
                 logger.warning(
@@ -1248,7 +1230,6 @@ class ForgeService:
                         poll_count=poll_count,
                     )
                     processing_triggered = poll_result["processing_triggered"]
-                    transcript_probe = poll_result["transcript_probe"]
                     completion_method = poll_result["completion_method"]
                     last_readaloud_status = poll_result["readaloud_status"]
                     last_aligned_at = poll_result["aligned_at"]
@@ -1275,18 +1256,7 @@ class ForgeService:
                     )
                     return
 
-            completion_msg = f"Auto-Forge: Completion confirmed via {completion_method}"
-            if transcript_probe.get("reason") == "validated":
-                completion_msg += " + validated_transcripts"
-            logger.info(completion_msg)
-            if transcript_probe and not transcript_probe.get("ready"):
-                logger.warning(
-                    "Auto-Forge: proceeding without validated Storyteller transcript assets "
-                    "(reason=%s expected=%s found=%s)",
-                    transcript_probe.get("reason"),
-                    transcript_probe.get("expected_count"),
-                    transcript_probe.get("found_count"),
-                )
+            logger.info("Auto-Forge: Completion confirmed via %s", completion_method)
 
             # Grace wait before download to let Storyteller finish internal writes.
             if self.storyteller_cleanup_grace_seconds > 0:

--- a/tests/test_forge_service.py
+++ b/tests/test_forge_service.py
@@ -610,12 +610,6 @@ class TestForgeService(unittest.TestCase):
                             return_value=ingest_manifest,
                         )
                     )
-                stack.enter_context(
-                    patch(
-                        "src.services.forge_service.probe_storyteller_transcripts",
-                        return_value={"ready": True, "reason": "assets_not_configured"},
-                    )
-                )
                 self.service._auto_forge_background_task(
                     abs_id="abs-1",
                     text_item=text_item,
@@ -756,19 +750,15 @@ class TestForgeService(unittest.TestCase):
                 "readaloud": {"filepath": "/storyteller/output/readaloud.epub"}
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": True, "reason": "assets_not_configured"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=True,
-                    poll_count=1,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=True,
+                poll_count=1,
+            )
 
             self.assertIsNone(result["completion_method"])
             self.assertIsNone(result["readaloud_status"])
@@ -787,19 +777,15 @@ class TestForgeService(unittest.TestCase):
                 "ebook": {"filepath": "/storyteller/library/Auto Book/Auto Book.epub", "missing": 0}
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": True, "reason": "assets_not_configured"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=False,
-                    poll_count=4,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=False,
+                poll_count=4,
+            )
 
             st_client.trigger_processing.assert_not_called()
             self.assertFalse(result["processing_triggered"])
@@ -817,19 +803,15 @@ class TestForgeService(unittest.TestCase):
                 "audiobook": {"filepath": "/storyteller/library/Auto Book", "missing": 0},
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": True, "reason": "assets_not_configured"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=False,
-                    poll_count=4,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=False,
+                poll_count=4,
+            )
 
             st_client.trigger_processing.assert_called_once_with("uuid-1")
             self.assertTrue(result["processing_triggered"])
@@ -854,19 +836,15 @@ class TestForgeService(unittest.TestCase):
                 "alignedAt": "2026-03-25T17:28:56.000Z",
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": False, "reason": "chapter_set_incomplete"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=True,
-                    poll_count=4,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=True,
+                poll_count=4,
+            )
 
             self.assertEqual(result["completion_method"], "storyteller_aligned")
             self.assertEqual(result["readaloud_status"], "ALIGNED")
@@ -891,19 +869,15 @@ class TestForgeService(unittest.TestCase):
                 },
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": True, "reason": "validated"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=True,
-                    poll_count=4,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=True,
+                poll_count=4,
+            )
 
             self.assertIsNone(result["completion_method"])
             self.assertEqual(result["readaloud_status"], "ALIGNED")
@@ -928,19 +902,15 @@ class TestForgeService(unittest.TestCase):
                 },
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": False, "reason": "chapter_set_incomplete"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=True,
-                    poll_count=4,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=True,
+                poll_count=4,
+            )
 
             self.assertIsNone(result["completion_method"])
             self.assertEqual(result["readaloud_status"], "ERROR")
@@ -966,19 +936,15 @@ class TestForgeService(unittest.TestCase):
                 "alignedAt": "2026-03-25T17:28:56.000Z",
             }
 
-            with patch(
-                "src.services.forge_service.probe_storyteller_transcripts",
-                return_value={"ready": False, "reason": "chapter_set_incomplete"},
-            ):
-                result = self.service._poll_auto_forge_completion(
-                    st_client=st_client,
-                    book_uuid="uuid-1",
-                    title="Auto Book",
-                    chapters=[],
-                    epub_cache=epub_cache,
-                    processing_triggered=True,
-                    poll_count=4,
-                )
+            result = self.service._poll_auto_forge_completion(
+                st_client=st_client,
+                book_uuid="uuid-1",
+                title="Auto Book",
+                chapters=[],
+                epub_cache=epub_cache,
+                processing_triggered=True,
+                poll_count=4,
+            )
 
             self.assertIsNone(result["completion_method"])
             self.assertEqual(result["readaloud_status"], "PROCESSING")
@@ -1040,7 +1006,6 @@ class TestForgeService(unittest.TestCase):
             return_value={
                 "processing_triggered": True,
                 "completion_method": None,
-                "transcript_probe": {"ready": False, "reason": "chapter_set_incomplete"},
                 "readaloud_status": "PROCESSING",
                 "aligned_at": None,
                 "terminal_error": False,
@@ -1070,7 +1035,6 @@ class TestForgeService(unittest.TestCase):
             return_value={
                 "processing_triggered": True,
                 "completion_method": None,
-                "transcript_probe": {"ready": False, "reason": "chapter_set_incomplete"},
                 "readaloud_status": "ERROR",
                 "aligned_at": None,
                 "terminal_error": True,

--- a/tests/test_storyteller_transcript.py
+++ b/tests/test_storyteller_transcript.py
@@ -86,7 +86,7 @@ def test_storyteller_validation_accepts_00000_prefix(tmp_path):
     _write_wordtimeline_file(transcriptions_dir, "00000-00001.json")
     _write_wordtimeline_file(transcriptions_dir, "00000-00002.json")
 
-    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 2)
+    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir)
     assert is_valid is True
     assert source_files == ["00000-00001.json", "00000-00002.json"]
     assert destination_files == ["00000-00001.json", "00000-00002.json"]
@@ -99,7 +99,7 @@ def test_storyteller_validation_accepts_00001_prefix(tmp_path):
     for idx in range(2):
         _write_wordtimeline_file(transcriptions_dir, f"00001-{idx + 1:05d}.json")
 
-    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 2)
+    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir)
     assert is_valid is True
     assert source_files == ["00001-00001.json", "00001-00002.json"]
     assert destination_files == ["00000-00001.json", "00000-00002.json"]
@@ -111,7 +111,7 @@ def test_storyteller_validation_accepts_chapter_first_zero_based(tmp_path):
     _write_wordtimeline_file(transcriptions_dir, "00000-00001.json")
     _write_wordtimeline_file(transcriptions_dir, "00001-00001.json")
 
-    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 2)
+    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir)
     assert is_valid is True
     assert source_files == ["00000-00001.json", "00001-00001.json"]
     assert destination_files == ["00000-00001.json", "00000-00002.json"]
@@ -123,22 +123,21 @@ def test_storyteller_validation_accepts_chapter_first_one_based(tmp_path):
     _write_wordtimeline_file(transcriptions_dir, "00001-00001.json")
     _write_wordtimeline_file(transcriptions_dir, "00002-00001.json")
 
-    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 2)
+    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir)
     assert is_valid is True
     assert source_files == ["00001-00001.json", "00002-00001.json"]
     assert destination_files == ["00000-00001.json", "00000-00002.json"]
 
 
-def test_storyteller_validation_accepts_count_mismatch(tmp_path):
-    # 3 valid files with expected_count=2 — the count check is removed;
-    # validation works with the actual file count.
+def test_storyteller_validation_accepts_any_count(tmp_path):
+    # 3 valid files — validation has no count expectation, works with whatever is present.
     transcriptions_dir = tmp_path / "transcriptions_count_mismatch"
     transcriptions_dir.mkdir(parents=True, exist_ok=True)
     _write_wordtimeline_file(transcriptions_dir, "00001-00001.json")
     _write_wordtimeline_file(transcriptions_dir, "00002-00001.json")
     _write_wordtimeline_file(transcriptions_dir, "00003-00001.json")
 
-    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 2)
+    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir)
     assert is_valid is True
     assert source_files == ["00001-00001.json", "00002-00001.json", "00003-00001.json"]
     assert destination_files == ["00000-00001.json", "00000-00002.json", "00000-00003.json"]
@@ -151,7 +150,7 @@ def test_storyteller_validation_rejects_non_wordtimeline_format(tmp_path):
     segment_like = [{"start": 0.0, "end": 1.0, "text": "hello"}]
     (transcriptions_dir / "00001-00001.json").write_text(json.dumps(segment_like), encoding="utf-8")
 
-    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir, 1)
+    is_valid, source_files, destination_files = _validate_storyteller_chapters(transcriptions_dir)
     assert is_valid is False
     assert source_files == []
     assert destination_files == []


### PR DESCRIPTION
…r validation

_validate_storyteller_chapters no longer takes an expected_count parameter. It finds whatever valid ^\d{5}-\d{5}\.json$ files exist, detects their naming layout, verifies structural validity (wordTimeline/timeline), and returns the set. No count comparison at all.

probe_storyteller_transcripts calls the simplified validation with no count argument. The audio_aligned flag is set when the found file count differs from the chapter list length, so ingest knows to derive timing from file contents via cumulative-duration. The chapterless guard remains for the empty-chapter-list + no-files case.

_poll_auto_forge_completion no longer calls probe_storyteller_transcripts. The polling loop gates only on readaloud.status from the Storyteller API. The probe-at-ingest (ingest_storyteller_transcripts) remains the single point where files are located and collected, called after the loop confirms ALIGNED status.

probe_storyteller_transcripts import removed from forge_service.py. Test mocks for probe_storyteller_transcripts removed from forge_service tests; poll tests unwrapped to call _poll_auto_forge_completion directly.

https://claude.ai/code/session_01My5THhhZKFzQCoaSnk2oxM