### PR TITLE
Fix CFI parsing to correctly handle spine step value of 6

### DIFF
--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -1712,20 +1712,22 @@ class EbookParser:
 
             if redirect_idx is not None:
                 package_steps = [step for step in combined_steps[:redirect_idx] if hasattr(step, "index")]
-                for step in reversed(package_steps):
-                    if step.index != 6:
-                        spine_step = int(step.index)
-                        break
+                # The package marker is the leading `/6` (spine container); the spine item
+                # is the last package step before the redirect. Identify it positionally so
+                # CFIs whose spine step is literally 6 (e.g. `/6/6!/...`) parse correctly.
+                if package_steps:
+                    spine_step = int(package_steps[-1].index)
                 element_steps = [step for step in combined_steps[redirect_idx + 1:] if hasattr(step, "index")]
             else:
                 indexed_steps = [step for step in combined_steps if hasattr(step, "index")]
-                for step in indexed_steps:
-                    if spine_step is None:
-                        if step.index == 6:
-                            continue
-                        spine_step = int(step.index)
-                    else:
-                        element_steps.append(step)
+                # No redirect: skip a single leading `/6` package marker (by position, not
+                # value-loop) so a spine item that is itself 6 is not discarded.
+                if indexed_steps and indexed_steps[0].index == 6 and len(indexed_steps) >= 2:
+                    spine_step = int(indexed_steps[1].index)
+                    element_steps = list(indexed_steps[2:])
+                elif indexed_steps:
+                    spine_step = int(indexed_steps[0].index)
+                    element_steps = list(indexed_steps[1:])
 
             char_offset = int(parsed_offset or 0)
             return spine_step, element_steps, char_offset

--- a/tests/test_cross_format_normalization_locator_priority.py
+++ b/tests/test_cross_format_normalization_locator_priority.py
@@ -523,6 +523,28 @@ def test_parse_cfi_components_supports_range_cfi():
     assert len(element_steps) > 0
 
 
+def test_parse_cfi_components_supports_spine_step_six():
+    parser = EbookParser.__new__(EbookParser)
+
+    spine_step, element_steps, char_offset = parser._parse_cfi_components(
+        "epubcfi(/6/6!/4/232/2/2/2:0)"
+    )
+
+    assert spine_step == 6
+    assert len(element_steps) > 0
+    assert char_offset == 0
+
+
+def test_parse_cfi_components_supports_minimal_cfi_with_spine_step_six():
+    parser = EbookParser.__new__(EbookParser)
+
+    spine_step, element_steps, char_offset = parser._parse_cfi_components("epubcfi(/6/6!/:0)")
+
+    assert spine_step == 6
+    assert element_steps == []
+    assert char_offset == 0
+
+
 def test_generate_cfi_never_emits_empty_element_path():
     parser = EbookParser.__new__(EbookParser)
 


### PR DESCRIPTION
## Summary

Fixed a bug in EPUB CFI (Canonical Fragment Identifier) parsing where spine items with an index of 6 were incorrectly discarded. The parser was using value-based logic to skip the package marker (`/6`), which caused CFIs with a spine step of 6 (e.g., `/6/6!/...`) to be misparsed.

## Changes

- **Refactored `_parse_cfi_components()` logic** in `src/utils/ebook_utils.py`:
  - Replaced value-based loop logic with positional-based step identification
  - For CFIs with a redirect: the spine item is now identified as the last package step (by position), not by skipping non-6 values
  - For CFIs without a redirect: the spine item is now identified as the second indexed step (if present), or the first step otherwise, rather than looping until a non-6 value is found
  - Added clarifying comments explaining the package marker and spine item identification strategy

- **Added test coverage** in `tests/test_cross_format_normalization_locator_priority.py`:
  - `test_parse_cfi_components_supports_spine_step_six()`: validates parsing of `/6/6!/4/232/2/2/2:0` correctly identifies spine step as 6
  - `test_parse_cfi_components_supports_minimal_cfi_with_spine_step_six()`: validates minimal CFI `/6/6!/:0` correctly identifies spine step as 6 with no element steps

## Implementation Details

The fix distinguishes between the package marker (the leading `/6` representing the spine container) and the spine item index by using positional logic rather than value matching. This allows CFIs where the actual spine item happens to be 6 to parse correctly without being filtered out.

https://claude.ai/code/session_016QsgFoCZXoHY22dhnEtccU