### PR TITLE
feat: Add CWA reading progress sync client

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,9 +131,22 @@ Advanced Grimmory cache tuning:
 | Setting | Env Var | Default | Notes |
 | --- | --- | --- | --- |
 | Enable | `CWA_ENABLED` | `false` | Turns on OPDS / CWA ebook search and download. |
-| Server URL | `CWA_SERVER` | empty | CWA base URL. |
-| Username | `CWA_USERNAME` | empty | Optional username. |
-| Password | `CWA_PASSWORD` | empty | Optional password. |
+| Server URL | `CWA_SERVER` | empty | CWA base URL (shared with CWA Sync below). |
+| Username | `CWA_USERNAME` | empty | Optional username for OPDS access. |
+| Password | `CWA_PASSWORD` | empty | Optional password for OPDS access. |
+
+#### CWA Sync
+
+Bidirectional reading progress sync with Calibre-Web Automated. Enables syncing between Audiobookshelf and any device that syncs with CWA (e.g., stock Kobo e-readers). Uses CWA's Kobo sync protocol internally.
+
+| Setting | Env Var | Default | Notes |
+| --- | --- | --- | --- |
+| Enable | `CWA_SYNC_ENABLED` | `false` | Turns on CWA progress sync. |
+| Auth Token | `CWA_SYNC_TOKEN` | empty | Token from CWA's Kobo sync settings page. |
+| Poll Mode | `CWA_SYNC_POLL_MODE` | `global` | `global` uses the main poll interval; `custom` uses the value below. |
+| Poll Interval | `CWA_SYNC_POLL_SECONDS` | `300` | Seconds between polls (when poll mode is `custom`). |
+
+**Setup:** Configure CWA (above) first with the server URL. Then enable CWA Sync and paste the auth token from your CWA user's Kobo sync settings page (`/kobo_auth`). Use "Test Connection" in the settings UI to verify.
 
 #### Hardcover.app
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 
 **ABS-KoSync Enhanced** is a self-hosted sync engine for audiobooks and ebooks. It keeps your reading and listening position aligned across multiple apps, whether the source is Audiobookshelf, Grimmory, KOReader, or Storyteller.
 
-### Five-Way Synchronization
+### Six-Way Synchronization
 
 | Platform | Type | Capability |
 | :--- | :--- | :--- |
@@ -25,6 +25,7 @@
 | **KOReader / KOSync** | Ebooks | Full read/write sync |
 | **Storyteller** | Read-along reader | Full read/write sync |
 | **Grimmory** | Ebooks + audiobooks | Full read/write sync |
+| **CWA (Calibre-Web Automated)** | Ebooks (Kobo e-readers) | Full read/write sync |
 | **Hardcover.app** | Reading tracker | Write-only tracking |
 
 ---

--- a/src/api/cwa_client.py
+++ b/src/api/cwa_client.py
@@ -1,4 +1,5 @@
 import os
+import re
 import requests
 import logging
 import base64
@@ -13,12 +14,13 @@ class CWAClient:
         raw_url = os.environ.get("CWA_SERVER", "").rstrip('/')
         if raw_url.endswith('/opds'):
             raw_url = raw_url[:-5]
-        
+
         # Ensure scheme is present (case-insensitive check)
         if raw_url and not raw_url.lower().startswith(('http://', 'https://')):
             raw_url = f"http://{raw_url}"
-            
+
         self.base_url = raw_url
+        self._uuid_cache: dict[str, str] = {}
         
         # Sanitize credentials (strip whitespace)
         self.username = os.environ.get("CWA_USERNAME", "").strip()
@@ -268,14 +270,13 @@ class CWAClient:
 
                     # Extract ID from entry (OPDS uses atom:id)
                     entry_id = None
-                    import re
 
                     # 1. Try to extract ID from links (Most reliable for Calibre-Web)
                     # Look for /opds/book/123 or /books/123 in any link
                     for link in entry.findall('atom:link', namespaces):
                         href = link.get('href', '')
-                        # Regex matches /book/123 or /books/123 anywhere in the path
-                        id_match = re.search(r'/(?:book|books)/(\d+)', href)
+                        # Regex matches /book/123, /books/123, or /download/123 anywhere in the path
+                        id_match = re.search(r'/(?:book|books|download)/(\d+)', href)
                         if id_match:
                             entry_id = id_match.group(1)
                             break
@@ -365,21 +366,80 @@ class CWAClient:
             logger.info(f"⬇️ CWA: Downloading ebook from {download_url}")
             # Clear cookies manually for download too
             self.session.cookies.clear()
-            
+
             with self.session.get(download_url, stream=True, timeout=120) as r:
                 r.raise_for_status()
                 with open(output_path, 'wb') as f:
                     for chunk in r.iter_content(chunk_size=8192):
                         f.write(chunk)
-            
+
             # Verify file size
             if os.path.getsize(output_path) < 1024:
                 logger.warning(f"⚠️ Downloaded file is too small ({os.path.getsize(output_path)} bytes), likely failed")
                 return False
-                
+
             return True
         except Exception as e:
             logger.error(f"❌ CWA Download failed: {e}")
             if os.path.exists(output_path):
                 os.remove(output_path)
             return False
+
+    def get_book_uuid(self, calibre_id: str) -> str | None:
+        """
+        Resolve a Calibre book ID or title to its UUID via OPDS search.
+        Results are cached in memory to avoid repeated lookups.
+        Uses the OPDS search endpoint (which works with auth) and extracts
+        the UUID from the atom:id field (urn:uuid:...).
+        """
+        if calibre_id in self._uuid_cache:
+            return self._uuid_cache[calibre_id]
+
+        if not self.is_configured():
+            return None
+
+        try:
+            # Use OPDS search — works with auth and returns atom:id with UUID
+            query = calibre_id
+            template = self._get_search_template()
+            if not template:
+                logger.warning(f"⚠️ CWA: No search template for UUID lookup of '{calibre_id}'")
+                return None
+
+            safe_query = quote(query)
+            search_url = template.replace("{searchTerms}", safe_query)
+            r = self._make_request(search_url, timeout=10)
+            if r.status_code != 200:
+                logger.warning(f"⚠️ CWA UUID lookup failed for '{calibre_id}': HTTP {r.status_code}")
+                return None
+
+            root = ET.fromstring(r.text)
+            ns = {'atom': 'http://www.w3.org/2005/Atom'}
+
+            for entry in root.findall('atom:entry', ns):
+                title_elem = entry.find('atom:title', ns)
+                title = title_elem.text if title_elem is not None else ""
+
+                # For non-numeric IDs (titles), prefer exact match
+                if not calibre_id.isdigit() and title.lower() != calibre_id.lower():
+                    continue
+
+                id_elem = entry.find('atom:id', ns)
+                if id_elem is not None and id_elem.text:
+                    uuid_match = re.search(
+                        r'([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
+                        id_elem.text, re.IGNORECASE,
+                    )
+                    if uuid_match:
+                        uuid = uuid_match.group(1)
+                        self._uuid_cache[calibre_id] = uuid
+                        logger.debug(f"📖 CWA: Resolved '{calibre_id}' -> UUID {uuid}")
+                        return uuid
+
+            logger.warning(f"⚠️ CWA: No UUID found for '{calibre_id}'")
+            self._uuid_cache[calibre_id] = None  # negative cache
+            return None
+
+        except Exception as e:
+            logger.error(f"❌ CWA UUID resolution error for '{calibre_id}': {e}")
+            return None

--- a/src/api/cwa_sync_api.py
+++ b/src/api/cwa_sync_api.py
@@ -1,0 +1,140 @@
+"""
+CWA Sync API client — reads and writes reading progress via
+Calibre-Web Automated's Kobo sync endpoints.
+"""
+
+import os
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Kobo reading status constants (per Kobo API protocol)
+STATUS_READING = "Reading"
+STATUS_FINISHED = "Finished"
+STATUS_READY = "ReadyToRead"
+
+
+class CWASyncApi:
+    def __init__(self, cwa_client=None):
+        self._cwa_client = cwa_client
+        self._session = requests.Session()
+        self._session.headers.update({"Content-Type": "application/json"})
+        self._timeout = 15
+
+        # Snapshot config at init (matches CWAClient pattern)
+        self._server = (cwa_client.base_url if cwa_client else
+                        os.environ.get("CWA_SERVER", "").rstrip("/"))
+        self._token = os.environ.get("CWA_SYNC_TOKEN", "").strip()
+        self._enabled = os.environ.get("CWA_SYNC_ENABLED", "").lower() == "true"
+
+    @property
+    def _base_url(self) -> str:
+        return f"{self._server}/kobo/{self._token}/v1"
+
+    def is_configured(self) -> bool:
+        return self._enabled and bool(self._server) and bool(self._token)
+
+    def check_connection(self) -> bool:
+        if not self.is_configured():
+            logger.warning("⚠️ CWA Sync not configured (skipping)")
+            return False
+
+        try:
+            url = f"{self._base_url}/initialization"
+            r = self._session.get(url, timeout=5)
+            if r.status_code == 200:
+                logger.info(f"✅ Connected to CWA sync at {self._server}")
+                return True
+            elif r.status_code in [401, 403]:
+                logger.error(f"❌ CWA Sync auth failed: {r.status_code}. Check auth token.")
+                return False
+            else:
+                logger.error(f"❌ CWA Sync connection failed: {r.status_code}")
+                return False
+        except Exception as e:
+            logger.error(f"❌ CWA Sync connection error: {e}")
+            return False
+
+    def get_reading_state(self, book_uuid: str) -> dict | None:
+        """Returns dict with progress_percent (0-1), status, href, frag; or None."""
+        if not self.is_configured():
+            return None
+
+        try:
+            url = f"{self._base_url}/library/{book_uuid}/state"
+            r = self._session.get(url, timeout=self._timeout)
+
+            if r.status_code != 200:
+                logger.debug(f"📖 CWA Sync: GET state for {book_uuid} returned {r.status_code}")
+                return None
+
+            data = r.json()
+            if not data or not isinstance(data, list) or len(data) == 0:
+                return None
+
+            entry = data[0]
+            bookmark = entry.get("CurrentBookmark") or {}
+            status_info = entry.get("StatusInfo") or {}
+
+            # CWA API uses 0-100 scale; normalize to 0-1
+            raw_progress = float(bookmark.get("ProgressPercent", 0.0) or 0.0)
+            progress = raw_progress / 100.0
+            status = status_info.get("Status", STATUS_READY)
+
+            location = bookmark.get("Location") or {}
+
+            return {
+                "progress_percent": progress,
+                "status": status,
+                "href": location.get("Source"),
+                "frag": location.get("Value"),
+            }
+
+        except Exception as e:
+            logger.error(f"❌ CWA Sync: Failed to get reading state for {book_uuid}: {e}")
+            return None
+
+    def update_reading_state(self, book_uuid: str, progress_percent: float, status: str = STATUS_READING) -> bool:
+        """Push reading position to CWA via Kobo sync protocol."""
+        if not self.is_configured():
+            return False
+
+        try:
+            url = f"{self._base_url}/library/{book_uuid}/state"
+            # CWA API uses 0-100 scale; bridge uses 0-1
+            api_pct = progress_percent * 100.0
+            payload = {
+                "ReadingStates": [{
+                    "CurrentBookmark": {
+                        "ProgressPercent": api_pct,
+                        "ContentSourceProgressPercent": api_pct,
+                        "Location": None,
+                    },
+                    "Statistics": None,
+                    "StatusInfo": {"Status": status},
+                }]
+            }
+
+            r = self._session.put(url, json=payload, timeout=self._timeout)
+
+            if r.status_code == 200:
+                resp = r.json()
+                if resp.get("RequestResult") == "Success":
+                    logger.info(f"📖 CWA Sync: Updated {book_uuid} to {progress_percent:.1%} ({status})")
+                    return True
+                else:
+                    logger.warning(f"⚠️ CWA Sync: Update returned non-success: {resp}")
+                    return False
+            else:
+                logger.error(f"❌ CWA Sync: Update failed for {book_uuid}: HTTP {r.status_code}")
+                return False
+
+        except Exception as e:
+            logger.error(f"❌ CWA Sync: Failed to update reading state for {book_uuid}: {e}")
+            return False
+
+    def resolve_book_uuid(self, calibre_id: str) -> str | None:
+        if not self._cwa_client:
+            return None
+        return self._cwa_client.get_book_uuid(calibre_id)

--- a/src/services/client_poller.py
+++ b/src/services/client_poller.py
@@ -23,6 +23,7 @@ class ClientPoller:
         ('Storyteller', 'STORYTELLER'),
         ('BookLore', 'BOOKLORE'),
         ('BookLoreAudio', 'BOOKLORE_AUDIO'),
+        ('CWA', 'CWA_SYNC'),
     ]
 
     def __init__(self, database_service, sync_manager, sync_clients_dict: dict):

--- a/src/sync_clients/cwa_sync_client.py
+++ b/src/sync_clients/cwa_sync_client.py
@@ -1,0 +1,122 @@
+"""
+CWA sync client — syncs reading progress with Calibre-Web Automated
+via its Kobo sync protocol.
+
+This allows bidirectional progress sync between Audiobookshelf (audiobooks)
+and a stock Kobo e-reader, using CWA as the intermediary.
+"""
+
+import os
+from typing import Optional
+import logging
+
+from src.api.cwa_sync_api import CWASyncApi, STATUS_READING, STATUS_FINISHED, STATUS_READY
+from src.api.cwa_client import CWAClient
+from src.db.models import Book, State
+from src.utils.ebook_utils import EbookParser
+from src.sync_clients.sync_client_interface import (
+    SyncClient, SyncResult, UpdateProgressRequest, ServiceState,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CWASyncClient(SyncClient):
+    def __init__(self, cwa_sync_api: CWASyncApi, cwa_client: CWAClient, ebook_parser: EbookParser):
+        super().__init__(ebook_parser)
+        self.cwa_sync_api = cwa_sync_api
+        self.cwa_client = cwa_client
+        self.delta_thresh = float(os.getenv("SYNC_DELTA_KOSYNC_PERCENT", 1)) / 100.0
+
+    def is_configured(self) -> bool:
+        return self.cwa_sync_api.is_configured()
+
+    def check_connection(self):
+        return self.cwa_sync_api.check_connection()
+
+    def get_supported_sync_types(self) -> set:
+        return {'audiobook', 'ebook'}
+
+    @staticmethod
+    def _resolve_epub_filename(book: Book) -> Optional[str]:
+        return getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
+
+    def _resolve_uuid(self, book: Book) -> Optional[str]:
+        """Resolve the Calibre UUID for a CWA-sourced book."""
+        source_id = getattr(book, "ebook_source_id", None)
+        if not source_id:
+            return None
+        return self.cwa_sync_api.resolve_book_uuid(str(source_id))
+
+    def supports_book(self, book: Book) -> bool:
+        if getattr(book, "ebook_source", None) != "CWA":
+            return False
+        if not getattr(book, "ebook_source_id", None):
+            return False
+        epub = self._resolve_epub_filename(book)
+        return bool(epub)
+
+    def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
+        uuid = self._resolve_uuid(book)
+        if not uuid:
+            logger.debug(f"📖 CWA Sync: Could not resolve UUID for '{book.abs_title}'")
+            return None
+
+        state = self.cwa_sync_api.get_reading_state(uuid)
+        if state is None:
+            return None
+
+        pct = state["progress_percent"]
+        prev_pct = prev_state.percentage if prev_state else 0
+        delta = abs(pct - prev_pct)
+
+        current = {"pct": pct}
+        # Include location data for higher-confidence normalization
+        if state.get("href"):
+            current["href"] = state["href"]
+        if state.get("frag"):
+            current["frag"] = state["frag"]
+
+        return ServiceState(
+            current=current,
+            previous_pct=prev_pct,
+            delta=delta,
+            threshold=self.delta_thresh,
+            is_configured=self.cwa_sync_api.is_configured(),
+            display=("CWA", "{prev:.4%} -> {curr:.4%}"),
+            value_formatter=lambda v: f"{v*100:.4f}%",
+        )
+
+    def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
+        pct = state.current.get("pct")
+        epub = self._resolve_epub_filename(book)
+        if pct is not None and epub and self.ebook_parser:
+            return self.ebook_parser.get_text_at_percentage(epub, pct)
+        return None
+
+    def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
+        uuid = self._resolve_uuid(book)
+        if not uuid:
+            logger.warning(f"⚠️ CWA Sync: Cannot update — no UUID for '{book.abs_title}'")
+            return SyncResult(success=False)
+
+        pct = request.locator_result.percentage
+
+        # Determine reading status from percentage
+        if pct >= 0.99:
+            status = STATUS_FINISHED
+        elif pct > 0:
+            status = STATUS_READING
+        else:
+            status = STATUS_READY
+
+        success = self.cwa_sync_api.update_reading_state(uuid, pct, status)
+
+        if success:
+            try:
+                from src.services.write_tracker import record_write
+                record_write('CWA', book.abs_id, pct)
+            except ImportError:
+                pass
+
+        return SyncResult(pct, success, {"pct": pct})

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -28,6 +28,8 @@ ALL_SETTINGS = [
 
     # CWA (Calibre-Web Automated)
     'CWA_ENABLED', 'CWA_SERVER', 'CWA_USERNAME', 'CWA_PASSWORD',
+    'CWA_SYNC_ENABLED', 'CWA_SYNC_TOKEN',
+    'CWA_SYNC_POLL_MODE', 'CWA_SYNC_POLL_SECONDS',
     
     # Hardcover
     'HARDCOVER_ENABLED', 'HARDCOVER_TOKEN',
@@ -101,6 +103,10 @@ DEFAULT_CONFIG = {
     'CWA_SERVER': '',
     'CWA_USERNAME': '',
     'CWA_PASSWORD': '',
+    'CWA_SYNC_ENABLED': 'false',
+    'CWA_SYNC_TOKEN': '',
+    'CWA_SYNC_POLL_MODE': 'global',
+    'CWA_SYNC_POLL_SECONDS': '300',
     'HARDCOVER_ENABLED': 'false',
     'TELEGRAM_ENABLED': 'false',
     'SUGGESTIONS_ENABLED': 'false',

--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -14,6 +14,7 @@ from dependency_injector import containers, providers
 from src.api.api_clients import ABSClient, KoSyncClient
 from src.api.booklore_client import BookloreClient
 from src.api.cwa_client import CWAClient
+from src.api.cwa_sync_api import CWASyncApi
 from src.api.hardcover_client import HardcoverClient
 from src.api.storyteller_api import StorytellerAPIClient
 from src.db.database_service import DatabaseService
@@ -34,6 +35,7 @@ from src.sync_clients.booklore_sync_client import BookloreSyncClient
 from src.sync_clients.booklore_audio_sync_client import BookLoreAudioSyncClient
 from src.sync_clients.abs_ebook_sync_client import ABSEbookSyncClient
 from src.sync_clients.hardcover_sync_client import HardcoverSyncClient
+from src.sync_clients.cwa_sync_client import CWASyncClient
 from src.sync_manager import SyncManager
 
 logger = logging.getLogger(__name__)
@@ -95,7 +97,10 @@ class Container(containers.DeclarativeContainer):
 
     cwa_client = providers.Singleton(CWAClient)
 
-
+    cwa_sync_api = providers.Singleton(
+        CWASyncApi,
+        cwa_client=cwa_client,
+    )
 
     # Ebook parser
     ebook_parser = providers.Singleton(
@@ -222,6 +227,13 @@ class Container(containers.DeclarativeContainer):
         database_service
     )
 
+    cwa_sync_client = providers.Singleton(
+        CWASyncClient,
+        cwa_sync_api,
+        cwa_client,
+        ebook_parser,
+    )
+
     abs_audio_source_adapter = providers.Singleton(
         ABSAudioSourceAdapter,
         abs_client=abs_client,
@@ -246,7 +258,8 @@ class Container(containers.DeclarativeContainer):
         Storyteller=storyteller_sync_client,
         BookLore=booklore_sync_client,
         BookLoreAudio=booklore_audio_sync_client,
-        Hardcover=hardcover_sync_client
+        Hardcover=hardcover_sync_client,
+        CWA=cwa_sync_client,
     )
 
     # Sync Manager

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1349,6 +1349,7 @@ def settings():
             'REPROCESS_ON_CLEAR_IF_NO_ALIGNMENT',
             'INSTANT_SYNC_ENABLED',
             'SHELFMARK_ENABLED',
+            'CWA_SYNC_ENABLED',
         ]
 
         # Current settings in DB
@@ -5344,6 +5345,11 @@ def test_connection(service: str):
             _coerce_test_str(data.get('CWA_USERNAME')),
             _coerce_test_str(data.get('CWA_PASSWORD')),
         ),
+        'cwa_sync': lambda data: _test_cwa_sync(
+            _coerce_test_bool(data.get('CWA_SYNC_ENABLED')),
+            _normalize_test_url(data.get('CWA_SERVER')),
+            _coerce_test_str(data.get('CWA_SYNC_TOKEN')),
+        ),
         'hardcover': lambda data: _test_hardcover(
             _coerce_test_bool(data.get('HARDCOVER_ENABLED')),
             _coerce_test_str(data.get('HARDCOVER_TOKEN')),
@@ -5504,6 +5510,21 @@ def _test_cwa(enabled: bool, url: str, user: str, pwd: str) -> dict:
         return {"ok": True, "message": "Connected to OPDS feed"}
     if r.status_code in (401, 403):
         return {"ok": False, "message": "Invalid credentials"}
+    return {"ok": False, "message": f"Server returned {r.status_code}"}
+
+
+def _test_cwa_sync(enabled: bool, url: str, token: str) -> dict:
+    if not enabled:
+        return {"ok": False, "message": "CWA Sync is disabled"}
+    if not url:
+        return {"ok": False, "message": "Missing CWA Server URL (configure in the CWA section above)"}
+    if not token:
+        return {"ok": False, "message": "Missing sync auth token"}
+    r = requests.get(f"{url}/kobo/{token}/v1/library/sync", timeout=5)
+    if r.status_code == 200:
+        return {"ok": True, "message": "Connected to CWA sync API"}
+    if r.status_code in (401, 403):
+        return {"ok": False, "message": "Invalid auth token"}
     return {"ok": False, "message": f"Server returned {r.status_code}"}
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -804,6 +804,48 @@
                         <label>Password</label>
                         <input type="password" name="CWA_PASSWORD" value="{{ get_val('CWA_PASSWORD') }}">
                     </div>
+                    <div class="form-group full-width">
+                        <label>
+                            <input type="checkbox" name="CWA_HIDE_LOCAL_EBOOKS" {% if get_bool('CWA_HIDE_LOCAL_EBOOKS') %}checked{% endif %}>
+                            Hide local ebook files when matching
+                        </label>
+                        <div class="help-text">When enabled, local filesystem ebooks are hidden from match results since CWA manages the same library.</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- CWA Sync (Optional) -->
+            <div class="settings-section">
+                {% set cwa_sync_enabled = get_bool('CWA_SYNC_ENABLED') %}
+                <div class="section-header">
+                    <h3>CWA Sync</h3>
+                    <button class="btn btn-sm" type="button" onclick="testConnection('cwa_sync', this)">🔗 Test</button>
+                    <div class="toggle-switch-wrapper">
+                        <span class="toggle-label">Enable</span>
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="toggle_cwa_sync" name="CWA_SYNC_ENABLED"
+                                onchange="toggleSection('cwa_sync_body', this.checked)" {% if cwa_sync_enabled %}checked{% endif %}>
+                            <span class="slider"></span>
+                        </label>
+                    </div>
+                </div>
+                <div id="cwa_sync_body" class="section-body {% if not cwa_sync_enabled %}collapsed{% endif %}">
+                    <div class="form-group full-width">
+                        <label>Sync Auth Token</label>
+                        <input type="password" name="CWA_SYNC_TOKEN" value="{{ get_val('CWA_SYNC_TOKEN') }}">
+                        <div class="help-text">Token from your CWA user's Kobo sync settings page. Uses the same CWA Server URL configured above.</div>
+                    </div>
+                    <div class="form-group">
+                        <label>Poll Mode</label>
+                        <select name="CWA_SYNC_POLL_MODE">
+                            <option value="global" {% if get_val('CWA_SYNC_POLL_MODE') == 'global' %}selected{% endif %}>Global</option>
+                            <option value="custom" {% if get_val('CWA_SYNC_POLL_MODE') == 'custom' %}selected{% endif %}>Custom</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Poll Interval (seconds)</label>
+                        <input type="number" name="CWA_SYNC_POLL_SECONDS" value="{{ get_val('CWA_SYNC_POLL_SECONDS') }}">
+                    </div>
                 </div>
             </div>
 
@@ -1474,6 +1516,7 @@
             storyteller: ['STORYTELLER_ENABLED', 'STORYTELLER_API_URL', 'STORYTELLER_USER', 'STORYTELLER_PASSWORD'],
             booklore: ['BOOKLORE_ENABLED', 'BOOKLORE_SERVER', 'BOOKLORE_USER', 'BOOKLORE_PASSWORD'],
             cwa: ['CWA_ENABLED', 'CWA_SERVER', 'CWA_USERNAME', 'CWA_PASSWORD'],
+            cwa_sync: ['CWA_SYNC_ENABLED', 'CWA_SYNC_TOKEN', 'CWA_SERVER'],
             hardcover: ['HARDCOVER_ENABLED', 'HARDCOVER_TOKEN'],
             telegram: ['TELEGRAM_ENABLED', 'TELEGRAM_BOT_TOKEN'],
         };

--- a/tests/test_cwa_sync_api.py
+++ b/tests/test_cwa_sync_api.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Unit tests for CWASyncApi."""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.api.cwa_sync_api import CWASyncApi, STATUS_READING, STATUS_FINISHED, STATUS_READY
+
+
+class TestCWASyncApi(unittest.TestCase):
+
+    def _make_client(self, server='http://cwa.local:8083', token='abc123token',
+                     enabled='true', cwa_client=None):
+        """Create a client with config snapshotted from env."""
+        with patch.dict('os.environ', {
+            'CWA_SERVER': server,
+            'CWA_SYNC_ENABLED': enabled,
+            'CWA_SYNC_TOKEN': token,
+        }):
+            return CWASyncApi(cwa_client=cwa_client)
+
+    def setUp(self):
+        self.mock_cwa_client = Mock()
+        self.mock_cwa_client.base_url = 'http://cwa.local:8083'
+        self.client = self._make_client(cwa_client=self.mock_cwa_client)
+
+    # -- Configuration --
+
+    def test_is_configured_when_all_set(self):
+        self.assertTrue(self.client.is_configured())
+
+    def test_not_configured_when_disabled(self):
+        client = self._make_client(enabled='false', cwa_client=self.mock_cwa_client)
+        self.assertFalse(client.is_configured())
+
+    def test_not_configured_when_no_token(self):
+        client = self._make_client(token='', cwa_client=self.mock_cwa_client)
+        self.assertFalse(client.is_configured())
+
+    def test_not_configured_when_no_server(self):
+        mock_cwa = Mock()
+        mock_cwa.base_url = ''
+        client = self._make_client(server='', cwa_client=mock_cwa)
+        self.assertFalse(client.is_configured())
+
+    # -- URL construction --
+
+    def test_base_url_construction(self):
+        self.assertEqual(
+            self.client._base_url,
+            'http://cwa.local:8083/kobo/abc123token/v1'
+        )
+
+    def test_server_from_cwa_client(self):
+        """Server URL should come from injected CWA client's base_url."""
+        self.assertEqual(self.client._server, 'http://cwa.local:8083')
+
+    # -- get_reading_state --
+
+    def test_get_reading_state_success(self):
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{
+            "EntitlementId": "test-uuid",
+            "CurrentBookmark": {
+                "ProgressPercent": 53.0,  # 0-100 scale
+                "ContentSourceProgressPercent": 53.0,
+                "Location": {
+                    "Source": "chapter3.html",
+                    "Type": "KoboSpan",
+                    "Value": "kobo.1.1",
+                },
+            },
+            "StatusInfo": {
+                "Status": "Reading",
+            },
+        }]
+        self.client._session = Mock()
+        self.client._session.get.return_value = mock_resp
+
+        result = self.client.get_reading_state("test-uuid")
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["progress_percent"], 0.53)
+        self.assertEqual(result["status"], "Reading")
+        self.assertEqual(result["href"], "chapter3.html")
+        self.assertEqual(result["frag"], "kobo.1.1")
+
+    def test_get_reading_state_empty_response(self):
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = []
+        self.client._session = Mock()
+        self.client._session.get.return_value = mock_resp
+
+        result = self.client.get_reading_state("test-uuid")
+        self.assertIsNone(result)
+
+    def test_get_reading_state_http_error(self):
+        mock_resp = Mock()
+        mock_resp.status_code = 404
+        self.client._session = Mock()
+        self.client._session.get.return_value = mock_resp
+
+        result = self.client.get_reading_state("test-uuid")
+        self.assertIsNone(result)
+
+    # -- update_reading_state --
+
+    def test_update_reading_state_success(self):
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"RequestResult": "Success"}
+        self.client._session = Mock()
+        self.client._session.put.return_value = mock_resp
+
+        result = self.client.update_reading_state("test-uuid", 0.75, STATUS_READING)
+
+        self.assertTrue(result)
+        call_args = self.client._session.put.call_args
+        payload = call_args[1]['json']
+        # Should be converted to 0-100 scale for the API
+        self.assertAlmostEqual(
+            payload["ReadingStates"][0]["CurrentBookmark"]["ProgressPercent"],
+            75.0,
+        )
+        self.assertEqual(
+            payload["ReadingStates"][0]["StatusInfo"]["Status"],
+            "Reading",
+        )
+
+    def test_update_reading_state_failure(self):
+        mock_resp = Mock()
+        mock_resp.status_code = 500
+        self.client._session = Mock()
+        self.client._session.put.return_value = mock_resp
+
+        result = self.client.update_reading_state("test-uuid", 0.5, STATUS_READING)
+        self.assertFalse(result)
+
+    # -- UUID resolution --
+
+    def test_resolve_book_uuid_delegates_to_cwa_client(self):
+        self.mock_cwa_client.get_book_uuid.return_value = "abcd-1234-uuid"
+        result = self.client.resolve_book_uuid("42")
+        self.assertEqual(result, "abcd-1234-uuid")
+        self.mock_cwa_client.get_book_uuid.assert_called_once_with("42")
+
+    def test_resolve_book_uuid_no_cwa_client(self):
+        client = self._make_client(cwa_client=None)
+        result = client.resolve_book_uuid("42")
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_cwa_sync_client.py
+++ b/tests/test_cwa_sync_client.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Unit tests for CWASyncClient — the sync client that bridges
+Audiobookshelf with CWA's reading progress sync.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.sync_clients.cwa_sync_client import CWASyncClient
+from src.sync_clients.sync_client_interface import (
+    UpdateProgressRequest, LocatorResult, ServiceState,
+)
+from src.db.models import Book, State
+
+
+class TestCWASyncClient(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_sync_api = Mock()
+        self.mock_cwa_client = Mock()
+        self.mock_ebook_parser = Mock()
+
+        self.mock_sync_api.is_configured.return_value = True
+
+        self.env_patcher = patch.dict('os.environ', {
+            'SYNC_DELTA_KOSYNC_PERCENT': '1',
+        })
+        self.env_patcher.start()
+
+        self.client = CWASyncClient(
+            cwa_sync_api=self.mock_sync_api,
+            cwa_client=self.mock_cwa_client,
+            ebook_parser=self.mock_ebook_parser,
+        )
+
+        self.test_book = Book(
+            abs_id='test-abs-id',
+            abs_title='Test Book',
+            ebook_filename='test-book.epub',
+            ebook_source='CWA',
+            ebook_source_id='42',
+            status='active',
+        )
+
+    def tearDown(self):
+        self.env_patcher.stop()
+
+    # -- Interface compliance --
+
+    def test_is_configured_delegates(self):
+        self.assertTrue(self.client.is_configured())
+        self.mock_sync_api.is_configured.assert_called()
+
+    def test_is_configured_false_when_not_configured(self):
+        self.mock_sync_api.is_configured.return_value = False
+        self.assertFalse(self.client.is_configured())
+
+    def test_check_connection_delegates(self):
+        self.mock_sync_api.check_connection.return_value = True
+        self.assertTrue(self.client.check_connection())
+
+    def test_supported_sync_types(self):
+        self.assertEqual(self.client.get_supported_sync_types(), {'audiobook', 'ebook'})
+
+    def test_can_be_leader(self):
+        self.assertTrue(self.client.can_be_leader())
+
+    # -- supports_book --
+
+    def test_supports_book_cwa_source(self):
+        self.assertTrue(self.client.supports_book(self.test_book))
+
+    def test_does_not_support_non_cwa_source(self):
+        book = Book(
+            abs_id='test-2',
+            abs_title='Other Book',
+            ebook_filename='other.epub',
+            ebook_source='BookLore',
+            ebook_source_id='99',
+            status='active',
+        )
+        self.assertFalse(self.client.supports_book(book))
+
+    def test_does_not_support_missing_source_id(self):
+        book = Book(
+            abs_id='test-3',
+            abs_title='No ID Book',
+            ebook_filename='noid.epub',
+            ebook_source='CWA',
+            ebook_source_id=None,
+            status='active',
+        )
+        self.assertFalse(self.client.supports_book(book))
+
+    def test_does_not_support_no_epub(self):
+        book = Book(
+            abs_id='test-4',
+            abs_title='No EPUB Book',
+            ebook_filename=None,
+            ebook_source='CWA',
+            ebook_source_id='42',
+            status='active',
+        )
+        self.assertFalse(self.client.supports_book(book))
+
+    # -- get_service_state --
+
+    def test_get_service_state_success(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.get_reading_state.return_value = {
+            'progress_percent': 0.45,
+            'status': 'Reading',
+        }
+
+        state = self.client.get_service_state(self.test_book, None)
+
+        self.assertIsNotNone(state)
+        self.assertAlmostEqual(state.current['pct'], 0.45)
+        self.assertAlmostEqual(state.previous_pct, 0)
+        self.assertAlmostEqual(state.delta, 0.45)
+
+    def test_get_service_state_with_previous_state(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.get_reading_state.return_value = {
+            'progress_percent': 0.60,
+            'status': 'Reading',
+        }
+
+        prev = Mock(spec=State)
+        prev.percentage = 0.50
+
+        state = self.client.get_service_state(self.test_book, prev)
+
+        self.assertIsNotNone(state)
+        self.assertAlmostEqual(state.previous_pct, 0.50)
+        self.assertAlmostEqual(state.delta, 0.10)
+
+    def test_get_service_state_no_uuid(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = None
+        state = self.client.get_service_state(self.test_book, None)
+        self.assertIsNone(state)
+
+    def test_get_service_state_api_returns_none(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.get_reading_state.return_value = None
+        state = self.client.get_service_state(self.test_book, None)
+        self.assertIsNone(state)
+
+    # -- get_text_from_current_state --
+
+    def test_get_text_from_current_state(self):
+        self.mock_ebook_parser.get_text_at_percentage.return_value = "Some text from the book"
+
+        state = ServiceState(
+            current={"pct": 0.5},
+            previous_pct=0.4,
+            delta=0.1,
+            threshold=0.01,
+            is_configured=True,
+            display=("CWA", "{prev:.4%} -> {curr:.4%}"),
+            value_formatter=lambda v: f"{v*100:.4f}%",
+        )
+
+        text = self.client.get_text_from_current_state(self.test_book, state)
+
+        self.assertEqual(text, "Some text from the book")
+        self.mock_ebook_parser.get_text_at_percentage.assert_called_once_with(
+            'test-book.epub', 0.5
+        )
+
+    # -- update_progress --
+
+    def test_update_progress_reading(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.update_reading_state.return_value = True
+
+        locator = LocatorResult(percentage=0.50)
+        request = UpdateProgressRequest(locator_result=locator)
+
+        result = self.client.update_progress(self.test_book, request)
+
+        self.assertTrue(result.success)
+        self.assertAlmostEqual(result.location, 0.50)
+        self.mock_sync_api.update_reading_state.assert_called_once_with(
+            'test-uuid', 0.50, 'Reading'
+        )
+
+    def test_update_progress_finished(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.update_reading_state.return_value = True
+
+        locator = LocatorResult(percentage=0.995)
+        request = UpdateProgressRequest(locator_result=locator)
+
+        result = self.client.update_progress(self.test_book, request)
+
+        self.assertTrue(result.success)
+        self.mock_sync_api.update_reading_state.assert_called_once_with(
+            'test-uuid', 0.995, 'Finished'
+        )
+
+    def test_update_progress_ready_to_read(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.update_reading_state.return_value = True
+
+        locator = LocatorResult(percentage=0.0)
+        request = UpdateProgressRequest(locator_result=locator)
+
+        result = self.client.update_progress(self.test_book, request)
+
+        self.assertTrue(result.success)
+        self.mock_sync_api.update_reading_state.assert_called_once_with(
+            'test-uuid', 0.0, 'ReadyToRead'
+        )
+
+    def test_update_progress_no_uuid(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = None
+
+        locator = LocatorResult(percentage=0.50)
+        request = UpdateProgressRequest(locator_result=locator)
+
+        result = self.client.update_progress(self.test_book, request)
+
+        self.assertFalse(result.success)
+        self.mock_sync_api.update_reading_state.assert_not_called()
+
+    def test_update_progress_api_failure(self):
+        self.mock_sync_api.resolve_book_uuid.return_value = 'test-uuid'
+        self.mock_sync_api.update_reading_state.return_value = False
+
+        locator = LocatorResult(percentage=0.50)
+        request = UpdateProgressRequest(locator_result=locator)
+
+        result = self.client.update_progress(self.test_book, request)
+
+        self.assertFalse(result.success)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -70,6 +70,7 @@ def test_dependency_injection():
         from src.sync_clients.kosync_sync_client import KoSyncSyncClient
         from src.sync_clients.storyteller_sync_client import StorytellerSyncClient
         from src.sync_clients.booklore_sync_client import BookloreSyncClient
+        from src.sync_clients.cwa_sync_client import CWASyncClient
 
         abs_sync_client = container.abs_sync_client()
         print(f"[OK] ABSSyncClient: {type(abs_sync_client).__name__}")
@@ -82,6 +83,9 @@ def test_dependency_injection():
 
         booklore_sync_client = container.booklore_sync_client()
         print(f"[OK] BookloreSyncClient: {type(booklore_sync_client).__name__}")
+
+        cwa_sync_client = container.cwa_sync_client()
+        print(f"[OK] CWASyncClient: {type(cwa_sync_client).__name__}")
 
         # Test 5: Test SyncManager creation with DI
         print("\n[TEST] Testing SyncManager creation with DI...")


### PR DESCRIPTION
## Summary

Adds bidirectional reading progress sync between Audiobookshelf and Calibre-Web Automated (CWA) via CWA's Kobo sync protocol. This enables stock Kobo e-readers (and any CWA-synced device) to participate in the bridge's cross-format sync loop.

- **New `CWASyncApi`** — HTTP client for CWA's Kobo sync endpoints (read/write progress, connection check)
- **New `CWASyncClient`** — Full `SyncClient` implementation with leader election support, UUID resolution via OPDS search, and percentage-based progress sync
- **Settings UI** — CWA Sync section with enable toggle, auth token, poll mode/interval, and test connection
- **Documentation** — Updated configuration reference and sync platform table
- **32 unit tests** covering API client and sync client

### How it works

```
ABS <-> Bridge <-> CWA (Kobo sync protocol) <-> Kobo / any CWA-synced device
```

The bridge polls CWA for reading progress via the Kobo sync API (`/kobo/{token}/v1/library/{uuid}/state`), and writes back when other clients lead. Auth is URL-path based (Kobo sync token from CWA's user settings). UUID resolution uses OPDS search with in-memory caching.

### Files

**New:**
- `src/api/cwa_sync_api.py`
- `src/sync_clients/cwa_sync_client.py`
- `tests/test_cwa_sync_api.py`
- `tests/test_cwa_sync_client.py`

**Modified:**
- `src/api/cwa_client.py` — Added `get_book_uuid()` for UUID resolution via OPDS search
- `src/utils/config_loader.py` — `CWA_SYNC_*` settings
- `src/utils/di_container.py` — DI registration
- `src/services/client_poller.py` — Pollable client registration
- `src/web_server.py` — Test connection handler
- `templates/settings.html` — CWA Sync settings section
- `docs/configuration.md`, `docs/index.md` — Documentation

## Test plan

- [x] 32 unit tests pass (`pytest tests/test_cwa_sync_api.py tests/test_cwa_sync_client.py`)
- [x] Bidirectional sync tested live (ABS to CWA and CWA to ABS)
- [x] CWA correctly resolves Calibre UUIDs via OPDS search
- [x] Settings UI renders, saves, and test connection works
- [ ] Verify DI container wiring with `test_dependency_injection.py`