### PR TITLE
[codex] Fix split-root same-folder suggestions

### DIFF
--- a/src/services/suggestions_service.py
+++ b/src/services/suggestions_service.py
@@ -318,6 +318,13 @@ class SuggestionsService:
         ".epub", ".pdf", ".mobi", ".azw", ".azw3", ".cbz", ".cbr",
         ".m4b", ".mp3", ".m4a", ".flac", ".ogg", ".opus", ".aac", ".wav",
     })
+    _EQUIVALENT_LIBRARY_ROOTS = frozenset({
+        "books",
+        "ebooks",
+        "audiobooks",
+        "linker_books",
+        "storyteller_library",
+    })
 
     @classmethod
     def _parent_dir_key(cls, raw_path: Any) -> str:
@@ -345,13 +352,24 @@ class SuggestionsService:
             return ""
         return "/".join(part.lower() for part in parts)
 
-    @staticmethod
-    def _same_directory_key(left_key: str, right_key: str) -> bool:
+    @classmethod
+    def _drop_equivalent_library_root(cls, parts: List[str]) -> List[str]:
+        if parts and parts[0] in cls._EQUIVALENT_LIBRARY_ROOTS:
+            return parts[1:]
+        return parts
+
+    @classmethod
+    def _same_directory_key(cls, left_key: str, right_key: str) -> bool:
         if not left_key or not right_key:
             return False
         left_parts = left_key.split("/")
         right_parts = right_key.split("/")
         if left_key == right_key:
+            return min(len(left_parts), len(right_parts)) >= 2
+
+        left_parts = cls._drop_equivalent_library_root(left_parts)
+        right_parts = cls._drop_equivalent_library_root(right_parts)
+        if left_parts == right_parts:
             return min(len(left_parts), len(right_parts)) >= 2
 
         shorter_len = min(len(left_parts), len(right_parts))

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1391,7 +1391,7 @@ def find_ebook_file(filename):
 
 
 def get_kosync_id_for_ebook(ebook_filename, booklore_id=None, original_filename=None,
-                            bookorbit_id=None):
+                            bookorbit_id=None, source_path=None):
     """Get KOSync document ID for an ebook.
     Tries Grimmory API first (if configured and booklore_id provided),
     falls back to filesystem, then BookOrbit / ABS / CWA on-demand downloads.
@@ -1410,8 +1410,21 @@ def get_kosync_id_for_ebook(ebook_filename, booklore_id=None, original_filename=
         except Exception as e:
             logger.warning(f"⚠️ Failed to get KOSync ID from Grimmory, falling back to filesystem: {e}")
 
-    # Fall back to filesystem
-    ebook_path = find_ebook_file(ebook_filename)
+    # Fall back to filesystem. When a queue item carries the selected local source path,
+    # prefer it over filename-only globbing so duplicate basenames do not hash the wrong book.
+    ebook_path = None
+    source_path_text = str(source_path or "").strip()
+    if source_path_text and "://" not in source_path_text:
+        try:
+            selected_path = Path(source_path_text)
+            if selected_path.exists() and selected_path.is_file():
+                ebook_path = selected_path
+            else:
+                logger.debug(f"Selected ebook source path not found, falling back to filename search: '{source_path_text}'")
+        except Exception as e:
+            logger.debug(f"Selected ebook source path could not be used, falling back to filename search: {e}")
+    if not ebook_path:
+        ebook_path = find_ebook_file(ebook_filename)
     if not ebook_path and original_filename:
         # [Tri-Link] Fallback to original filename if Storyteller file not found/relevant
         logger.debug(f"Primary file '{ebook_filename}' not found, checking original '{original_filename}'")
@@ -2514,6 +2527,7 @@ def _create_or_update_booklore_audio_mapping(
     ebook_source,
     ebook_source_id,
     storyteller_uuid,
+    ebook_source_path=None,
 ):
     bridge_key = _build_bridge_key("BookLore", audio_source_id)
     existing_book = (
@@ -2554,7 +2568,11 @@ def _create_or_update_booklore_audio_mapping(
             "Grimmory audiobook match",
         )
     else:
-        kosync_doc_id = get_kosync_id_for_ebook(resolved_ebook_filename, booklore_ebook_id)
+        kosync_doc_id = get_kosync_id_for_ebook(
+            resolved_ebook_filename,
+            booklore_ebook_id,
+            source_path=ebook_source_path,
+        )
 
     if existing_book and existing_book.kosync_doc_id:
         kosync_doc_id = existing_book.kosync_doc_id
@@ -4144,6 +4162,7 @@ def match():
         selected_filename = (request.form.get('ebook_filename') or '').strip() or None
         ebook_source = (request.form.get('ebook_source') or request.form.get('source_type') or '').strip() or None
         ebook_source_id = (request.form.get('ebook_source_id') or request.form.get('source_id') or '').strip() or None
+        source_path = (request.form.get('ebook_source_path') or request.form.get('source_path') or '').strip() or None
         storyteller_uuid = (request.form.get('storyteller_uuid') or '').strip() or None
         forge_stage_mode = (request.form.get('forge_stage_mode') or '').strip() or None
         ebook_filename = selected_filename
@@ -4170,6 +4189,7 @@ def match():
                 ebook_source=ebook_source,
                 ebook_source_id=ebook_source_id,
                 storyteller_uuid=storyteller_uuid,
+                ebook_source_path=source_path,
             )
             if err_msg:
                 return err_msg, err_code
@@ -4230,13 +4250,17 @@ def match():
                 return "Original ebook filename required for forge match", 400
 
             source_type = request.form.get('source_type')
-            source_path = request.form.get('source_path')
+            source_path = request.form.get('source_path') or source_path
             source_id = request.form.get('source_id')
             text_item = _build_forge_text_item(source_type, source_id, source_path, original_filename)
             normalized_source_type = text_item.get("source")
 
             initial_booklore_id = source_id if normalized_source_type == 'Booklore' else None
-            kosync_doc_id = get_kosync_id_for_ebook(original_filename, initial_booklore_id)
+            kosync_doc_id = get_kosync_id_for_ebook(
+                original_filename,
+                initial_booklore_id,
+                source_path=source_path,
+            )
 
             if not kosync_doc_id:
                 logger.warning(f"Could not compute ID for original '{original_filename}'")
@@ -4361,6 +4385,7 @@ def match():
                 ebook_filename,
                 booklore_id,
                 bookorbit_id=ebook_source_id if ebook_source == 'BookOrbit' else None,
+                source_path=source_path,
             )
 
         if not kosync_doc_id:
@@ -4667,6 +4692,7 @@ def _process_batch_queue(queue_items):
                 ebook_source=item.get('ebook_source'),
                 ebook_source_id=item.get('ebook_source_id'),
                 storyteller_uuid=item.get('storyteller_uuid'),
+                ebook_source_path=item.get('ebook_source_path'),
             )
             if err_msg:
                 logger.warning(
@@ -4723,6 +4749,7 @@ def _process_batch_queue(queue_items):
                 ebook_filename,
                 booklore_id,
                 bookorbit_id=item.get('ebook_source_id') if _item_ebook_source == 'BookOrbit' else None,
+                source_path=item.get('ebook_source_path'),
             )
 
         if not kosync_doc_id:
@@ -4825,6 +4852,7 @@ def _process_forge_match_queue(queue_items):
                     ebook_source=item.get('ebook_source'),
                     ebook_source_id=item.get('ebook_source_id'),
                     storyteller_uuid=storyteller_uuid,
+                    ebook_source_path=item.get('ebook_source_path'),
                 )
                 if err_msg:
                     logger.warning(
@@ -4979,7 +5007,11 @@ def _process_forge_match_queue(queue_items):
 
         text_item = _build_forge_text_item(source_type, source_id, source_path, original_filename)
         initial_booklore_id = source_id if text_item.get('source') == 'Booklore' else None
-        kosync_doc_id = get_kosync_id_for_ebook(original_filename, initial_booklore_id)
+        kosync_doc_id = get_kosync_id_for_ebook(
+            original_filename,
+            initial_booklore_id,
+            source_path=source_path,
+        )
         if not kosync_doc_id:
             logger.warning(
                 "Batch Forge: Could not compute KOSync ID for '%s', continuing with forge fallback hash",
@@ -5830,6 +5862,7 @@ def suggestions_page():
                         ebook_source=item.get('ebook_source'),
                         ebook_source_id=item.get('ebook_source_id'),
                         storyteller_uuid=item.get('storyteller_uuid'),
+                        ebook_source_path=item.get('ebook_source_path'),
                     )
                     if err_msg:
                         logger.warning(
@@ -5897,7 +5930,11 @@ def suggestions_page():
                         if book:
                             booklore_id = book.get('id')
 
-                    kosync_doc_id = get_kosync_id_for_ebook(ebook_filename, booklore_id)
+                    kosync_doc_id = get_kosync_id_for_ebook(
+                        ebook_filename,
+                        booklore_id,
+                        source_path=item.get('ebook_source_path'),
+                    )
 
                 if not kosync_doc_id:
                     logger.warning(f"Could not compute KOSync ID for {sanitize_log_data(ebook_filename)}, skipping")

--- a/tests/test_bookorbit_match_hash.py
+++ b/tests/test_bookorbit_match_hash.py
@@ -94,6 +94,31 @@ def test_kosync_id_skips_bookorbit_when_local_file_present():
     bookorbit.download_book.assert_not_called()
 
 
+def test_kosync_id_prefers_selected_source_path_before_filename_glob():
+    """Approved Suggestions should hash the selected ebook file, not the first basename match."""
+    bookorbit = MagicMock()
+    bookorbit.is_configured.return_value = False
+
+    with tempfile.TemporaryDirectory() as tmp:
+        selected = Path(tmp) / "selected" / _EBOOK
+        first_basename_match = Path(tmp) / "other" / _EBOOK
+        selected.parent.mkdir()
+        first_basename_match.parent.mkdir()
+        selected.write_bytes(b"SELECTED")
+        first_basename_match.write_bytes(b"OTHER")
+
+        container, parser = _container(tmp, "unused")
+        parser.get_kosync_id.return_value = "selectedhash"
+        with patch.object(web_server, "uc", return_value=_clients(bookorbit)), \
+             patch.object(web_server, "container", container), \
+             patch.object(web_server, "find_ebook_file", wraps=web_server.find_ebook_file):
+            result = web_server.get_kosync_id_for_ebook(_EBOOK, source_path=str(selected))
+
+    assert result == "selectedhash"
+    parser.get_kosync_id.assert_called_once_with(selected)
+    bookorbit.download_book.assert_not_called()
+
+
 def test_kosync_id_none_when_bookorbit_has_no_match():
     """No local file, BookOrbit configured but the book isn't found -> None."""
     bookorbit = MagicMock()

--- a/tests/test_match_paths_regression.py
+++ b/tests/test_match_paths_regression.py
@@ -459,6 +459,7 @@ class TestMatchPathsRegression(unittest.TestCase):
                 "audiobook_id": "ab-1",
                 "ebook_filename": "batch.epub",
                 "ebook_display_name": "Batch Book",
+                "ebook_source_path": "/books/Author/Batch/batch.epub",
             },
         )
         self.assertEqual(add_response.status_code, 302)
@@ -479,6 +480,10 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.assertEqual(processed_book.abs_id, "ab-1")
         self.assertEqual(processed_book.ebook_filename, "batch.epub")
         self.assertEqual(processed_book.kosync_doc_id, "hash-batch-1")
+        self.assertEqual(
+            _mock_kosync.call_args.kwargs.get("source_path"),
+            "/books/Author/Batch/batch.epub",
+        )
 
         self.assertEqual(web_server._load_match_queue(), [])
 
@@ -981,6 +986,7 @@ class TestMatchPathsRegression(unittest.TestCase):
                 "audiobook_id": "ab-1",
                 "ebook_filename": "suggested.epub",
                 "ebook_display_name": "Suggested Book",
+                "ebook_source_path": "/books/Author/Suggested/suggested.epub",
             },
         )
         self.assertEqual(add_response.status_code, 302)
@@ -997,6 +1003,10 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.assertTrue(process_response.location.endswith("/"))
 
         self.mock_container.mock_database_service.save_book.assert_called_once()
+        self.assertEqual(
+            _mock_kosync.call_args.kwargs.get("source_path"),
+            "/books/Author/Suggested/suggested.epub",
+        )
         self.assertEqual(web_server._load_match_queue(), [])
 
     @patch("src.web_server._create_or_update_booklore_audio_mapping", return_value=(Mock(abs_id="booklore:42"), None, None))
@@ -1017,6 +1027,7 @@ class TestMatchPathsRegression(unittest.TestCase):
                 "ebook_display_name": "BookLore Suggested",
                 "ebook_source": "BookLore",
                 "ebook_source_id": "6798",
+                "ebook_source_path": "/books/BookLore/booklore-suggested.epub",
             },
         )
         self.assertEqual(add_response.status_code, 302)
@@ -1037,6 +1048,7 @@ class TestMatchPathsRegression(unittest.TestCase):
         self.assertEqual(call_kwargs["ebook_filename"], "booklore-suggested.epub")
         self.assertEqual(call_kwargs["ebook_source"], "BookLore")
         self.assertEqual(call_kwargs["ebook_source_id"], "6798")
+        self.assertEqual(call_kwargs["ebook_source_path"], "/books/BookLore/booklore-suggested.epub")
 
         self.mock_container.mock_database_service.save_book.assert_not_called()
         self.assertEqual(web_server._load_match_queue(), [])

--- a/tests/test_suggestions_same_folder.py
+++ b/tests/test_suggestions_same_folder.py
@@ -164,6 +164,53 @@ def test_same_folder_match_allows_relative_suffix_paths():
     assert result["matches"][0]["score"] == 100.0
 
 
+def test_same_folder_match_treats_equivalent_library_mount_roots_as_same_parent():
+    svc = _build_service()
+    candidate_pool = svc._prepare_candidate_pool([
+        _ebook(
+            "The Ministry for the Future",
+            "/books/Kim Stanley Robinson/The Ministry for the Future (2020)/The Ministry for the Future.epub",
+        ),
+    ])
+
+    result = svc._scan_single_audiobook(
+        {
+            "audio_source": "ABS",
+            "audio_source_id": "abs-1",
+            "audio_title": "The Ministry for the Future",
+            "audio_author": "Kim Stanley Robinson",
+            "audio_path": "/audiobooks/Kim Stanley Robinson/The Ministry for the Future (2020)",
+        },
+        candidate_pool,
+    )
+
+    assert result is not None
+    assert result["matches"][0]["score"] == 100.0
+    assert result["matches"][0]["match_reason"] == "same_folder"
+
+
+def test_split_mount_same_folder_still_requires_title_agreement_for_exact_match():
+    svc = _build_service()
+    candidate_pool = svc._prepare_candidate_pool([
+        _ebook("Warbreaker", "/books/Sanderson/Shared Folder/warbreaker.epub"),
+    ])
+
+    result = svc._scan_single_audiobook(
+        {
+            "audio_source": "ABS",
+            "audio_source_id": "abs-1",
+            "audio_title": "Mistborn",
+            "audio_author": "Brandon Sanderson",
+            "audio_path": "/audiobooks/Sanderson/Shared Folder/audio.m4b",
+        },
+        candidate_pool,
+    )
+
+    assert result is not None
+    assert result["matches"][0]["score"] == 94.0
+    assert result["matches"][0]["match_reason"] == "same_folder_ambiguous"
+
+
 def test_same_folder_match_ignores_bare_filenames_and_shared_roots():
     svc = _build_service()
 


### PR DESCRIPTION
Follow-up to #295 after testing same-folder suggestions against a split-mount library setup.

## Summary

- treat common equivalent library mount roots (`/books`, `/ebooks`, `/audiobooks`, `/linker_books`, `/storyteller_library`) as the same parent tree for same-folder suggestion matching
- preserve the existing title-agreement guard so split-root shared folders with mismatched titles stay reviewable instead of exact
- let approved queue items pass their selected ebook source path into KOSync hash resolution, so duplicate basenames do not fall back to the first filename glob match
- thread the selected source path through normal Suggestions/Batch approval and BookLore-audio mapping helpers without adding schema state

## Validation

- `.venv/bin/python -m pytest tests/test_suggestions_same_folder.py tests/test_bookorbit_match_hash.py tests/test_match_paths_regression.py -q`
- `.venv/bin/python -m pytest tests/ -q`
- `git diff --check`

## Notes

No separate issue was opened because this is a bounded follow-up to the merged #295 behavior and the original #294 request. Happy to split the source-path plumbing if you prefer that tracked separately.