### PR TITLE
[codex] Add same-folder matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 - **Smart Alignment Sources**: Uses Storyteller forced-alignment transcripts when available, then SMIL, then Whisper fallback.
 - **Web UI**: Full management dashboard for tracking syncs and matching books.
 - **Library Suggestions Page**: Scan your library for likely audiobook + ebook pairs, review them, and queue matches in bulk.
+- **Same-Folder Matching**: Treat sibling audiobook and ebook files in the same
+  title folder as high-confidence matches.
 - **Guided Settings Workflow**: Check your service settings from the UI and save everything in one place.
 - **Optional Bridge Sync Plugin Collections**: If you install the Bridge Sync KOReader plugin, Grimmory shelves can be used to shape KOReader collections.
 - **Split-Port Security**: Expose only the sync API to the internet while keeping the dashboard on your LAN.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,6 +268,9 @@ Suggestions notes:
 - A normal scan reuses cached results so repeat scans are faster.
 - **Full Refresh** rescans the whole unmatched library from scratch.
 - Suggestions can queue ABS-backed links, Grimmory-audio links, ebook-only links, and Storyteller-only links.
+- If your audio and ebook providers expose the same mounted `/books` tree,
+  sibling files in the same title folder are treated as same-folder matches
+  before fuzzy or Ollama scoring.
 
 ### Transcription Settings
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,6 +145,10 @@ You can start in either of these ways:
 4. Add the good ones to the queue.
 5. Click **Process All**.
 
+If your audiobook and ebook services point at the same mounted `/books` tree,
+sibling audio and ebook files in the same title folder appear as high-confidence
+same-folder matches.
+
 ### Add Book
 
 1. Open **Add Book**.

--- a/src/services/audio_source_adapters.py
+++ b/src/services/audio_source_adapters.py
@@ -25,6 +25,7 @@ class AudioResult:
     display_name: str = ""
     provider_book_id: Optional[str] = None
     provider_file_id: Optional[str] = None
+    path: str = ""
 
 
 class AudioSourceAdapter:
@@ -105,6 +106,45 @@ class ABSAudioSourceAdapter(AudioSourceAdapter):
         metadata = media.get("metadata", {}) or item.get("metadata", {}) or {}
         return metadata.get("authorName") or ""
 
+    @staticmethod
+    def _extract_item_path(item: dict) -> str:
+        media = item.get("media", {}) or {}
+        metadata = media.get("metadata", {}) or item.get("metadata", {}) or {}
+        candidates = [
+            item.get("path"),
+            item.get("folderPath"),
+            item.get("relPath"),
+            media.get("path"),
+            media.get("folderPath"),
+            media.get("relPath"),
+            metadata.get("path"),
+            metadata.get("folderPath"),
+        ]
+
+        for library_file in item.get("libraryFiles", []) or []:
+            file_metadata = library_file.get("metadata", {}) or {}
+            candidates.extend([
+                library_file.get("path"),
+                library_file.get("relPath"),
+                file_metadata.get("path"),
+                file_metadata.get("relPath"),
+            ])
+
+        for audio_file in media.get("audioFiles", []) or []:
+            file_metadata = audio_file.get("metadata", {}) or {}
+            candidates.extend([
+                audio_file.get("path"),
+                audio_file.get("relPath"),
+                file_metadata.get("path"),
+                file_metadata.get("relPath"),
+            ])
+
+        for candidate in candidates:
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return ""
+
     def search(self, query: str) -> list[AudioResult]:
         library_scope = self._parse_library_scope()
         query_mode = bool(query)
@@ -145,6 +185,7 @@ class ABSAudioSourceAdapter(AudioSourceAdapter):
                     duration=float(duration) if duration is not None else None,
                     display_name=title,
                     provider_book_id=item_id,
+                    path=self._extract_item_path(item),
                 )
             )
         return results
@@ -255,6 +296,35 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
                     return seconds
         return None
 
+    @staticmethod
+    def _extract_book_path(book: dict) -> str:
+        info = book.get("audiobookInfo") or {}
+        primary_file = book.get("primaryFile") or {}
+        candidates = [
+            info.get("filePath"),
+            info.get("filepath"),
+            info.get("path"),
+            primary_file.get("filePath"),
+            primary_file.get("filepath"),
+            primary_file.get("path"),
+            book.get("filePath"),
+            book.get("filepath"),
+            book.get("path"),
+        ]
+
+        for track in info.get("tracks", []) or []:
+            candidates.extend([
+                track.get("filePath"),
+                track.get("filepath"),
+                track.get("path"),
+            ])
+
+        for candidate in candidates:
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return ""
+
     def search(self, query: str) -> list[AudioResult]:
         results: list[AudioResult] = []
         include_info = bool(query and query.strip())
@@ -278,6 +348,7 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
                     display_name=title,
                     provider_book_id=str(book_id),
                     provider_file_id=str(provider_file_id) if provider_file_id is not None else None,
+                    path=self._extract_book_path(book),
                 )
             )
         return results

--- a/src/services/shelf_watch_service.py
+++ b/src/services/shelf_watch_service.py
@@ -249,6 +249,7 @@ class ShelfWatchService:
             'title': (grimmory_book.get('title') or '').strip(),
             'authors': self._extract_author(grimmory_book),
             'grimmory_id': grimmory_id,
+            'path': grimmory_book.get('filePath') or grimmory_book.get('filepath') or grimmory_book.get('path') or '',
         }
 
         scan_result = self._get_suggestions_service()._scan_single_ebook(ebook_anchor, candidate_pool)

--- a/src/services/suggestions_service.py
+++ b/src/services/suggestions_service.py
@@ -270,6 +270,13 @@ class SuggestionsService:
     _SUGGEST_FUZZY_FLOOR = 45.0
     _SUGGEST_TITLE_STRONG = 85.0
 
+    # A same-folder pair is auto-trusted (exact 100, pinned ahead of and skipping the
+    # Ollama judge) only when the titles ALSO loosely agree. Without this, a lone
+    # audiobook + ebook that merely share a *grouping* folder — e.g. a flat author
+    # folder holding two different books — would surface as a confident 100% match and
+    # bypass all fuzzy/Ollama verification. Below the floor the pair stays reviewable.
+    _SAME_FOLDER_TITLE_FLOOR = 45.0
+
     @staticmethod
     def _normalize_title_for_match(text: str) -> str:
         """Strip surface noise that wrecks fuzzy/embedding scoring: leading numbering
@@ -359,6 +366,19 @@ class SuggestionsService:
             cls._parent_dir_key(right_path),
         )
 
+    @classmethod
+    def _same_folder_tier(cls, same_folder_count: int, title_score: float) -> tuple[float, str]:
+        """Score/reason for a same-folder candidate.
+
+        Exact ('same_folder', 100) requires the folder to hold a single candidate AND the
+        titles to loosely agree, so a wrong pairing sharing a grouping folder can't be
+        auto-trusted past the judge. Everything else stays reviewable
+        ('same_folder_ambiguous', 94, surfaced with a 'Same folder?' badge).
+        """
+        if same_folder_count == 1 and title_score >= cls._SAME_FOLDER_TITLE_FLOOR:
+            return 100.0, "same_folder"
+        return 94.0, "same_folder_ambiguous"
+
     def _suggestion_shell(self, ab: dict, matches: List[dict]) -> dict:
         """Build the suggestion dict skeleton (audio metadata + matches)."""
         audio_source = self._audio_source(ab)
@@ -429,11 +449,10 @@ class SuggestionsService:
             norm_candidate_title = self._normalize_title_for_match(candidate_info["title"])
 
             if self._paths_share_parent(audio_path, candidate_info.get("path")):
-                score = 100.0 if same_folder_count == 1 else 94.0
+                title_score = float(fuzz.token_sort_ratio(norm_audio_title, norm_candidate_title))
+                score, match_reason = self._same_folder_tier(same_folder_count, title_score)
                 match = self._match_from_pool(candidate_info, score)
-                match["match_reason"] = (
-                    "same_folder" if same_folder_count == 1 else "same_folder_ambiguous"
-                )
+                match["match_reason"] = match_reason
                 matches.append(match)
                 continue
 
@@ -1083,7 +1102,8 @@ class SuggestionsService:
                 cand.get("audio_path") or cand.get("path"),
             )
             if same_folder:
-                score = 100.0 if same_folder_count == 1 else 94.0
+                title_score = float(fuzz.token_sort_ratio(ebook_title, cand_title))
+                score, match_reason = self._same_folder_tier(same_folder_count, title_score)
                 matches.append({
                     "audio_source": cand.get("audio_source", ""),
                     "audio_source_id": cand.get("audio_source_id", ""),
@@ -1095,11 +1115,7 @@ class SuggestionsService:
                     "audio_provider_book_id": cand.get("audio_provider_book_id", ""),
                     "audio_provider_file_id": cand.get("audio_provider_file_id", ""),
                     "score": score,
-                    "match_reason": (
-                        "same_folder"
-                        if same_folder_count == 1
-                        else "same_folder_ambiguous"
-                    ),
+                    "match_reason": match_reason,
                 })
                 if best_overall is None or score > best_overall[0]:
                     best_overall = (score, cand_title, cand_author)

--- a/src/services/suggestions_service.py
+++ b/src/services/suggestions_service.py
@@ -91,6 +91,7 @@ class SuggestionsService:
                 "name": getattr(candidate, 'name', ''),
                 "display_name": getattr(candidate, 'display_name', None) or getattr(candidate, 'name', ''),
                 "abs_identifier": abs_identifier,
+                "path": getattr(candidate, 'path', None),
             })
 
         return prepared
@@ -173,6 +174,10 @@ class SuggestionsService:
         except (TypeError, ValueError):
             return None
 
+    def _audio_path(self, ab: dict) -> str:
+        raw_path = ab.get("audio_path") or ab.get("path") or ""
+        return str(raw_path).strip()
+
     def _audio_cover_url(self, ab: dict, audio_source: str, audio_source_id: str) -> str:
         cover_url = (ab.get("audio_cover_url") or ab.get("cover_url") or "").strip()
         if cover_url:
@@ -251,6 +256,7 @@ class SuggestionsService:
                     "author": candidate_info.get("author", ""),
                     "source": candidate_info.get("source", ""),
                     "source_id": candidate_info.get("source_id"),
+                    "source_path": candidate_info.get("path") or "",
                     "score": 100.0,
                 }
         return None
@@ -295,8 +301,61 @@ class SuggestionsService:
             "author": candidate_info.get("author", ""),
             "source": candidate_info.get("source", ""),
             "source_id": candidate_info.get("source_id"),
+            "source_path": candidate_info.get("path") or "",
             "score": round(score, 1),
         }
+
+    _SAME_FOLDER_MEDIA_EXTENSIONS = frozenset({
+        ".epub", ".pdf", ".mobi", ".azw", ".azw3", ".cbz", ".cbr",
+        ".m4b", ".mp3", ".m4a", ".flac", ".ogg", ".opus", ".aac", ".wav",
+    })
+
+    @classmethod
+    def _parent_dir_key(cls, raw_path: Any) -> str:
+        """Return a normalized parent-directory key for local media paths."""
+        text = str(raw_path or "").strip()
+        if not text or "://" in text:
+            return ""
+
+        normalized = text.replace("\\", "/").strip().rstrip("/")
+        if not normalized:
+            return ""
+
+        parts = [part for part in normalized.split("/") if part and part != "."]
+        if not parts:
+            return ""
+
+        last = parts[-1]
+        suffix = ""
+        if "." in last:
+            suffix = f".{last.rsplit('.', 1)[-1].lower()}"
+        if suffix in cls._SAME_FOLDER_MEDIA_EXTENSIONS:
+            parts = parts[:-1]
+
+        if not parts:
+            return ""
+        return "/".join(part.lower() for part in parts)
+
+    @staticmethod
+    def _same_directory_key(left_key: str, right_key: str) -> bool:
+        if not left_key or not right_key:
+            return False
+        left_parts = left_key.split("/")
+        right_parts = right_key.split("/")
+        if left_key == right_key:
+            return min(len(left_parts), len(right_parts)) >= 2
+
+        shorter_len = min(len(left_parts), len(right_parts))
+        if shorter_len < 2:
+            return False
+        return left_parts[-shorter_len:] == right_parts[-shorter_len:]
+
+    @classmethod
+    def _paths_share_parent(cls, left_path: Any, right_path: Any) -> bool:
+        return cls._same_directory_key(
+            cls._parent_dir_key(left_path),
+            cls._parent_dir_key(right_path),
+        )
 
     def _suggestion_shell(self, ab: dict, matches: List[dict]) -> dict:
         """Build the suggestion dict skeleton (audio metadata + matches)."""
@@ -315,6 +374,7 @@ class SuggestionsService:
             "audio_author": audio_author,
             "audio_duration": audio_duration,
             "audio_cover_url": audio_cover_url,
+            "audio_path": self._audio_path(ab),
             "audio_provider_book_id": str(ab.get("audio_provider_book_id") or audio_source_id or ""),
             "audio_provider_file_id": str(ab.get("audio_provider_file_id") or ""),
             # Legacy aliases kept for template/session compatibility.
@@ -357,9 +417,23 @@ class SuggestionsService:
 
         norm_audio_title = self._normalize_title_for_match(audio_title)
         matches = []
+        audio_path = self._audio_path(ab)
+        same_folder_count = sum(
+            1 for candidate_info in per_book_pool
+            if self._paths_share_parent(audio_path, candidate_info.get("path"))
+        )
         for candidate_info in per_book_pool:
             candidate_author = candidate_info["author"]
             norm_candidate_title = self._normalize_title_for_match(candidate_info["title"])
+
+            if self._paths_share_parent(audio_path, candidate_info.get("path")):
+                score = 100.0 if same_folder_count == 1 else 94.0
+                match = self._match_from_pool(candidate_info, score)
+                match["match_reason"] = (
+                    "same_folder" if same_folder_count == 1 else "same_folder_ambiguous"
+                )
+                matches.append(match)
+                continue
 
             title_score = float(fuzz.token_sort_ratio(norm_audio_title, norm_candidate_title))
             if audio_author:
@@ -896,6 +970,7 @@ class SuggestionsService:
                 "audio_author": audio_author,
                 "audio_duration": audio_duration,
                 "audio_cover_url": audio_cover_url,
+                "audio_path": self._audio_path(ab),
                 "audio_provider_book_id": str(ab.get("audio_provider_book_id") or audio_source_id or ""),
                 "audio_provider_file_id": str(ab.get("audio_provider_file_id") or ""),
                 "search_text": f"{audio_title} {audio_author}".strip(),
@@ -922,11 +997,18 @@ class SuggestionsService:
         grimmory_id = ebook.get("grimmory_id") or ebook.get("id") or ebook.get("book_id")
         if grimmory_id is not None:
             grimmory_id = str(grimmory_id).strip()
+        path = str(
+            ebook.get("path")
+            or ebook.get("filePath")
+            or ebook.get("filepath")
+            or ""
+        ).strip()
         return {
             "title": title,
             "author": author,
             "filename": filename,
             "grimmory_id": grimmory_id or "",
+            "path": path,
         }
 
     def _scan_single_ebook(self, ebook: dict, candidate_pool: List[dict]) -> Optional[dict]:
@@ -956,9 +1038,43 @@ class SuggestionsService:
 
         matches = []
         best_overall = None  # Track the highest-scoring candidate even if below the floor.
+        same_folder_count = sum(
+            1 for cand in candidate_pool
+            if self._paths_share_parent(
+                anchor.get("path"),
+                cand.get("audio_path") or cand.get("path"),
+            )
+        )
         for cand in candidate_pool:
             cand_title = cand.get("audio_title") or ""
             cand_author = cand.get("audio_author") or ""
+
+            same_folder = self._paths_share_parent(
+                anchor.get("path"),
+                cand.get("audio_path") or cand.get("path"),
+            )
+            if same_folder:
+                score = 100.0 if same_folder_count == 1 else 94.0
+                matches.append({
+                    "audio_source": cand.get("audio_source", ""),
+                    "audio_source_id": cand.get("audio_source_id", ""),
+                    "bridge_key": cand.get("bridge_key", ""),
+                    "audio_title": cand_title,
+                    "audio_author": cand_author,
+                    "audio_duration": cand.get("audio_duration"),
+                    "audio_cover_url": cand.get("audio_cover_url", ""),
+                    "audio_provider_book_id": cand.get("audio_provider_book_id", ""),
+                    "audio_provider_file_id": cand.get("audio_provider_file_id", ""),
+                    "score": score,
+                    "match_reason": (
+                        "same_folder"
+                        if same_folder_count == 1
+                        else "same_folder_ambiguous"
+                    ),
+                })
+                if best_overall is None or score > best_overall[0]:
+                    best_overall = (score, cand_title, cand_author)
+                continue
 
             title_score = float(fuzz.token_sort_ratio(ebook_title, cand_title))
             if ebook_author:

--- a/src/services/suggestions_service.py
+++ b/src/services/suggestions_service.py
@@ -74,6 +74,8 @@ class SuggestionsService:
             candidate_author = self._candidate_author(candidate)
             candidate_source = (getattr(candidate, 'source', None) or '').strip()
             source_id = getattr(candidate, 'source_id', None) or getattr(candidate, 'booklore_id', None)
+            raw_path = getattr(candidate, 'path', None)
+            path = str(raw_path) if raw_path else None
 
             abs_identifier = getattr(candidate, 'abs_identifier', None)
             if not abs_identifier and resolver_enabled and candidate_source.upper() == 'CWA' and source_id:
@@ -91,7 +93,7 @@ class SuggestionsService:
                 "name": getattr(candidate, 'name', ''),
                 "display_name": getattr(candidate, 'display_name', None) or getattr(candidate, 'name', ''),
                 "abs_identifier": abs_identifier,
-                "path": getattr(candidate, 'path', None),
+                "path": path,
             })
 
         return prepared
@@ -571,10 +573,27 @@ class SuggestionsService:
         """
         if not matches or not self._ollama_ready():
             return matches
+        matches = self._pin_exact_same_folder_match(matches)
+        if self._has_exact_same_folder_match(matches):
+            return matches
 
         matches = self._ollama_rerank_band(audio_title, audio_author, matches)
         matches = self._ollama_judge_and_resolve(audio_title, audio_author, matches)
         return matches
+
+    @staticmethod
+    def _has_exact_same_folder_match(matches: List[dict]) -> bool:
+        return bool(matches and matches[0].get("match_reason") == "same_folder")
+
+    @staticmethod
+    def _pin_exact_same_folder_match(matches: List[dict]) -> List[dict]:
+        """Keep the unique same-folder match ahead of optional LLM reranking."""
+        if not matches:
+            return matches
+        exact = next((m for m in matches if m.get("match_reason") == "same_folder"), None)
+        if exact is None:
+            return matches
+        return [exact] + [m for m in matches if m is not exact]
 
     def _apply_ollama_reranking_batch(self, suggestions: List[dict]) -> Set[str]:
         """Re-rank (embeddings) then judge-gate (chat) all fresh suggestions, batched by
@@ -596,8 +615,16 @@ class SuggestionsService:
         if not rerank_on and not judge_on:
             return suppressed
 
-        # Phase A — embedding re-rank (nomic loads once).
-        rerankable = [s for s in suggestions if len(s.get("matches") or []) >= 2]
+        for s in suggestions:
+            s["matches"] = self._pin_exact_same_folder_match(s.get("matches") or [])
+
+        # Phase A — embedding re-rank (nomic loads once). Exact same-folder matches
+        # are deterministic and must not be demoted by semantic title/author scoring.
+        rerankable = [
+            s for s in suggestions
+            if len(s.get("matches") or []) >= 2
+            and not self._has_exact_same_folder_match(s.get("matches") or [])
+        ]
         if rerank_on and rerankable:
             self._prewarm_rerank_embeddings(rerankable)
             for s in rerankable:
@@ -617,6 +644,8 @@ class SuggestionsService:
         for s in suggestions:
             matches = s.get("matches") or []
             if not matches:
+                continue
+            if self._has_exact_same_folder_match(matches):
                 continue
             # A strong fuzzy+semantic top match is almost certainly correct — trust it
             # and spend no chat call.

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -2188,6 +2188,7 @@ def get_suggestion_audiobooks():
                 "audio_author": author,
                 "audio_duration": item.duration,
                 "audio_cover_url": item.cover_url or "",
+                "audio_path": item.path or "",
                 "audio_provider_book_id": str(item.provider_book_id or source_id),
                 "audio_provider_file_id": str(item.provider_file_id or ""),
                 # Legacy aliases maintained for compatibility with existing templates/session keys.
@@ -2258,6 +2259,7 @@ def get_searchable_ebooks(search_term):
                             subtitle=b.get('subtitle'),
                             authors=b.get('authors'),
                             booklore_id=b.get('id'),
+                            path=b.get('filePath') or b.get('filepath') or b.get('path'),
                             source='Grimmory'
                         ))
         except Exception as e:
@@ -2290,6 +2292,7 @@ def get_searchable_ebooks(search_term):
                     name=fname,
                     title=b.get('title'),
                     authors=b.get('authors'),
+                    path=b.get('filePath') or b.get('filepath') or b.get('path'),
                     source='BookOrbit',
                     source_id=b.get('id'),
                 ))

--- a/templates/suggestions.html
+++ b/templates/suggestions.html
@@ -66,6 +66,7 @@
         .source-badge.localfile { background: rgba(156,39,176,0.2); color: #ce93d8; }
         .source-badge.unknown { background: rgba(255,255,255,0.14); color: rgba(255,255,255,0.85); }
         .source-badge.transcript { background: rgba(167,139,250,0.2); color: #a78bfa; }
+        .source-badge.samefolder { background: rgba(45,212,191,0.18); color: #5eead4; }
         .score { display: inline-block; margin-bottom: 4px; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 700; color: #7ec8ff; background: rgba(126,200,255,0.12); border: 1px solid rgba(126,200,255,0.32); }
         .card-actions { margin-top: 8px; width: 100%; display: flex; gap: 8px; justify-content: flex-start; flex-wrap: wrap; }
         .card-actions .btn { opacity: 1; border-width: 1px; font-weight: 700; }
@@ -302,6 +303,7 @@
                             <input type="hidden" name="ebook_display_name" id="selected_ebook_display_name" value="">
                             <input type="hidden" name="ebook_source" id="selected_ebook_source" value="">
                             <input type="hidden" name="ebook_source_id" id="selected_ebook_source_id" value="">
+                            <input type="hidden" name="ebook_source_path" id="selected_ebook_source_path" value="">
                             <input type="hidden" name="storyteller_uuid" id="selected_storyteller_uuid" value="">
                             <label class="field-label" for="storytellerCardGrid">Storyteller (Preferred)</label>
                             <p class="field-hint">Optional. Choose this to create a tri-link.</p>
@@ -497,12 +499,13 @@
                 });
         }
 
-        function setSelectedEbook(filename, displayName, source = '', sourceId = '') {
+        function setSelectedEbook(filename, displayName, source = '', sourceId = '', sourcePath = '') {
             const hasSelection = !!filename;
             document.getElementById('selected_ebook_filename').value = hasSelection ? filename : '';
             document.getElementById('selected_ebook_display_name').value = hasSelection ? (displayName || filename) : '';
             document.getElementById('selected_ebook_source').value = hasSelection ? (source || '') : '';
             document.getElementById('selected_ebook_source_id').value = hasSelection ? (sourceId || '') : '';
+            document.getElementById('selected_ebook_source_path').value = hasSelection ? (sourcePath || '') : '';
             updateAddButton();
         }
 
@@ -510,10 +513,10 @@
             document.querySelectorAll('#ebookCardGrid .ebook-card').forEach((card) => card.classList.remove('selected'));
         }
 
-        function selectEbookCard(element, filename, displayName, source, sourceId) {
+        function selectEbookCard(element, filename, displayName, source, sourceId, sourcePath) {
             clearSelectedEbookCards();
             if (element) element.classList.add('selected');
-            setSelectedEbook(filename, displayName, source, sourceId);
+            setSelectedEbook(filename, displayName, source, sourceId, sourcePath);
         }
 
         function updateAddButton() {
@@ -749,6 +752,8 @@
                 const displayName = match.display_name || ebookFilename;
                 const source = match.source || inferSourceFromFilename(ebookFilename);
                 const sourceId = match.source_id || '';
+                const sourcePath = match.source_path || match.path || '';
+                const matchReason = match.match_reason || '';
                 const author = match.author || '';
                 const score = Math.round(match.score || 0);
 
@@ -758,7 +763,15 @@
                 card.dataset.displayName = displayName;
                 card.dataset.source = source || '';
                 card.dataset.sourceId = sourceId || '';
-                card.onclick = () => selectEbookCard(card, ebookFilename, displayName, source, sourceId);
+                card.dataset.sourcePath = sourcePath || '';
+                card.onclick = () => selectEbookCard(
+                    card,
+                    ebookFilename,
+                    displayName,
+                    source,
+                    sourceId,
+                    sourcePath
+                );
 
                 const icon = document.createElement('div');
                 icon.className = 'ebook-icon';
@@ -791,6 +804,13 @@
                     card.appendChild(badge);
                 }
 
+                if (matchReason === 'same_folder' || matchReason === 'same_folder_ambiguous') {
+                    const folderBadge = document.createElement('span');
+                    folderBadge.className = 'source-badge samefolder';
+                    folderBadge.textContent = matchReason === 'same_folder' ? 'Same folder' : 'Same folder?';
+                    card.appendChild(folderBadge);
+                }
+
                 grid.appendChild(card);
             });
 
@@ -804,6 +824,7 @@
                         firstCard.dataset.displayName || '',
                         firstCard.dataset.source || '',
                         firstCard.dataset.sourceId || '',
+                        firstCard.dataset.sourcePath || '',
                     );
                 }
             } else {

--- a/tests/test_suggestions_same_folder.py
+++ b/tests/test_suggestions_same_folder.py
@@ -37,14 +37,14 @@ def _ebook(title: str, path: str) -> SimpleNamespace:
 def test_scan_single_audiobook_scores_same_folder_as_exact_match():
     svc = _build_service()
     candidate_pool = svc._prepare_candidate_pool([
-        _ebook("Unrelated Ebook Title", "/books/Alice/Series/Shared Folder/book.epub"),
+        _ebook("Shared Title Book", "/books/Alice/Series/Shared Folder/book.epub"),
     ])
 
     result = svc._scan_single_audiobook(
         {
             "audio_source": "ABS",
             "audio_source_id": "abs-1",
-            "audio_title": "Totally Different Audio Title",
+            "audio_title": "Shared Title Book",
             "audio_author": "Different Author",
             "audio_path": "/books/Alice/Series/Shared Folder/audio.m4b",
         },
@@ -54,6 +54,31 @@ def test_scan_single_audiobook_scores_same_folder_as_exact_match():
     assert result is not None
     assert result["matches"][0]["score"] == 100.0
     assert result["matches"][0]["match_reason"] == "same_folder"
+
+
+def test_same_folder_with_grossly_mismatched_titles_stays_reviewable():
+    # A lone audiobook + ebook sharing a folder but with unrelated titles (e.g. two
+    # different books in a flat author folder) must NOT be auto-trusted as an exact
+    # 100% match — it stays reviewable so the judge gate / user can vet it.
+    svc = _build_service()
+    candidate_pool = svc._prepare_candidate_pool([
+        _ebook("Warbreaker", "/books/Sanderson/warbreaker.epub"),
+    ])
+
+    result = svc._scan_single_audiobook(
+        {
+            "audio_source": "ABS",
+            "audio_source_id": "abs-1",
+            "audio_title": "Mistborn",
+            "audio_author": "Different Author",
+            "audio_path": "/books/Sanderson/audio.m4b",
+        },
+        candidate_pool,
+    )
+
+    assert result is not None
+    assert result["matches"][0]["score"] == 94.0
+    assert result["matches"][0]["match_reason"] == "same_folder_ambiguous"
 
 
 def test_candidate_path_is_json_serializable():
@@ -121,14 +146,14 @@ def test_exact_same_folder_match_skips_ollama_reranking(monkeypatch):
 def test_same_folder_match_allows_relative_suffix_paths():
     svc = _build_service()
     candidate_pool = svc._prepare_candidate_pool([
-        _ebook("Unrelated Ebook Title", "/books/Alice/Series/Shared Folder/book.epub"),
+        _ebook("Shared Title Book", "/books/Alice/Series/Shared Folder/book.epub"),
     ])
 
     result = svc._scan_single_audiobook(
         {
             "audio_source": "ABS",
             "audio_source_id": "abs-1",
-            "audio_title": "Totally Different Audio Title",
+            "audio_title": "Shared Title Book",
             "audio_author": "Different Author",
             "audio_path": "Alice/Series/Shared Folder",
         },

--- a/tests/test_suggestions_same_folder.py
+++ b/tests/test_suggestions_same_folder.py
@@ -1,5 +1,7 @@
+import json
 import os
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -52,6 +54,68 @@ def test_scan_single_audiobook_scores_same_folder_as_exact_match():
     assert result is not None
     assert result["matches"][0]["score"] == 100.0
     assert result["matches"][0]["match_reason"] == "same_folder"
+
+
+def test_candidate_path_is_json_serializable():
+    svc = _build_service()
+    candidate_pool = svc._prepare_candidate_pool([
+        _ebook("Unrelated Ebook Title", Path("/books/Alice/Series/Shared Folder/book.epub")),
+    ])
+
+    result = svc._scan_single_audiobook(
+        {
+            "audio_source": "ABS",
+            "audio_source_id": "abs-1",
+            "audio_title": "Totally Different Audio Title",
+            "audio_author": "Different Author",
+            "audio_path": "/books/Alice/Series/Shared Folder/audio.m4b",
+        },
+        candidate_pool,
+    )
+
+    assert result is not None
+    assert isinstance(result["matches"][0]["source_path"], str)
+    json.dumps(result)
+
+
+def test_exact_same_folder_match_skips_ollama_reranking(monkeypatch):
+    svc = _build_service()
+    ollama = MagicMock()
+    ollama.is_configured.return_value = True
+    ollama.embed.side_effect = AssertionError("same-folder matches must not be embedded")
+    ollama.judge.side_effect = AssertionError("same-folder matches must not be judged")
+    svc.ollama_client = ollama
+    monkeypatch.setenv("OLLAMA_RERANK_SUGGESTIONS", "true")
+    monkeypatch.setenv("OLLAMA_JUDGE_SUGGESTIONS", "true")
+    monkeypatch.setenv("OLLAMA_SUGGEST_JUDGE_GATE", "true")
+
+    suggestions = [{
+        "bridge_key": "abs-1",
+        "audio_title": "Totally Different Audio Title",
+        "audio_author": "Different Author",
+        "matches": [
+            {
+                "display_name": "Unrelated Ebook Title.epub",
+                "author": "Different Author",
+                "score": 100.0,
+                "match_reason": "same_folder",
+                "ebook_filename": "book.epub",
+            },
+            {
+                "display_name": "Fuzzy Candidate.epub",
+                "author": "Different Author",
+                "score": 99.0,
+                "ebook_filename": "fuzzy.epub",
+            },
+        ],
+    }]
+
+    suppressed = svc._apply_ollama_reranking_batch(suggestions)
+
+    assert suppressed == set()
+    assert suggestions[0]["matches"][0]["match_reason"] == "same_folder"
+    ollama.embed.assert_not_called()
+    ollama.judge.assert_not_called()
 
 
 def test_same_folder_match_allows_relative_suffix_paths():

--- a/tests/test_suggestions_same_folder.py
+++ b/tests/test_suggestions_same_folder.py
@@ -1,0 +1,82 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.services.suggestions_service import SuggestionsService
+
+
+def _build_service() -> SuggestionsService:
+    return SuggestionsService(
+        database_service=MagicMock(),
+        container=MagicMock(),
+        manager=MagicMock(),
+        get_audiobooks_conditionally=lambda: [],
+        get_searchable_ebooks=lambda _q: [],
+        audiobook_matches_search=lambda _ab, _q: False,
+        get_abs_author=lambda _ab: '',
+        logger=MagicMock(),
+    )
+
+
+def _ebook(title: str, path: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=f"{title}.epub",
+        title=title,
+        authors="Different Author",
+        source="Grimmory",
+        source_id=f"ebook-{title}",
+        path=path,
+    )
+
+
+def test_scan_single_audiobook_scores_same_folder_as_exact_match():
+    svc = _build_service()
+    candidate_pool = svc._prepare_candidate_pool([
+        _ebook("Unrelated Ebook Title", "/books/Alice/Series/Shared Folder/book.epub"),
+    ])
+
+    result = svc._scan_single_audiobook(
+        {
+            "audio_source": "ABS",
+            "audio_source_id": "abs-1",
+            "audio_title": "Totally Different Audio Title",
+            "audio_author": "Different Author",
+            "audio_path": "/books/Alice/Series/Shared Folder/audio.m4b",
+        },
+        candidate_pool,
+    )
+
+    assert result is not None
+    assert result["matches"][0]["score"] == 100.0
+    assert result["matches"][0]["match_reason"] == "same_folder"
+
+
+def test_same_folder_match_allows_relative_suffix_paths():
+    svc = _build_service()
+    candidate_pool = svc._prepare_candidate_pool([
+        _ebook("Unrelated Ebook Title", "/books/Alice/Series/Shared Folder/book.epub"),
+    ])
+
+    result = svc._scan_single_audiobook(
+        {
+            "audio_source": "ABS",
+            "audio_source_id": "abs-1",
+            "audio_title": "Totally Different Audio Title",
+            "audio_author": "Different Author",
+            "audio_path": "Alice/Series/Shared Folder",
+        },
+        candidate_pool,
+    )
+
+    assert result is not None
+    assert result["matches"][0]["score"] == 100.0
+
+
+def test_same_folder_match_ignores_bare_filenames_and_shared_roots():
+    svc = _build_service()
+
+    assert not svc._paths_share_parent("audio.m4b", "book.epub")
+    assert not svc._paths_share_parent("/books/audio.m4b", "/books/book.epub")

--- a/tests/test_suggestions_scan_single_ebook.py
+++ b/tests/test_suggestions_scan_single_ebook.py
@@ -149,7 +149,7 @@ def test_scan_single_ebook_scores_same_folder_as_exact_match():
         "audio_source": "ABS",
         "audio_source_id": "abs-1",
         "bridge_key": "abs-1",
-        "audio_title": "Totally Different Audio Title",
+        "audio_title": "Shared Title Book",
         "audio_author": "Different Author",
         "audio_duration": 3600.0,
         "audio_cover_url": "",
@@ -157,7 +157,7 @@ def test_scan_single_ebook_scores_same_folder_as_exact_match():
     }]
     result = svc._scan_single_ebook(
         {
-            "title": "Unrelated Ebook Title",
+            "title": "Shared Title Book",
             "authors": "Another Author",
             "filename": "book.epub",
             "path": "/books/Alice/Series/Shared Folder/book.epub",
@@ -168,6 +168,34 @@ def test_scan_single_ebook_scores_same_folder_as_exact_match():
     assert result is not None
     assert result["matches"][0]["score"] == 100.0
     assert result["matches"][0]["match_reason"] == "same_folder"
+
+
+def test_scan_single_ebook_same_folder_mismatched_titles_stay_reviewable():
+    # Same folder but unrelated titles must not be auto-trusted as an exact 100% match.
+    svc = _build_service()
+    pool = [{
+        "audio_source": "ABS",
+        "audio_source_id": "abs-1",
+        "bridge_key": "abs-1",
+        "audio_title": "Mistborn",
+        "audio_author": "Different Author",
+        "audio_duration": 3600.0,
+        "audio_cover_url": "",
+        "audio_path": "/books/Sanderson/audio.m4b",
+    }]
+    result = svc._scan_single_ebook(
+        {
+            "title": "Warbreaker",
+            "authors": "Another Author",
+            "filename": "warbreaker.epub",
+            "path": "/books/Sanderson/warbreaker.epub",
+            "id": "2",
+        },
+        pool,
+    )
+    assert result is not None
+    assert result["matches"][0]["score"] == 94.0
+    assert result["matches"][0]["match_reason"] == "same_folder_ambiguous"
 
 
 def test_ebook_anchor_fields_normalises_authors_list():

--- a/tests/test_suggestions_scan_single_ebook.py
+++ b/tests/test_suggestions_scan_single_ebook.py
@@ -27,8 +27,8 @@ def _build_service(audiobooks=None):
     )
 
 
-def _ab(audio_source_id, title, author=None, duration=3600.0):
-    return {
+def _ab(audio_source_id, title, author=None, duration=3600.0, path=""):
+    record = {
         "audio_source": "ABS",
         "audio_source_id": audio_source_id,
         "audio_title": title,
@@ -36,6 +36,9 @@ def _ab(audio_source_id, title, author=None, duration=3600.0):
         "audio_duration": duration,
         "audio_cover_url": "",
     }
+    if path:
+        record["audio_path"] = path
+    return record
 
 
 def test_build_pool_filters_titleless():
@@ -138,6 +141,33 @@ def test_scan_single_ebook_sorts_by_score():
     scores = [m["score"] for m in result["matches"]]
     assert scores == sorted(scores, reverse=True)
     assert result["matches"][0]["audio_source_id"] == "high"
+
+
+def test_scan_single_ebook_scores_same_folder_as_exact_match():
+    svc = _build_service()
+    pool = [{
+        "audio_source": "ABS",
+        "audio_source_id": "abs-1",
+        "bridge_key": "abs-1",
+        "audio_title": "Totally Different Audio Title",
+        "audio_author": "Different Author",
+        "audio_duration": 3600.0,
+        "audio_cover_url": "",
+        "audio_path": "/books/Alice/Series/Shared Folder/audio.m4b",
+    }]
+    result = svc._scan_single_ebook(
+        {
+            "title": "Unrelated Ebook Title",
+            "authors": "Another Author",
+            "filename": "book.epub",
+            "path": "/books/Alice/Series/Shared Folder/book.epub",
+            "id": "2",
+        },
+        pool,
+    )
+    assert result is not None
+    assert result["matches"][0]["score"] == 100.0
+    assert result["matches"][0]["match_reason"] == "same_folder"
 
 
 def test_ebook_anchor_fields_normalises_authors_list():


### PR DESCRIPTION
Addresses #294.

## Summary

- propagate provider/local filesystem paths through audio and ebook suggestion candidates
- treat a unique shared parent folder as a deterministic 100% same-folder match before fuzzy or Ollama scoring
- keep ambiguous same-folder siblings reviewable with a lower score and visible badge
- preserve ebook source paths through the Suggestions queue and document the behavior

## Validation

- `.venv/bin/python -m pytest tests/ -q`
- `.venv/bin/python -m pytest tests/test_suggestions_same_folder.py tests/test_suggestions_scan_single_ebook.py tests/test_suggestions_authoritative_match.py -q`
- `git diff --check`
