### PR TITLE
Guard against stale KoSync rollback deltas

### DIFF
--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -1713,6 +1713,8 @@ class SyncManager:
                         f"'{changed_client}' (low-confidence source=percent_fallback); evaluating all candidates"
                     )
                 elif changed_ts is not None and other_ts:
+                    max_other_ts = max(other_ts)
+                    NORMALIZED_LEAD_EPSILON_SECONDS = 2.0
                     changed_raw_pct = vals.get(changed_client)
                     changed_locator_pct = config[changed_client].current.get("_locator_pct")
                     has_locator_mismatch = (
@@ -1721,16 +1723,20 @@ class SyncManager:
                         and abs(changed_locator_pct - changed_raw_pct) > 0.01
                     )
 
-                    if has_locator_mismatch:
-                        max_other_ts = max(other_ts)
-                        NORMALIZED_LEAD_EPSILON_SECONDS = 2.0
-                        if changed_ts <= (max_other_ts + NORMALIZED_LEAD_EPSILON_SECONDS):
-                            single_delta_low_conf = True
-                            logger.info(
-                                f"🔄 '{abs_id}' '{title_snip}' Ignoring single-client delta from "
-                                f"'{changed_client}' (raw/locator mismatch and not ahead on normalized timeline: "
-                                f"{changed_ts:.1f}s vs max peer {max_other_ts:.1f}s); evaluating all candidates"
-                            )
+                    MATERIAL_ROLLBACK_SECONDS = 30.0
+                    material_rollback = changed_ts < (max_other_ts - MATERIAL_ROLLBACK_SECONDS)
+                    mismatch_not_ahead = has_locator_mismatch and changed_ts <= (max_other_ts + NORMALIZED_LEAD_EPSILON_SECONDS)
+                    if material_rollback or mismatch_not_ahead:
+                        single_delta_low_conf = True
+                        if material_rollback:
+                            reason = f"material rollback on normalized timeline (> {MATERIAL_ROLLBACK_SECONDS:.0f}s behind)"
+                        else:
+                            reason = "raw/locator mismatch and not ahead on normalized timeline"
+                        logger.info(
+                            f"🔄 '{abs_id}' '{title_snip}' Ignoring single-client delta from "
+                            f"'{changed_client}' ({reason}: "
+                            f"{changed_ts:.1f}s vs max peer {max_other_ts:.1f}s); evaluating all candidates"
+                        )
 
         if len(clients_with_delta) == 1 and not single_delta_low_conf:
             # Only one client changed - that client is the leader (most recent change wins)

--- a/tests/test_cross_format_normalization_locator_priority.py
+++ b/tests/test_cross_format_normalization_locator_priority.py
@@ -425,6 +425,44 @@ def test_single_non_abs_delta_must_be_ahead_on_normalized_timeline():
     assert leader_pct == config["ABS"].current["pct"]
 
 
+def test_single_kosync_delta_behind_abs_does_not_lead():
+    manager = SyncManager.__new__(SyncManager)
+
+    class _Client:
+        def can_be_leader(self):
+            return True
+
+    manager.sync_clients = {
+        "ABS": _Client(),
+        "KoSync": _Client(),
+        "Hardcover": _Client(),
+    }
+    manager.cross_format_deadband_seconds = 2.0
+    manager._has_significant_delta = MagicMock(side_effect=lambda name, cfg, book: name == "KoSync")
+    manager._normalize_for_cross_format_comparison = MagicMock(
+        return_value={"ABS": 15310.7, "KoSync": 7812.8, "Hardcover": 14600.0}
+    )
+
+    book = SimpleNamespace(duration=21175.4, transcript_file="DB_MANAGED", audio_source="ABS")
+    config = {
+        "ABS": _state({"pct": 0.7230, "ts": 15310.7}),
+        "KoSync": _state(
+            {
+                "pct": 0.3913,
+                "xpath": "/body/DocFragment[7]/body/div/p[706]/text()[1].0",
+                "_normalization_source": "xpath",
+            }
+        ),
+        "Hardcover": _state({"pct": 0.7344}),
+    }
+    config["KoSync"].previous_pct = 0.7360
+
+    leader, leader_pct = manager._determine_leader(config, book, "abs-heart", "Heart the Lover")
+
+    assert leader == "ABS"
+    assert leader_pct == config["ABS"].current["pct"]
+
+
 def test_single_storyteller_delta_with_href_progression_is_not_demoted():
     manager = SyncManager.__new__(SyncManager)
 


### PR DESCRIPTION
## Summary

Follow-up hardening after #268.

This guards against a rollback pattern observed during real KOReader/Kobo testing:

1. Kobo pulls the correct forward KoSync position from the bridge.
2. KOReader immediately PUTs its stale local position back to KoSync.
3. The bridge correctly refuses to move ABS backward, but without this guard the stale KoSync delta can still be selected as leader and pull follower state such as Hardcover backward.

The change makes single-client non-audio deltas lead only when their normalized timestamp is not materially behind the rest of the sync state. Small alignment fuzz is still allowed; the guard only demotes a single-client delta when it represents a material rollback on the normalized timeline.

## Field evidence

Observed after #268 was merged:

- ABS was around 72-83% forward.
- Kobo/KOReader pulled the forward KoSync value.
- KOReader then PUT a stale ~39% local position.
- Existing ABS update logic prevented ABS from moving backward.
- KoSync/Hardcover state could still be pulled backward without this leader-selection guard.

## Tests

```text
.venv/bin/python -m pytest -q tests/test_cross_format_normalization_locator_priority.py tests/test_kosync_xpath_safety.py tests/test_abs_unittest.py
42 passed, 1 warning
```
