### PR TITLE
[Fix] Resolve KOReader /text()[N].MMM XPath form in ebook_utils

### DIFF
--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -1123,11 +1123,14 @@ class EbookParser:
             book_path = self.resolve_book_path(filename)
             full_text, spine_map = self.extract_text_and_map(book_path)
 
-            # Parse path and offset
+            # Parse path and offset. KOReader emits two forms for the trailing
+            # character offset: "/text().NNN" (single text node) and
+            # "/text()[N].MMM" (Nth text node when inline children split a
+            # paragraph's text into multiple nodes). Both must be recognised.
             relative_path = xpath_str.split(f"DocFragment[{spine_index}]")[-1]
-            offset_match = re.search(r'/text\(\)\.(\d+)$', relative_path)
+            offset_match = re.search(r'/text\(\)(?:\[\d+\])?\.(\d+)$', relative_path)
             target_offset = int(offset_match.group(1)) if offset_match else 0
-            clean_xpath = re.sub(r'/text\(\)\.(\d+)$', '', relative_path)
+            clean_xpath = re.sub(r'/text\(\)(?:\[\d+\])?\.\d+$', '', relative_path)
 
             if clean_xpath.startswith('/'):
                 clean_xpath = '.' + clean_xpath
@@ -1245,9 +1248,9 @@ class EbookParser:
             full_text, spine_map = self.extract_text_and_map(book_path)
 
             relative_path = xpath_str.split(f"DocFragment[{spine_index}]")[-1]
-            offset_match = re.search(r'/text\(\)\.(\d+)$', relative_path)
+            offset_match = re.search(r'/text\(\)(?:\[\d+\])?\.(\d+)$', relative_path)
             target_offset = int(offset_match.group(1)) if offset_match else 0
-            clean_xpath = re.sub(r'/text\(\)\.(\d+)$', '', relative_path)
+            clean_xpath = re.sub(r'/text\(\)(?:\[\d+\])?\.\d+$', '', relative_path)
 
             if clean_xpath.startswith('/'):
                 clean_xpath = '.' + clean_xpath

--- a/tests/test_resolve_xpath_to_index_bs4_fallback.py
+++ b/tests/test_resolve_xpath_to_index_bs4_fallback.py
@@ -143,6 +143,44 @@ def test_resolve_xpath_to_index_unresolved_xpath_returns_none():
     assert index is None
 
 
+def test_resolve_xpath_to_index_bracketed_text_node_offset():
+    # KOReader emits "/text()[N].MMM" when a paragraph contains inline children
+    # (<em>, <a>, <span>...) that split its text into multiple nodes. The
+    # bracketed predicate plus the trailing character offset must both parse;
+    # otherwise the resolver returns None and KoSync falls back to percent.
+    html_content = (
+        "<html><body>"
+        "<p>Lead text <em>emphasis</em> trailing text.</p>"
+        "</body></html>"
+    )
+    parser = _parser_for_single_spine(html_content, start=0)
+
+    index = parser.resolve_xpath_to_index(
+        "book.epub", "/body/DocFragment[1]/body/p[1]/text()[2].5"
+    )
+
+    assert index is not None
+    chapter_text_len = len(
+        BeautifulSoup(html_content, "html.parser").get_text(separator=" ", strip=True)
+    )
+    assert 0 <= index <= chapter_text_len
+
+
+def test_resolve_xpath_to_index_unbracketed_text_node_offset_still_works():
+    # Regression guard: the unbracketed "/text().MMM" form must keep resolving
+    # after the bracketed-form fix.
+    html_content = (
+        "<html><body><p>Lead text emphasis trailing text.</p></body></html>"
+    )
+    parser = _parser_for_single_spine(html_content, start=0)
+
+    index = parser.resolve_xpath_to_index(
+        "book.epub", "/body/DocFragment[1]/body/p[1]/text().5"
+    )
+
+    assert index == 5
+
+
 def test_resolve_xpath_to_index_falls_back_to_nearby_spine_when_docfragment_drifts(caplog):
     caplog.set_level(logging.INFO)
     parser = _parser_for_spines(


### PR DESCRIPTION
The offset-stripping regex in resolve_xpath and resolve_xpath_to_index only matched /text().NNN, leaving the .MMM glued onto clean_xpath when KOReader emitted /text()[N].MMM (which it does whenever a paragraph contains inline children that split text into multiple nodes). lxml then rejected the path as invalid and the resolver returned None, demoting KoSync normalization to percent_fallback and bypassing the single-client-delta and deadband-rollback protections in sync_manager.

Match the canonical detection regex already used in _sanitize_kosync_xpath and get_sentence_level_ko_xpath so both the bracketed and unbracketed forms parse.