### PR TITLE
Improve KOReader KoSync write-back compatibility

### DIFF
--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -804,6 +804,11 @@ class KoSyncClient:
         CRITICAL FIX: Returns TUPLE (percentage, xpath_string)
         This prevents the 'cannot unpack non-iterable float' crash.
         """
+        pct, xpath, _metadata = self.get_progress_with_metadata(doc_id)
+        return pct, xpath
+
+    def get_progress_with_metadata(self, doc_id):
+        """Return percentage, progress locator, and bridge-specific response metadata."""
         headers = kosync_auth_headers(self.user, self.auth_token)
         url = f"{self.base_url}/syncs/progress/{doc_id}"
         try:
@@ -813,11 +818,11 @@ class KoSyncClient:
                 pct = float(data.get('percentage', 0))
                 # Grab the raw progress string (XPath)
                 xpath = data.get('progress')
-                return pct, xpath
+                return pct, xpath, data
         except Exception as e:
             logger.error(f"❌ Error fetching KoSync progress for doc '{doc_id}': {e}")
             pass
-        return None, None
+        return None, None, {}
 
     def update_progress(self, doc_id, percentage, xpath=None):
         if not self.is_configured(): return False
@@ -853,4 +858,3 @@ class KoSyncClient:
             logger.error(f"❌ Failed to update KoSync: {e}")
             return False
 # [END FILE]
-

--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -58,6 +58,65 @@ _KOSYNC_PUT_DEBOUNCE_SECONDS_DEFAULT = 300
 _KOSYNC_DEVICE_SESSION_REGISTRY_KEY = "KOSYNC_DEVICE_SESSION_REGISTRY"
 _kosync_device_session_registry = None
 _kosync_device_session_registry_lock = threading.Lock()
+_kosync_recent_external_puts: dict = {}
+_kosync_recent_external_puts_lock = threading.Lock()
+
+
+def _recent_external_put_ttl_seconds() -> int:
+    configured = os.environ.get("KOSYNC_RECENT_EXTERNAL_PUT_SECONDS")
+    if configured:
+        try:
+            return max(0, int(configured))
+        except ValueError:
+            logger.warning("Invalid KOSYNC_RECENT_EXTERNAL_PUT_SECONDS=%r; using default", configured)
+    return 600
+
+
+def _record_recent_external_kosync_put(
+    document_hash: str,
+    device: str | None,
+    device_id: str | None,
+    percentage,
+    now_ts: float,
+) -> None:
+    if not document_hash:
+        return
+    with _kosync_recent_external_puts_lock:
+        _kosync_recent_external_puts[document_hash] = {
+            "timestamp": now_ts,
+            "device": device or "",
+            "device_id": device_id or "",
+            "percentage": float(percentage or 0),
+        }
+
+
+def _recent_external_kosync_put_metadata(document_hash: str | None, percentage=None) -> dict:
+    if not document_hash:
+        return {}
+    now_ts = time.time()
+    ttl = _recent_external_put_ttl_seconds()
+    with _kosync_recent_external_puts_lock:
+        entry = _kosync_recent_external_puts.get(document_hash)
+        if not entry:
+            return {}
+        age = now_ts - float(entry.get("timestamp") or 0)
+        if ttl <= 0 or age > ttl:
+            _kosync_recent_external_puts.pop(document_hash, None)
+            return {}
+
+    if percentage is not None:
+        try:
+            if abs(float(entry.get("percentage") or 0) - float(percentage or 0)) > 0.0001:
+                return {}
+        except (TypeError, ValueError):
+            return {}
+
+    return {
+        "_bridge_recent_external_put": True,
+        "_bridge_recent_external_put_age_seconds": round(age, 3),
+        "_bridge_recent_external_put_device": entry.get("device") or "",
+        "_bridge_recent_external_put_device_id": entry.get("device_id") or "",
+    }
 
 def signal_manifest_rebuild() -> None:
     """Wake the manifest prebuilder thread so it rebuilds on the next cycle."""
@@ -613,14 +672,21 @@ def kosync_get_progress(doc_id):
             )
             if poison_pill is not None:
                 return poison_pill
-            return jsonify({
+            response_data = {
                 "device": kosync_doc.device or "",
                 "device_id": kosync_doc.device_id or "",
                 "document": kosync_doc.document_hash,
                 "percentage": float(kosync_doc.percentage) if kosync_doc.percentage else 0,
                 "progress": kosync_doc.progress or "",
                 "timestamp": int(kosync_doc.timestamp.timestamp()) if kosync_doc.timestamp else 0
-            }), 200
+            }
+            response_data.update(
+                _recent_external_kosync_put_metadata(
+                    kosync_doc.document_hash,
+                    response_data["percentage"],
+                )
+            )
+            return jsonify(response_data), 200
         # Document exists but has no progress and no linked book — fall through
         # to try sibling resolution for better data
 
@@ -737,6 +803,8 @@ def kosync_put_progress():
         kosync_doc.timestamp = now
 
     _database_service.save_kosync_document(kosync_doc)
+    if not is_internal:
+        _record_recent_external_kosync_put(doc_hash, device, device_id, percentage, now_ts)
 
     # Update linked book if exists
     linked_book = None
@@ -1500,14 +1568,21 @@ def _respond_from_book_states(doc_id, book):
         poison_pill = _suppress_empty_progress_response(doc_id, float(best_doc.percentage), best_doc.progress)
         if poison_pill is not None:
             return poison_pill
-        return jsonify({
+        response_data = {
             "device": "abs-kosync-bridge",
             "device_id": "abs-kosync-bridge",
             "document": doc_id,
             "percentage": float(best_doc.percentage),
             "progress": best_doc.progress or "",
             "timestamp": int(best_doc.timestamp.timestamp()) if best_doc.timestamp else 0
-        }), 200
+        }
+        response_data.update(
+            _recent_external_kosync_put_metadata(
+                best_doc.document_hash,
+                response_data["percentage"],
+            )
+        )
+        return jsonify(response_data), 200
 
     if not states:
         return jsonify({"message": "Document not found on server"}), 502

--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -11,10 +11,12 @@ from src.sync_clients.sync_client_interface import SyncClient, SyncResult, Updat
 logger = logging.getLogger(__name__)
 
 class KoSyncSyncClient(SyncClient):
-    _FRAGILE_INLINE_SEGMENT_RE = re.compile(
-        r"/(?:span|em|strong|b|i|u|small|sub|sup|font|mark|abbr|cite|code|q|time|s|del|ins)(?:\[\d+\])?/",
-        re.IGNORECASE,
-    )
+    _KOSYNC_BLOCK_TAGS = {
+        "p", "li",
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        "blockquote", "figcaption", "dd", "dt", "td", "th",
+        "div", "section", "article", "pre",
+    }
 
     def __init__(self, kosync_client: KoSyncClient, ebook_parser: EbookParser):
         super().__init__(ebook_parser)
@@ -91,18 +93,27 @@ class KoSyncSyncClient(SyncClient):
 
         clean_xpath = re.sub(r"/{2,}", "/", clean_xpath).rstrip("/")
 
-        if not re.match(r"^/body/DocFragment\[\d+\](/.+)?$", clean_xpath):
+        match = re.match(r"^(/body/DocFragment\[\d+\])/(.+)$", clean_xpath)
+        if not match:
             return None
-        if self._FRAGILE_INLINE_SEGMENT_RE.search(clean_xpath):
+
+        prefix, relative_path = match.groups()
+        steps = [step for step in relative_path.split("/") if step]
+        last_block_idx = None
+        normalized_steps = []
+
+        for idx, step in enumerate(steps):
+            normalized_step = re.sub(r"\.\d+$", "", step)
+            tag_match = re.match(r"^([A-Za-z][\w:-]*)(?:\[\d+\])?$", normalized_step)
+            normalized_steps.append(normalized_step)
+            if tag_match and tag_match.group(1).lower() in self._KOSYNC_BLOCK_TAGS:
+                last_block_idx = idx
+
+        if last_block_idx is None:
             return None
 
-        if re.search(r"/text\(\)(\[\d+\])?\.\d+$", clean_xpath):
-            return clean_xpath
-
-        if re.search(r"/text\(\)(\[\d+\])?$", clean_xpath):
-            return f"{clean_xpath}.0"
-
-        return f"{clean_xpath}/text().0"
+        block_path = "/".join(normalized_steps[:last_block_idx + 1])
+        return f"{prefix}/{block_path}.0"
 
     def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
         pct = request.locator_result.percentage
@@ -113,9 +124,9 @@ class KoSyncSyncClient(SyncClient):
             if book
             else None
         )
-        # Always use sentence-level XPaths for KOSync.
-        # Character-level offsets don't survive cross-engine rendering differences
-        # between our parser and KOReader's CREngine.
+        # Always collapse generated KoSync positions to block-level XPointers.
+        # Text-node and inline offsets can resolve poorly in KOReader/CREngine,
+        # while paragraph-level anchors survive renderer differences better.
         safe_xpath = None
         if epub and pct is not None and pct > 0:
             sentence_xpath = self.ebook_parser.get_sentence_level_ko_xpath(epub, pct)

--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -36,7 +36,14 @@ class KoSyncSyncClient(SyncClient):
 
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         ko_id = book.kosync_doc_id
-        ko_pct, ko_xpath = self.kosync_client.get_progress(ko_id)
+        ko_metadata = {}
+        if hasattr(self.kosync_client, "get_progress_with_metadata"):
+            try:
+                ko_pct, ko_xpath, ko_metadata = self.kosync_client.get_progress_with_metadata(ko_id)
+            except (TypeError, ValueError):
+                ko_pct, ko_xpath = self.kosync_client.get_progress(ko_id)
+        else:
+            ko_pct, ko_xpath = self.kosync_client.get_progress(ko_id)
         book_label = f"'{title_snip}' " if title_snip else ""
         if ko_pct is None:
             if ko_xpath is None:
@@ -52,8 +59,15 @@ class KoSyncSyncClient(SyncClient):
 
         delta = abs(ko_pct - prev_kosync_pct)
 
+        current = {"pct": ko_pct, "xpath": ko_xpath}
+        if ko_metadata.get("_bridge_recent_external_put"):
+            current["_kosync_recent_external_put"] = True
+            current["_kosync_last_put_device"] = ko_metadata.get("_bridge_recent_external_put_device") or ""
+            current["_kosync_last_put_device_id"] = ko_metadata.get("_bridge_recent_external_put_device_id") or ""
+            current["_kosync_last_put_age_seconds"] = ko_metadata.get("_bridge_recent_external_put_age_seconds")
+
         return ServiceState(
-            current={"pct": ko_pct, "xpath": ko_xpath},
+            current=current,
             previous_pct=prev_kosync_pct,
             delta=delta,
             threshold=self.delta_kosync_thresh,

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -1693,7 +1693,19 @@ class SyncManager:
                     if name != changed_client and name in vals
                 ]
 
-                if changed_source == "percent_fallback" and primary_audio_client in vals:
+                recent_external_kosync_put = (
+                    changed_client.lower() == "kosync"
+                    and bool(config[changed_client].current.get("_kosync_recent_external_put"))
+                )
+                if changed_source == "percent_fallback" and primary_audio_client in vals and recent_external_kosync_put:
+                    device = config[changed_client].current.get("_kosync_last_put_device") or "unknown"
+                    age = config[changed_client].current.get("_kosync_last_put_age_seconds")
+                    age_msg = f", age={age:.1f}s" if isinstance(age, (int, float)) else ""
+                    logger.info(
+                        f"🔄 '{abs_id}' '{title_snip}' Trusting recent external KoSync PUT from "
+                        f"'{device}' despite source=percent_fallback{age_msg}"
+                    )
+                elif changed_source == "percent_fallback" and primary_audio_client in vals:
                     single_delta_low_conf = True
                     low_conf_single_delta_client = changed_client
                     logger.info(

--- a/tests/test_abs_unittest.py
+++ b/tests/test_abs_unittest.py
@@ -100,6 +100,30 @@ class TestABSLeadsSync(BaseSyncCycleTestCase):
         self.assertIsNone(result.updated_state.get('xpath'))
         kosync_api.update_progress.assert_not_called()
 
+    def test_kosync_state_includes_recent_external_put_metadata(self):
+        kosync_api = Mock()
+        kosync_api.get_progress_with_metadata.return_value = (
+            0.441,
+            "/body/DocFragment[31]/body/div[1].0",
+            {
+                "_bridge_recent_external_put": True,
+                "_bridge_recent_external_put_device": "Kobo_monza",
+                "_bridge_recent_external_put_device_id": "device-id",
+                "_bridge_recent_external_put_age_seconds": 247.0,
+            },
+        )
+        kosync_api.is_configured.return_value = True
+        ebook_parser = Mock()
+        client = KoSyncSyncClient(kosync_api, ebook_parser)
+
+        book = SimpleNamespace(kosync_doc_id='test-kosync-doc')
+        state = client.get_service_state(book, prev_state=None, title_snip="Test Audiobook")
+
+        self.assertTrue(state.current["_kosync_recent_external_put"])
+        self.assertEqual(state.current["_kosync_last_put_device"], "Kobo_monza")
+        self.assertEqual(state.current["_kosync_last_put_device_id"], "device-id")
+        self.assertEqual(state.current["_kosync_last_put_age_seconds"], 247.0)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/test_cross_format_normalization_locator_priority.py
+++ b/tests/test_cross_format_normalization_locator_priority.py
@@ -545,6 +545,66 @@ def test_deadband_allows_switch_when_delta_exceeds_threshold():
     assert leader_pct == config["KoSync"].current["pct"]
 
 
+def test_recent_external_kosync_percent_fallback_can_lead():
+    manager = SyncManager.__new__(SyncManager)
+    manager.cross_format_deadband_seconds = 2.0
+
+    class _Client:
+        def can_be_leader(self):
+            return True
+
+    manager.sync_clients = {"ABS": _Client(), "KoSync": _Client()}
+    manager._has_significant_delta = MagicMock(side_effect=lambda name, cfg, book: name == "KoSync")
+    manager._normalize_for_cross_format_comparison = MagicMock(
+        return_value={"ABS": 28667.3, "KoSync": 30400.0}
+    )
+
+    config = {
+        "ABS": _state({"pct": 0.415762, "ts": 28667.3}),
+        "KoSync": _state(
+            {
+                "pct": 0.441,
+                "_normalization_source": "percent_fallback",
+                "_kosync_recent_external_put": True,
+                "_kosync_last_put_device": "Kobo_monza",
+                "_kosync_last_put_age_seconds": 247.0,
+            }
+        ),
+    }
+    book = SimpleNamespace(duration=68940, transcript_file="DB_MANAGED")
+
+    leader, leader_pct = manager._determine_leader(config, book, "abs-1", "Leviathan Wakes")
+
+    assert leader == "KoSync"
+    assert leader_pct == config["KoSync"].current["pct"]
+
+
+def test_stale_kosync_percent_fallback_is_demoted():
+    manager = SyncManager.__new__(SyncManager)
+    manager.cross_format_deadband_seconds = 2.0
+
+    class _Client:
+        def can_be_leader(self):
+            return True
+
+    manager.sync_clients = {"ABS": _Client(), "KoSync": _Client()}
+    manager._has_significant_delta = MagicMock(side_effect=lambda name, cfg, book: name == "KoSync")
+    manager._normalize_for_cross_format_comparison = MagicMock(
+        return_value={"ABS": 28667.3, "KoSync": 30400.0}
+    )
+
+    config = {
+        "ABS": _state({"pct": 0.415762, "ts": 28667.3}),
+        "KoSync": _state({"pct": 0.441, "_normalization_source": "percent_fallback"}),
+    }
+    book = SimpleNamespace(duration=68940, transcript_file="DB_MANAGED")
+
+    leader, leader_pct = manager._determine_leader(config, book, "abs-1", "Leviathan Wakes")
+
+    assert leader == "ABS"
+    assert leader_pct == config["ABS"].current["pct"]
+
+
 def test_deadband_rollback_guard_skips_high_conf_locator_client():
     manager = SyncManager.__new__(SyncManager)
     manager.cross_format_deadband_seconds = 2.0

--- a/tests/test_kosync_xpath_safety.py
+++ b/tests/test_kosync_xpath_safety.py
@@ -15,20 +15,38 @@ class TestKoSyncXPathSafety(unittest.TestCase):
     def test_sanitize_repairs_trailing_slash(self):
         malformed = "/body/DocFragment[9]/body/div[1]/"
         repaired = self.client._sanitize_kosync_xpath(malformed, 0.5)
-        self.assertEqual(repaired, "/body/DocFragment[9]/body/div[1]/text().0")
+        self.assertEqual(repaired, "/body/DocFragment[9]/body/div[1].0")
 
-    def test_sanitize_accepts_indexed_text_nodes(self):
+    def test_sanitize_collapses_indexed_text_nodes_to_block(self):
         indexed = "/body/DocFragment[3]/body/p[2]/text()[2].0"
         repaired = self.client._sanitize_kosync_xpath(indexed, 0.5)
-        self.assertEqual(repaired, indexed)
+        self.assertEqual(repaired, "/body/DocFragment[3]/body/p[2].0")
+
+    def test_sanitize_collapses_direct_text_nodes_to_block(self):
+        text_node = "/body/DocFragment[27]/body/p[90]/text().0"
+        repaired = self.client._sanitize_kosync_xpath(text_node, 0.5)
+        self.assertEqual(repaired, "/body/DocFragment[27]/body/p[90].0")
+
+    def test_sanitize_collapses_inline_text_nodes_to_nearest_block(self):
+        inline_xpath = "/body/DocFragment[28]/body/p[20]/span/text()[2].166"
+        repaired = self.client._sanitize_kosync_xpath(inline_xpath, 0.5)
+        self.assertEqual(repaired, "/body/DocFragment[28]/body/p[20].0")
+
+    def test_sanitize_preserves_parent_structure_when_collapsing_inline_nodes(self):
+        inline_xpath = "/body/DocFragment[10]/body/section/p[4]/em/text().0"
+        repaired = self.client._sanitize_kosync_xpath(inline_xpath, 0.5)
+        self.assertEqual(repaired, "/body/DocFragment[10]/body/section/p[4].0")
 
     def test_empty_xpath_allowed_only_for_clear_progress(self):
         self.assertEqual(self.client._sanitize_kosync_xpath("", 0.0), "")
         self.assertIsNone(self.client._sanitize_kosync_xpath("", 0.2))
 
-    def test_sanitize_rejects_fragile_inline_xpath_segments(self):
+    def test_sanitize_collapses_fragile_inline_xpath_segments(self):
         inline_xpath = "/body/DocFragment[24]/body/p[15]/span[2]/text().0"
-        self.assertIsNone(self.client._sanitize_kosync_xpath(inline_xpath, 0.5))
+        self.assertEqual(
+            self.client._sanitize_kosync_xpath(inline_xpath, 0.5),
+            "/body/DocFragment[24]/body/p[15].0",
+        )
 
     def test_update_progress_skips_malformed_xpath_when_unrecoverable(self):
         self.ebook_parser.get_sentence_level_ko_xpath.return_value = None
@@ -55,7 +73,7 @@ class TestKoSyncXPathSafety(unittest.TestCase):
         self.kosync_api.update_progress.assert_called_once_with(
             "doc-2",
             0.73,
-            "/body/DocFragment[4]/body/p[1]/text().0",
+            "/body/DocFragment[4]/body/p[1].0",
         )
 
     def test_update_progress_replaces_fragile_inline_xpath(self):
@@ -75,7 +93,7 @@ class TestKoSyncXPathSafety(unittest.TestCase):
         self.kosync_api.update_progress.assert_called_once_with(
             "doc-4",
             0.61,
-            "/body/DocFragment[24]/body/p[15]/text().0",
+            "/body/DocFragment[24]/body/p[15].0",
         )
 
     def test_update_progress_clear_flow_forces_empty_xpath(self):


### PR DESCRIPTION
## Summary

This PR improves KOReader/KoSync compatibility for generated progress write-back.

It addresses two related failure modes discussed in #260:

1. ABS/audio-led sync could write a generated XPath such as a text-node or inline-child locator into KoSync. In KOReader on Kobo, those locators can resolve badly and send the reader to the cover/page 1 even when the percentage is correct.
2. KOReader/Kobo-originated progress could be treated as low-confidence when XPath resolution fell back to percentage, allowing stale ABS progress to overwrite a recent real KoSync PUT.

The changes here:

- collapse bridge-generated KoSync locators to block-level XPointers before write-back, e.g. `/body/DocFragment[38]/body/p[51].0`
- keep validating/using richer locators for internal resolution where possible
- preserve locator metadata in KoSync API responses
- trust recent external KoSync PUTs enough to let Kobo-side progress lead when the only confidence issue is percentage fallback
- add focused unit coverage for locator safety and recent external KoSync priority

## Field testing

I have been running this branch in my homelab against a Kobo using KOReader and Audiobookshelf-backed sync.

Observed results:

- ABS/audio -> Kobo no longer jumps to cover/page 1 for the EPUBs tested.
- Kobo/KOReader -> ABS progress handoff works, including overnight handoffs.
- Tested successfully across multiple books, including `Leviathan Wakes` and `Heart the Lover`.

This is not intended to claim universal KOReader locator validation. It is a narrower compatibility improvement: generated write-back locators avoid fragile text-node/inline-child anchors, while recent real KOReader updates are not discarded solely because XPath resolution had to fall back to percentage.

## Tests

```text
.venv/bin/python -m pytest -q tests/test_kosync_xpath_safety.py tests/test_cross_format_normalization_locator_priority.py tests/test_abs_unittest.py
41 passed, 1 warning
```

Fixes #260
