### PR TITLE
Publish CUDA image variant to GHCR, fix GPU auto-detection

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,6 +66,17 @@ jobs:
           flavor: |
             suffix=${{ matrix.suffix }},onlatest=true
 
+      # Resolve app version independent of the Docker tag suffix
+      - name: Resolve app version
+        id: appver
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+            echo "value=dev-${{ steps.build_num.outputs.value }}" >> $GITHUB_OUTPUT
+          else
+            version='${{ steps.meta.outputs.version }}'
+            echo "value=${version%${{ matrix.suffix }}}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -77,5 +88,5 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
           build-args: |
-            APP_VERSION=${{ github.ref == 'refs/heads/dev' && format('dev-{0}', steps.build_num.outputs.value) || steps.meta.outputs.version }}
+            APP_VERSION=${{ steps.appver.outputs.value }}
             INSTALL_GPU=${{ matrix.install_gpu }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,18 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            platforms: linux/amd64,linux/arm64
+            install_gpu: "false"
+            suffix: ""
+          - variant: cuda
+            platforms: linux/amd64
+            install_gpu: "true"
+            suffix: "-cuda"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,16 +63,19 @@ jobs:
             type=sha,enable={{is_default_branch}}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=dev-${{ steps.build_num.outputs.value }},enable=${{ github.ref == 'refs/heads/dev' }}
+          flavor: |
+            suffix=${{ matrix.suffix }},onlatest=true
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
           build-args: |
             APP_VERSION=${{ github.ref == 'refs/heads/dev' && format('dev-{0}', steps.build_num.outputs.value) || steps.meta.outputs.version }}
+            INSTALL_GPU=${{ matrix.install_gpu }}

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -4,15 +4,18 @@
 # See README.md for detailed configuration instructions.
 
 services:
-  abs-kosync:
+  bookbridge:
     container_name: bookbridge
     image: ghcr.io/cporcellijr/bookbridge:latest
+    # For NVIDIA GPU transcription, use the CUDA image instead (amd64 only, ~800MB larger):
+    #   image: ghcr.io/cporcellijr/bookbridge:latest-cuda
+    # It also needs the deploy block at the bottom of this file.
 
-    # Optional: Build locally if you need specific modifications or GPU libraries included
+    # Optional: Build locally if you need specific modifications.
     # build:
     #   context: .
     #   args:
-    #     # Set to "true" to download NVIDIA CUDA libraries (adds ~800MB to image)
+    #     # Set to "true" to bundle the NVIDIA CUDA libraries (same as the -cuda image)
     #     INSTALL_GPU: "false"
     restart: unless-stopped
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -457,15 +457,25 @@ Found under **Settings -> System**.
 
 For faster local transcription, you can give the container access to an NVIDIA GPU.
 
-### 1. Install NVIDIA Container Toolkit
+### 1. Use the CUDA image
+
+The default image does not ship the NVIDIA CUDA libraries to keep it small. Switch to the `-cuda` tag, which bundles them:
+
+```yaml
+image: ghcr.io/cporcellijr/bookbridge:latest-cuda
+```
+
+Every release tag has a CUDA twin (`v1.2.3-cuda`, `dev-cuda`, and so on). Note that these are `amd64` only.
+
+### 2. Install NVIDIA Container Toolkit
 
 Follow the official guide for the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 
-### 2. Update Docker Compose
+### 3. Update Docker Compose
 
 ```yaml
 services:
-  abs-kosync:
+  bookbridge:
     # ... other config ...
     deploy:
       resources:
@@ -476,11 +486,8 @@ services:
               capabilities: [gpu]
 ```
 
-### 3. Configure the bridge
+### 4. Configure the bridge
 
-In **Settings**:
+In **Settings**, set **Transcription Provider** to `local`. **Whisper Device** defaults to `auto`, which uses the GPU once the three steps above are done, so there is nothing else to set. Compute type follows the device (`float16` on GPU, `int8` on CPU).
 
-1. Set **Transcription Provider** to `local`.
-2. Set **Whisper Device** to `cuda`.
-3. Set **Whisper Compute Type** to `float16`.
-4. Use a larger model such as `small` or `medium` if your GPU can handle it.
+Consider raising **Whisper Model** to `small` or `medium` if your GPU can handle it.

--- a/src/utils/transcriber.py
+++ b/src/utils/transcriber.py
@@ -46,12 +46,6 @@ class AudioTranscriber:
         self.cache_root = data_dir / "audio_cache"
         self.cache_root.mkdir(parents=True, exist_ok=True)
 
-        self.model_size = os.environ.get("WHISPER_MODEL", "base")
-        
-        # GPU/Device configuration
-        self.whisper_device = os.environ.get("WHISPER_DEVICE", "auto").lower()
-        self.whisper_compute_type = os.environ.get("WHISPER_COMPUTE_TYPE", "auto").lower()
-
         self._transcript_cache = OrderedDict()
         self._cache_capacity = 3
 
@@ -61,42 +55,6 @@ class AudioTranscriber:
         # [UPDATED] Use the injected instances
         self.smil_extractor = smil_extractor
         self.polisher = polisher
-
-    def _get_whisper_config(self) -> tuple[str, str]:
-        """
-        Determine the Whisper device and compute type based on configuration.
-        
-        Returns:
-            (device, compute_type) tuple
-        
-        Configuration options:
-            WHISPER_DEVICE: 'auto', 'cpu', 'cuda'
-            WHISPER_COMPUTE_TYPE: 'auto', 'int8', 'float16', 'float32'
-        
-        When 'auto', attempts CUDA detection with graceful fallback to CPU.
-        """
-        device = self.whisper_device
-        compute_type = self.whisper_compute_type
-        
-        if device == 'auto':
-            try:
-                import torch
-                if torch.cuda.is_available():
-                    device = 'cuda'
-                    logger.info(f"🎮 CUDA available: {torch.cuda.get_device_name(0)}")
-                else:
-                    device = 'cpu'
-                    logger.info("💻 CUDA not available, using CPU")
-            except ImportError:
-                device = 'cpu'
-                logger.info("💻 PyTorch not installed, using CPU")
-        
-        if compute_type == 'auto':
-            # float16 for GPU, int8 for CPU (optimal defaults)
-            compute_type = 'float16' if device == 'cuda' else 'int8'
-        
-        logger.info(f"⚙️ Whisper config: device={device}, compute_type={compute_type}, model={self.model_size}")
-        return device, compute_type
 
     def validate_smil(self, smil_segments: list, ebook_text: str) -> tuple[bool, float]:
         """

--- a/src/utils/transcription_providers.py
+++ b/src/utils/transcription_providers.py
@@ -5,6 +5,7 @@ Abstract interface and implementations for transcription services.
 Supports local Whisper and cloud providers like Deepgram.
 """
 
+import importlib.util
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -64,23 +65,39 @@ class LocalWhisperProvider(TranscriptionProvider):
     def get_name(self) -> str:
         return f"LocalWhisper ({self.model_size})"
     
+    def _detect_cuda(self) -> tuple[bool, str]:
+        """
+        Check whether CTranslate2 can actually run on CUDA here.
+        This is dependent on the image that is used (only the image with the -cuda suffix has CUDA libraries)
+        and whether the GPU is visible in the container (via deploy block in the compose file)
+        """
+        if importlib.util.find_spec("nvidia.cudnn") is None:
+            return False, "CUDA libraries not bundled (use the -cuda image tag)"
+
+        try:
+            import ctranslate2 # transitive dependency by faster-whisper
+            device_count = ctranslate2.get_cuda_device_count()
+        except Exception as e:
+            return False, f"CUDA probe failed: {e}"
+
+        if device_count < 1:
+            return False, "no GPU visible to the container"
+
+        return True, f"{device_count} CUDA device(s) available"
+
     def _get_device_config(self) -> tuple[str, str]:
         """Determine device and compute type with auto-detection."""
         device = self.whisper_device
         compute_type = self.whisper_compute_type
         
         if device == 'auto':
-            try:
-                import torch
-                if torch.cuda.is_available():
-                    device = 'cuda'
-                    logger.info(f"🎮 CUDA available: {torch.cuda.get_device_name(0)}")
-                else:
-                    device = 'cpu'
-                    logger.info("💻 CUDA not available, using CPU")
-            except ImportError:
+            cuda_ok, reason = self._detect_cuda()
+            if cuda_ok:
+                device = 'cuda'
+                logger.info(f"🎮 CUDA enabled: {reason}")
+            else:
                 device = 'cpu'
-                logger.info("💻 PyTorch not installed, using CPU")
+                logger.info(f"💻 Using CPU: {reason}")
         
         if compute_type == 'auto':
             compute_type = 'float16' if device == 'cuda' else 'int8'

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2285,15 +2285,6 @@
                                     rel="noopener noreferrer">Deepgram
                                     Models</a>
                             </div>
-                            <div class="alert alert-warning" id="gpu_warning" style="display:none; margin-top:10px;">
-                                <strong>⚠️ NVIDIA GPU Selected:</strong>
-                                <ul style="margin: 5px 0 0 20px; font-size: 0.9em;">
-                                    <li>Ensure <code>INSTALL_GPU: "true"</code> is set in docker-compose.yml (this
-                                        builds the container with CUDA libraries).</li>
-                                    <li>Ensure the <strong>NVIDIA Container Toolkit</strong> is installed on your host
-                                        system (this allows Docker to access your GPU).</li>
-                                </ul>
-                            </div>
                         </div>
                     </div>
 
@@ -2322,13 +2313,17 @@
                         <div class="form-group">
                             <label>Whisper Device</label>
                             <select name="WHISPER_DEVICE">
+                                <option value="auto" {% if get_val('WHISPER_DEVICE')=='auto' %}selected{% endif %}>Auto
+                                    (detect GPU)
+                                </option>
                                 <option value="cpu" {% if get_val('WHISPER_DEVICE')=='cpu' %}selected{% endif %}>CPU
                                 </option>
                                 <option value="cuda" {% if get_val('WHISPER_DEVICE')=='cuda' %}selected{% endif %}>GPU
                                     (NVIDIA)
                                 </option>
                             </select>
-                            <div class="help-text">Use CUDA for NVIDIA GPU. Default is CPU.</div>
+                            <div class="help-text">Auto (default) uses an NVIDIA GPU when one is available, otherwise
+                                CPU. Requires the <code>-cuda</code> image.</div>
                         </div>
                         <div class="form-group">
                             <label>Whisper Compute Type</label>
@@ -2917,7 +2912,7 @@
             if (deviceSelect) {
                 deviceSelect.addEventListener('change', function () {
                     if (this.value === 'cuda') {
-                        alert("To use an NVIDIA GPU, you must modify your docker-compose.yml to include the 'deploy' block with 'capabilities: [gpu]' and ensure the NVIDIA Container Toolkit is installed on your host.");
+                        alert("Forcing GPU requires all three, or transcription will fail:\n\n1. The CUDA image (ghcr.io/cporcellijr/bookbridge:latest-cuda) — the default image has no CUDA libraries.\n2. The NVIDIA Container Toolkit on your host.\n3. A 'deploy' block with 'capabilities: [gpu]' in docker-compose.yml.\n\nAuto detects all three and falls back to CPU instead of failing.");
                     }
                 });
             }

--- a/tests/test_transcription_providers.py
+++ b/tests/test_transcription_providers.py
@@ -20,36 +20,53 @@ class TestLocalWhisperProvider(unittest.TestCase):
         self.assertEqual(provider.whisper_compute_type, "auto")
         self.assertIn("LocalWhisper", provider.get_name())
 
-    @patch("utils.transcription_providers.logger")
-    def test_get_device_config_auto_cpu(self, mock_logger):
-        """Test auto detection when CUDA is NOT available."""
-        provider = LocalWhisperProvider()
-        
-        # Mock torch to raise ImportError or return false for cuda
-        with patch.dict(sys.modules, {'torch': MagicMock()}):
-            sys.modules['torch'].cuda.is_available.return_value = False
-            
-            device, compute_type = provider._get_device_config()
-            
-            self.assertEqual(device, "cpu")
-            self.assertEqual(compute_type, "int8") # Default for CPU in auto mode
+    @staticmethod
+    def _fake_cuda_env(libs_bundled: bool, device_count: int = 0):
+        """Simulate CUDA libs and visible GPU (both required for CUDA to work in the container)"""
+        mock_ct2 = MagicMock()
+        mock_ct2.get_cuda_device_count.return_value = device_count
+        return (
+            patch("utils.transcription_providers.importlib.util.find_spec",
+                  return_value=MagicMock() if libs_bundled else None),
+            patch.dict(sys.modules, {'ctranslate2': mock_ct2}),
+        )
 
     @patch("utils.transcription_providers.logger")
     def test_get_device_config_auto_gpu(self, mock_logger):
-        """Test auto detection when CUDA IS available."""
+        """CUDA image on a host with a GPU: auto picks cuda."""
         provider = LocalWhisperProvider()
-        
-        # Mock torch to have cuda available
-        mock_torch = MagicMock()
-        mock_torch.cuda.is_available.return_value = True
-        mock_torch.cuda.get_device_name.return_value = "Test GPU"
-        
-        with patch.dict(sys.modules, {'torch': mock_torch}):
+        find_spec, ct2 = self._fake_cuda_env(libs_bundled=True, device_count=1)
+
+        with find_spec, ct2:
             device, compute_type = provider._get_device_config()
-            
-            self.assertEqual(device, "cuda")
-            self.assertEqual(compute_type, "float16") # Default for GPU in auto mode
-            mock_logger.info.assert_any_call(f"🎮 CUDA available: Test GPU")
+
+        self.assertEqual(device, "cuda")
+        self.assertEqual(compute_type, "float16")  # Default for GPU in auto mode
+
+    @patch("utils.transcription_providers.logger")
+    def test_get_device_config_auto_cpu_no_libs(self, mock_logger):
+        """CPU image on a GPU host: no bundled CUDA libs, so stay on CPU."""
+        provider = LocalWhisperProvider()
+        find_spec, ct2 = self._fake_cuda_env(libs_bundled=False, device_count=1)
+
+        with find_spec, ct2:
+            device, compute_type = provider._get_device_config()
+
+        self.assertEqual(device, "cpu")
+        self.assertEqual(compute_type, "int8")  # Default for CPU in auto mode
+
+    @patch("utils.transcription_providers.logger")
+    def test_get_device_config_auto_cpu_no_gpu(self, mock_logger):
+        """CUDA image with no GPU passed through to the container: stay on CPU."""
+        provider = LocalWhisperProvider()
+        find_spec, ct2 = self._fake_cuda_env(libs_bundled=True, device_count=0)
+
+        with find_spec, ct2:
+            device, compute_type = provider._get_device_config()
+
+        self.assertEqual(device, "cpu")
+        self.assertEqual(compute_type, "int8")
+
 
     @patch("utils.transcription_providers.logger")
     def test_explicit_config(self, mock_logger):


### PR DESCRIPTION
As pointed out in #179, in order to get GPU accel in the container, one needs to rebuild the image with `--build-arg INSTALL_GPU=true`. However, that is not so user friendly, which is why this PR adds a CUDA-image-build into the CI.

While I was doing that, I found that the GPU auto-detection is buggy and doesn't work, so I am including both fixes in this PR:

## 1. Publish CUDA image
`docker-publish.yml` is now a matrix:


| variant | platforms | `INSTALL_GPU` | tags |
| --- | --- | --- | --- |
| cpu | amd64 + arm64 | `false` | unchanged: `latest`, `v1.2.3`, `dev`, … |
| cuda | amd64 | `true` | `latest-cuda`, `v1.2.3-cuda`, `dev-cuda`, … |

Every existing tag rule now get a CUDA twin, so each tag also has another twin with the `-cuda` suffix. I decided to do amd64-only, since the nvidia cu12 libs don't have an arm64 build.

The docs, compose example, and settings page have been updated to point to the `-cuda` tag instead of telling users to rebuild the image with `INSTALL_GPU`

## 2. GPU auto-detection
`WHISPER_DEVICE=auto` probed for CUDA via `import torch`, but PyTorch isn't a dependency (as far as I was able to see), meaning that it would always fall back to using CPU, unless the Whisper device was manually set in the settings UI.

Fixes:
- CUDA probing now happens with CTranslate2 (transitive dependency of faster-whisper)
- Check that CUDA libraries are present and GPU has been passed through before selecting CUDA as device
- Add `Auto` option to the settings page
- Remove redundant/dead code `AudioTranscriber._get_whisper_config`

There is deliberately no CPU fallback, if CUDA load fails (on the CUDA image), since CUDA failing will likely be a user error which the user should fix.

## Testing
I tested the CI and CUDA image and can confirm that they are working. Regarding tests, I wrote some new tests that cover the CUDA probing

## Note
If an existing user now pulls the CUDA image, they need to manually go into the settings page and set the device to Auto or GPU