### PR TITLE
Fix KoSync element-node XPath offsets

### DIFF
--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -1096,6 +1096,25 @@ class EbookParser:
         logger.warning(f"Could not resolve XPath in {filename}: {clean_xpath}")
         return None, None, None
 
+    def _parse_koreader_relative_xpath(self, relative_path: str):
+        """
+        Split KOReader's trailing character offset from the XPath target.
+
+        KOReader usually reports text-node targets such as
+        "/body/p[1]/text().42" or "/body/p[1]/text()[2].42", but pages with
+        images, empty tags, or block-only content can report element-node
+        targets such as "/body/p.0" or "/body/div[1].0".  lxml cannot evaluate
+        the latter until the terminal ".N" offset suffix is removed.
+        """
+        offset_match = re.search(r'\.(\d+)$', relative_path)
+        target_offset = int(offset_match.group(1)) if offset_match else 0
+
+        clean_xpath = re.sub(r'/text\(\)(?:\[\d+\])?\.\d+$', '', relative_path)
+        if clean_xpath == relative_path:
+            clean_xpath = re.sub(r'\.\d+$', '', relative_path)
+
+        return target_offset, clean_xpath
+
     def resolve_xpath(self, filename, xpath_str):
         """
         RESOLVER:
@@ -1113,14 +1132,11 @@ class EbookParser:
             book_path = self.resolve_book_path(filename)
             full_text, spine_map = self.extract_text_and_map(book_path)
 
-            # Parse path and offset. KOReader emits two forms for the trailing
-            # character offset: "/text().NNN" (single text node) and
-            # "/text()[N].MMM" (Nth text node when inline children split a
-            # paragraph's text into multiple nodes). Both must be recognised.
+            # Parse path and offset. KOReader usually emits text-node offsets,
+            # but can emit element-node offsets for image-only or block-only
+            # pages. Both must be recognised before lxml evaluates the path.
             relative_path = xpath_str.split(f"DocFragment[{spine_index}]")[-1]
-            offset_match = re.search(r'/text\(\)(?:\[\d+\])?\.(\d+)$', relative_path)
-            target_offset = int(offset_match.group(1)) if offset_match else 0
-            clean_xpath = re.sub(r'/text\(\)(?:\[\d+\])?\.\d+$', '', relative_path)
+            target_offset, clean_xpath = self._parse_koreader_relative_xpath(relative_path)
 
             if clean_xpath.startswith('/'):
                 clean_xpath = '.' + clean_xpath
@@ -1152,14 +1168,12 @@ class EbookParser:
             # 1. Extract anchor text directly from target node content only.
             node_text = target_node.text_content().strip()
             clean_anchor = " ".join(node_text.split())
-            if not clean_anchor:
-                return None
 
             # 2. Find this anchor in the BS4 content (spine_map item)
             # We search specifically in this chapter's content to minimize false positives
             bs4_chapter_text = BeautifulSoup(target_item['content'], 'html.parser').get_text(separator=' ', strip=True)
             
-            local_start_index = bs4_chapter_text.find(clean_anchor)
+            local_start_index = bs4_chapter_text.find(clean_anchor) if clean_anchor else -1
             
             if local_start_index != -1:
                 # Found it! Calculate global position
@@ -1238,9 +1252,7 @@ class EbookParser:
             full_text, spine_map = self.extract_text_and_map(book_path)
 
             relative_path = xpath_str.split(f"DocFragment[{spine_index}]")[-1]
-            offset_match = re.search(r'/text\(\)(?:\[\d+\])?\.(\d+)$', relative_path)
-            target_offset = int(offset_match.group(1)) if offset_match else 0
-            clean_xpath = re.sub(r'/text\(\)(?:\[\d+\])?\.\d+$', '', relative_path)
+            target_offset, clean_xpath = self._parse_koreader_relative_xpath(relative_path)
 
             if clean_xpath.startswith('/'):
                 clean_xpath = '.' + clean_xpath
@@ -1290,8 +1302,6 @@ class EbookParser:
 
             node_text = target_node.text_content().strip()
             clean_anchor = " ".join(node_text.split())
-            if not clean_anchor:
-                return None
             chapter_len = max(0, target_item['end'] - target_item['start'])
             chapter_base = target_item['start']
             full_len = len(full_text)

--- a/tests/test_resolve_xpath_to_index_bs4_fallback.py
+++ b/tests/test_resolve_xpath_to_index_bs4_fallback.py
@@ -181,6 +181,38 @@ def test_resolve_xpath_to_index_unbracketed_text_node_offset_still_works():
     assert index == 5
 
 
+def test_resolve_xpath_to_index_element_node_offset():
+    # KOReader can report element-node offsets on formatted chapter/title pages.
+    # The terminal ".N" suffix is a character offset, not part of lxml XPath.
+    html_content = (
+        "<html><body>"
+        "<p>Chapter</p>"
+        "<p>Opening sentence after the formatted heading.</p>"
+        "</body></html>"
+    )
+    parser = _parser_for_single_spine(html_content, start=20)
+
+    index = parser.resolve_xpath_to_index("book.epub", "/body/DocFragment[1]/body/p[1].3")
+
+    assert index == 23
+
+
+def test_resolve_xpath_to_index_empty_element_node_uses_position_fallback(caplog):
+    caplog.set_level(logging.DEBUG)
+    html_content = (
+        "<html><body>"
+        "<div class='chapter-art'><img alt='Chapter art' src='chapter.png'/></div>"
+        "<p>First readable paragraph.</p>"
+        "</body></html>"
+    )
+    parser = _parser_for_single_spine(html_content, start=15)
+
+    index = parser.resolve_xpath_to_index("book.epub", "/body/DocFragment[1]/body/div[1].0")
+
+    assert index == 15
+    assert any("lxml_position_fallback" in record.message for record in caplog.records)
+
+
 def test_resolve_xpath_to_index_falls_back_to_nearby_spine_when_docfragment_drifts(caplog):
     caplog.set_level(logging.INFO)
     parser = _parser_for_spines(


### PR DESCRIPTION
## Summary
- parse KOReader terminal offset suffixes on element-node XPaths like /body/p.0 and /body/div[1].0
- keep existing text-node offset handling for /text().N and /text()[N].N
- allow empty/image-only element targets to reach the lxml positional fallback instead of falling back to raw percentage sync

## Tests
- .venv/bin/python -m pytest tests/test_resolve_xpath_to_index_bs4_fallback.py
- .venv/bin/python -m pytest tests/test_kosync_xpath_safety.py tests/test_ebook_sentence_xpath_fallback.py tests/test_resolve_xpath_to_index_bs4_fallback.py