### PR TITLE
[Fix] Harden completion propagation and suggestions auto-match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to BookBridge will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Finishing a book on one service can now mark it finished everywhere.** Raw
+  percentages never agree at the end of a book — an ebook's back matter is not
+  narrated — so a title you finished in one app could sit at 92-97% in another and
+  never register as read. Turn on *Propagate Completion* under Settings > Sync and,
+  once any service crosses the completion threshold (99% by default), BookBridge
+  marks the book finished on the others instead of only pushing the position. Off by
+  default, and it acts on the crossing rather than re-asserting itself every cycle.
+  StoryGraph and Hardcover are unaffected by the setting: both already post as soon
+  as a book reaches completion.
+
+- **Suggestions can now link themselves when a match is certain.** Turn on
+  *Auto-match suggestions* under Settings > Suggestions and any candidate scoring at
+  or above the threshold is linked as soon as a scan finds it, instead of waiting on
+  the Suggestions page. Off by default, and at the default threshold of 100 only an
+  identifier agreement or an identical title and author qualifies. Books whose titles
+  merely agree loosely — including two books that happen to share a folder — are
+  never linked automatically no matter what they score; those stay on the Suggestions
+  page behind their "Same folder?" badge for you to confirm. Lowering the threshold
+  below 95 is warned about in the UI, because below that the top candidate is often a
+  sequel or a different edition.
+
 ### Fixed
 
 - **StoryGraph and Hardcover cooldowns now fire when their timer expires.** A

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -76,6 +76,21 @@ logger = logging.getLogger(__name__)
 
 _STATE_FETCH_SLOW_SECONDS = 15.0
 
+# Clients that must not receive completion propagation writes.
+# StoryGraph and Hardcover are write-only trackers driven exclusively by the
+# trailing-edge idle-cooldown handlers (_handle_tracker_cooldown), which bypass
+# their cooldown and post immediately at completion. Writing to them here would
+# be a layering violation and redundant.
+# ABSEbook must also be skipped: its update_progress rejects a locator whose
+# cfi is None (which a percentage-only LocatorResult produces), so it can only
+# ever log a warning and fail — and the ABS branch's mark_finished already
+# marks the whole ABS library item finished, which covers the ebook side.
+_COMPLETION_PROPAGATION_EXCLUDED_CLIENTS: frozenset[str] = frozenset({
+    "StoryGraph",
+    "Hardcover",
+    "ABSEbook",
+})
+
 # Multi-user: per-cycle override of the active sync-client bundle. Set by
 # sync_cycle when running for a specific user; None => use the global clients.
 import contextvars as _contextvars
@@ -258,27 +273,58 @@ class SyncManager:
 
         return current
 
-    def _completion_propagation_enabled(self):
+    def _completion_propagation_enabled(self) -> bool:
         return env_truthy('SYNC_COMPLETION_PROPAGATION')
 
-    def _completion_threshold(self):
+    def _completion_threshold(self) -> float:
         try:
             value = float(os.environ.get('SYNC_COMPLETION_THRESHOLD', '99'))
         except (TypeError, ValueError):
             value = 99.0
         return max(0.0, min(value, 100.0)) / 100.0
 
-    def _propagate_completion(self, book, active_clients, leader, abs_id, title_snip):
+    def _propagate_completion(
+        self,
+        book: Book | None,
+        active_clients: dict,
+        leader: str,
+        abs_id: str,
+        title_snip: str,
+    ) -> None:
+        """Mark a book finished on non-leader clients once the leader crosses
+        the configured completion threshold.
+
+        Trackers (StoryGraph, Hardcover) and ABSEbook are excluded: trackers
+        are driven by trailing-edge idle-cooldown handlers, and ABSEbook rejects
+        a percentage-only locator. ABS uses mark_finished instead of
+        update_progress.
+        """
+        current_time = time.time()
         request = UpdateProgressRequest(LocatorResult(percentage=1.0), "Book finished", previous_location=None)
         for client_name, client in self._iter_update_targets(active_clients, leader):
+            if client_name in _COMPLETION_PROPAGATION_EXCLUDED_CLIENTS:
+                continue
             try:
                 if client_name.lower() == 'abs':
-                    client.abs_client.mark_finished(abs_id)
+                    success = client.abs_client.mark_finished(abs_id)
+                    if success:
+                        try:
+                            from src.services.write_tracker import record_write
+                            record_write('ABS', abs_id)
+                        except ImportError:
+                            pass
+                        logger.info(f"🏁 '{abs_id}' '{title_snip}' completion propagated to '{client_name}'")
+                    else:
+                        logger.warning(f"⚠️ Completion propagation failed for '{client_name}': mark_finished returned False")
                 else:
-                    client.update_progress(book, request)
-                logger.info(f"🏁 '{abs_id}' '{title_snip}' completion propagated to '{client_name}'")
+                    result = client.update_progress(book, request)
+                    if getattr(result, 'success', False):
+                        self._persist_state_snapshot(book, client_name, {'pct': 1.0}, current_time)
+                        logger.info(f"🏁 '{abs_id}' '{title_snip}' completion propagated to '{client_name}'")
+                    else:
+                        logger.warning(f"⚠️ Completion propagation failed for '{client_name}': client reported unsuccessful write")
             except Exception as e:
-                logger.warning(f"⚠️ Completion propagation failed for '{client_name}': {e}")
+                logger.warning(f"⚠️ Completion propagation failed for '{client_name}': {e}", exc_info=True)
 
     def _iter_update_targets(self, active_clients: dict, leader_name: str | None):
         """Yield non-leader clients with KoSync updated last."""

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -6880,7 +6880,12 @@ def _start_suggestions_scan_job(cached_suggestions_by_abs=None, cached_no_match_
     return job_id
 
 
-def _auto_match_threshold():
+def _auto_match_threshold() -> float:
+    """Return the auto-match threshold as a float (0-100 scale).
+
+    Reads the SUGGESTIONS_AUTO_MATCH_THRESHOLD setting from the environment,
+    clamping to the valid range. Defaults to 100.0.
+    """
     try:
         value = float(os.environ.get('SUGGESTIONS_AUTO_MATCH_THRESHOLD', '100'))
     except (TypeError, ValueError):
@@ -6888,7 +6893,35 @@ def _auto_match_threshold():
     return max(0.0, min(value, 100.0))
 
 
-def _auto_match_suggestions(results, user_id):
+def _is_same_folder_match(match: dict) -> bool:
+    """Return True if the match is a same-folder candidate and should be excluded from auto-matching.
+
+    Same-folder matches (match_reason starting with 'same_folder') receive a score of 100.0
+    or 94.0 merely because the audiobook and ebook share a folder with a loose title
+    agreement (fuzzy ratio >= 45). They are explicitly surfaced for human review with a
+    'Same folder?' badge and must not be auto-linked, as a wrong link would sync a
+    reader's position into the wrong book.
+    """
+    reason = match.get('match_reason') or ''
+    return reason.startswith('same_folder')
+
+
+def _auto_match_suggestions(results: object, user_id: int | None) -> object:
+    """Auto-link suggestions whose best eligible candidate meets the threshold.
+
+    Walks the suggestions produced by a library scan, selects the highest-scoring
+    *eligible* candidate from each suggestion's matches list (excluding same-folder
+    matches), and if that candidate's score is at or above the configurable threshold,
+    links the book automatically via book_mapping_service.create_audio_mapping_from_match.
+    Suggestions that are not auto-matched remain in the list for human review.
+
+    Args:
+        results: The scan results object (expected to be a dict with 'suggestions' key).
+        user_id: Ambient user id to own the created mappings, or None.
+
+    Returns:
+        The (potentially modified) results object.
+    """
     if not env_truthy('SUGGESTIONS_AUTO_MATCH_ENABLED'):
         return results
     if not isinstance(results, dict):
@@ -6905,7 +6938,17 @@ def _auto_match_suggestions(results, user_id):
 
     for suggestion in suggestions:
         matches = suggestion.get('matches') or []
-        top = max(matches, key=lambda m: m.get('score') or 0.0) if matches else None
+        eligible_matches = [m for m in matches if not _is_same_folder_match(m)]
+        best_overall = max(matches, key=lambda m: m.get('score') or 0.0) if matches else None
+        top = max(eligible_matches, key=lambda m: m.get('score') or 0.0) if eligible_matches else None
+        if best_overall is not None and _is_same_folder_match(best_overall):
+            # The highest-scoring candidate was suppressed. Log the decision and its
+            # reason so an operator can see why a 100-scoring match was not linked.
+            logger.debug(
+                f"Auto-match excluded the top same-folder candidate for "
+                f"'{suggestion.get('abs_title')}' "
+                f"(score={best_overall.get('score') or 0.0:.1f}) — left for review"
+            )
         score = float(top.get('score') or 0.0) if top else 0.0
         if not top or score < threshold:
             remaining.append(suggestion)
@@ -6925,7 +6968,7 @@ def _auto_match_suggestions(results, user_id):
                 user_id=user_id,
             )
         except Exception as e:
-            logger.warning(f"⚠️ Auto-match failed for '{suggestion.get('abs_title')}': {e}")
+            logger.warning(f"⚠️ Auto-match failed for '{suggestion.get('abs_title')}': {e}", exc_info=True)
             remaining.append(suggestion)
             continue
         if not saved:

--- a/tests/test_propagate_completion.py
+++ b/tests/test_propagate_completion.py
@@ -1,0 +1,339 @@
+"""Tests for _propagate_completion and its helper methods.
+
+These tests verify the completion propagation logic that marks a book finished
+on non-leader clients once the leader crosses the configured completion threshold.
+"""
+
+import os
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.sync_clients.sync_client_interface import SyncResult
+from src.sync_manager import SyncManager
+from src.db.models import Book
+
+
+def _make_minimal_manager():
+    """Build a minimal SyncManager without calling __init__.
+
+    _propagate_completion only uses self._iter_update_targets,
+    self._persist_state_snapshot, and the module-level exclusion set.
+    This pattern is used in tests/test_bookorbit_multiuser_ownership.py.
+    """
+    mgr = SyncManager.__new__(SyncManager)
+    mgr._iter_update_targets = types.MethodType(SyncManager._iter_update_targets, mgr)
+    mgr._persist_state_snapshot = MagicMock()
+    return mgr
+
+
+def _make_book(abs_id="test-book", ebook_filename="test.epub"):
+    """Create a test book."""
+    return Book(
+        abs_id=abs_id,
+        abs_title="Test Book",
+        ebook_filename=ebook_filename,
+        status="active",
+        duration=1000.0,
+    )
+
+
+class TestPropagateCompletion(unittest.TestCase):
+    """Tests for _propagate_completion behavior."""
+
+    def test_abs_success_records_write(self):
+        """ABS success records the write in the write tracker.
+
+        This is the headline regression. mark_finished bypasses
+        ABSSyncClient.update_progress, and the ABS Socket.IO listener checks
+        is_own_write('ABS', abs_id) before reacting. Without the recorded
+        write, our own PATCH comes back as external movement and triggers a
+        spurious instant sync.
+
+        Note: the production code imports record_write lazily inside the
+        function body, so we patch it at its definition site
+        (src.services.write_tracker.record_write) rather than as an attribute
+        of src.sync_manager.
+        """
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_abs_client = MagicMock()
+        mock_abs_client.abs_client = MagicMock()
+        mock_abs_client.abs_client.mark_finished.return_value = True
+
+        active_clients = {"ABS": mock_abs_client}
+
+        with patch("src.services.write_tracker.record_write") as mock_record_write:
+            mgr._propagate_completion(book, active_clients, "BookLore", "test-book", "Test Book")
+
+            mock_abs_client.abs_client.mark_finished.assert_called_once_with("test-book")
+            mock_record_write.assert_called_once_with("ABS", "test-book")
+
+    def test_abs_failure_does_not_record_write(self):
+        """ABS failure does not record the write and logs a warning."""
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_abs_client = MagicMock()
+        mock_abs_client.abs_client = MagicMock()
+        mock_abs_client.abs_client.mark_finished.return_value = False
+
+        active_clients = {"ABS": mock_abs_client}
+
+        with patch("src.services.write_tracker.record_write") as mock_record_write:
+            with self.assertLogs(logger="src.sync_manager", level="WARNING") as cm:
+                mgr._propagate_completion(book, active_clients, "BookLore", "test-book", "Test Book")
+
+                mock_record_write.assert_not_called()
+                warning_logs = [log for log in cm.output if "Completion propagation failed" in log]
+                self.assertTrue(len(warning_logs) > 0, "Expected warning log for failed ABS propagation")
+                self.assertIn("mark_finished returned False", warning_logs[0])
+
+    def test_non_abs_success_persists_state_snapshot_at_100_percent(self):
+        """Non-ABS success persists a state snapshot at 100 percent.
+
+        Without this the DB keeps the pre-propagation position, the client
+        reads back ~100 percent next cycle, that looks like fresh movement,
+        and completion can re-fire.
+        """
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_client = MagicMock()
+        mock_client.update_progress.return_value = SyncResult(success=True, location=1.0)
+
+        active_clients = {"BookLore": mock_client}
+
+        with patch.object(mgr, "_persist_state_snapshot") as mock_persist:
+            mgr._propagate_completion(book, active_clients, "ABS", "test-book", "Test Book")
+
+            mock_client.update_progress.assert_called_once()
+            mock_persist.assert_called_once()
+            args, _ = mock_persist.call_args
+            state_dict = args[2]
+            self.assertEqual(state_dict.get("pct"), 1.0)
+
+    def test_non_abs_failure_persists_nothing(self):
+        """Non-ABS failure persists nothing and logs a warning."""
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_client = MagicMock()
+        mock_client.update_progress.return_value = SyncResult(success=False, error_code="some_error")
+
+        active_clients = {"BookLore": mock_client}
+
+        with patch.object(mgr, "_persist_state_snapshot") as mock_persist:
+            with self.assertLogs(logger="src.sync_manager", level="WARNING") as cm:
+                mgr._propagate_completion(book, active_clients, "ABS", "test-book", "Test Book")
+
+                mock_client.update_progress.assert_called_once()
+                mock_persist.assert_not_called()
+                warning_logs = [log for log in cm.output if "Completion propagation failed" in log]
+                self.assertTrue(len(warning_logs) > 0, "Expected warning log for failed propagation")
+                self.assertIn("client reported unsuccessful write", warning_logs[0])
+
+    def test_client_returning_none_is_treated_as_failure(self):
+        """A client returning None is treated as a failure (defensive).
+
+        No snapshot should be persisted and a warning should be logged.
+        """
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_client = MagicMock()
+        mock_client.update_progress.return_value = None
+
+        active_clients = {"BookLore": mock_client}
+
+        with patch.object(mgr, "_persist_state_snapshot") as mock_persist:
+            with self.assertLogs(logger="src.sync_manager", level="WARNING") as cm:
+                mgr._propagate_completion(book, active_clients, "ABS", "test-book", "Test Book")
+
+                mock_client.update_progress.assert_called_once()
+                mock_persist.assert_not_called()
+                warning_logs = [log for log in cm.output if "Completion propagation failed" in log]
+                self.assertTrue(len(warning_logs) > 0, "Expected warning log for None return")
+
+    def test_excluded_clients_are_skipped_entirely(self):
+        """Excluded clients (StoryGraph, Hardcover, ABSEbook) are skipped entirely.
+
+        The trackers are driven exclusively by the trailing-edge idle-cooldown
+        handlers which already bypass the cooldown at completion, and ABSEbook
+        rejects a percentage-only locator because its cfi is None.
+        """
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_storygraph = MagicMock()
+        mock_hardcover = MagicMock()
+        mock_absebook = MagicMock()
+        mock_ordinary = MagicMock()
+        mock_ordinary.update_progress.return_value = SyncResult(success=True, location=1.0)
+
+        active_clients = {
+            "StoryGraph": mock_storygraph,
+            "Hardcover": mock_hardcover,
+            "ABSEbook": mock_absebook,
+            "BookLore": mock_ordinary,
+        }
+
+        with patch.object(mgr, "_persist_state_snapshot") as mock_persist:
+            mgr._propagate_completion(book, active_clients, "ABS", "test-book", "Test Book")
+
+            mock_storygraph.update_progress.assert_not_called()
+            mock_hardcover.update_progress.assert_not_called()
+            mock_absebook.update_progress.assert_not_called()
+            mock_ordinary.update_progress.assert_called_once()
+            mock_persist.assert_called_once()
+
+    def test_leader_is_never_written_to(self):
+        """The leader itself is never written to."""
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_leader = MagicMock()
+        mock_leader.update_progress.return_value = SyncResult(success=True, location=1.0)
+
+        active_clients = {"BookLore": mock_leader}
+
+        with patch.object(mgr, "_persist_state_snapshot") as mock_persist:
+            mgr._propagate_completion(book, active_clients, "BookLore", "test-book", "Test Book")
+
+            mock_leader.update_progress.assert_not_called()
+            mock_persist.assert_not_called()
+
+    def test_exception_in_one_client_does_not_abort_others(self):
+        """An exception raised by one client does not abort propagation to the others."""
+        mgr = _make_minimal_manager()
+        book = _make_book()
+
+        mock_failing = MagicMock()
+        mock_failing.update_progress.side_effect = Exception("boom")
+
+        mock_healthy = MagicMock()
+        mock_healthy.update_progress.return_value = SyncResult(success=True, location=1.0)
+
+        active_clients = {
+            "FailingClient": mock_failing,
+            "HealthyClient": mock_healthy,
+        }
+
+        with patch.object(mgr, "_persist_state_snapshot") as mock_persist:
+            with self.assertLogs(logger="src.sync_manager", level="WARNING") as cm:
+                mgr._propagate_completion(book, active_clients, "ABS", "test-book", "Test Book")
+
+                mock_failing.update_progress.assert_called_once()
+                mock_healthy.update_progress.assert_called_once()
+                mock_persist.assert_called_once()  # Healthy client's persist
+                warning_logs = [log for log in cm.output if "Completion propagation failed" in log]
+                self.assertTrue(len(warning_logs) > 0, "Expected warning log for exception")
+
+
+class TestCompletionThreshold(unittest.TestCase):
+    """Tests for _completion_threshold helper method."""
+
+    def _set_env_and_test(self, value, expected):
+        """Helper to set SYNC_COMPLETION_THRESHOLD and test the conversion."""
+        mgr = _make_minimal_manager()
+        prev = os.environ.get("SYNC_COMPLETION_THRESHOLD")
+        try:
+            if value is None:
+                os.environ.pop("SYNC_COMPLETION_THRESHOLD", None)
+            else:
+                os.environ["SYNC_COMPLETION_THRESHOLD"] = value
+            result = mgr._completion_threshold()
+            self.assertEqual(result, expected)
+        finally:
+            if prev is None:
+                os.environ.pop("SYNC_COMPLETION_THRESHOLD", None)
+            else:
+                os.environ["SYNC_COMPLETION_THRESHOLD"] = prev
+
+    def test_converts_0_100_setting_to_0_1_fraction(self):
+        """_completion_threshold converts the 0-100 setting into a 0-1 fraction."""
+        mgr = _make_minimal_manager()
+        self._set_env_and_test("99", 0.99)
+        self._set_env_and_test("100", 1.0)
+        self._set_env_and_test("50", 0.5)
+
+    def test_fallback_to_0_99_on_unparseable(self):
+        """_completion_threshold falls back to 0.99 when the value is unparseable."""
+        mgr = _make_minimal_manager()
+        self._set_env_and_test("abc", 0.99)
+        self._set_env_and_test("", 0.99)
+
+    def test_clamps_out_of_range_values(self):
+        """_completion_threshold clamps out-of-range values."""
+        mgr = _make_minimal_manager()
+        self._set_env_and_test("-10", 0.0)
+        self._set_env_and_test("150", 1.0)
+
+    def test_returns_0_99_when_variable_absent(self):
+        """_completion_threshold returns 0.99 when the variable is absent entirely."""
+        mgr = _make_minimal_manager()
+        prev = os.environ.get("SYNC_COMPLETION_THRESHOLD")
+        try:
+            os.environ.pop("SYNC_COMPLETION_THRESHOLD", None)
+            result = mgr._completion_threshold()
+            self.assertEqual(result, 0.99)
+        finally:
+            if prev is None:
+                os.environ.pop("SYNC_COMPLETION_THRESHOLD", None)
+            else:
+                os.environ["SYNC_COMPLETION_THRESHOLD"] = prev
+
+
+class TestCompletionPropagationEnabled(unittest.TestCase):
+    """Tests for _completion_propagation_enabled helper method."""
+
+    def _set_env_and_test(self, value, expected):
+        """Helper to set SYNC_COMPLETION_PROPAGATION and test the result."""
+        mgr = _make_minimal_manager()
+        prev = os.environ.get("SYNC_COMPLETION_PROPAGATION")
+        try:
+            if value is None:
+                os.environ.pop("SYNC_COMPLETION_PROPAGATION", None)
+            else:
+                os.environ["SYNC_COMPLETION_PROPAGATION"] = value
+            result = mgr._completion_propagation_enabled()
+            self.assertEqual(result, expected)
+        finally:
+            if prev is None:
+                os.environ.pop("SYNC_COMPLETION_PROPAGATION", None)
+            else:
+                os.environ["SYNC_COMPLETION_PROPAGATION"] = prev
+
+    def test_false_when_setting_absent(self):
+        """_completion_propagation_enabled is False when the setting is absent."""
+        mgr = _make_minimal_manager()
+        prev = os.environ.get("SYNC_COMPLETION_PROPAGATION")
+        try:
+            os.environ.pop("SYNC_COMPLETION_PROPAGATION", None)
+            result = mgr._completion_propagation_enabled()
+            self.assertFalse(result)
+        finally:
+            if prev is None:
+                os.environ.pop("SYNC_COMPLETION_PROPAGATION", None)
+            else:
+                os.environ["SYNC_COMPLETION_PROPAGATION"] = prev
+
+    def test_true_for_true_spelling(self):
+        """_completion_propagation_enabled is True for 'true' spelling."""
+        mgr = _make_minimal_manager()
+        self._set_env_and_test("true", True)
+
+    def test_true_for_on_spelling(self):
+        """_completion_propagation_enabled is True for 'on' spelling.
+
+        The 'on' spelling matters because settings checkboxes in this app
+        POST "on", and this is a recurring source of bugs, so cover both
+        explicitly.
+        """
+        mgr = _make_minimal_manager()
+        self._set_env_and_test("on", True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_suggestions_auto_match.py
+++ b/tests/test_suggestions_auto_match.py
@@ -1,0 +1,423 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.web_server import (
+    _auto_match_threshold,
+    _is_same_folder_match,
+    _auto_match_suggestions,
+)
+
+
+def _make_match(
+    score: float,
+    match_reason: str | None = None,
+    ebook_filename: str = "book.epub",
+    display_name: str = "Book Title",
+    source: str = "KOReader",
+    source_id: str = "123",
+) -> dict:
+    """Build a minimal match dict for testing."""
+    m = {
+        "ebook_filename": ebook_filename,
+        "display_name": display_name,
+        "source": source,
+        "source_id": source_id,
+        "score": score,
+    }
+    if match_reason is not None:
+        m["match_reason"] = match_reason
+    return m
+
+
+def _make_suggestion(
+    abs_id: str = "abs-1",
+    abs_title: str = "Test Audiobook",
+    audio_source: str = "ABS",
+    audio_source_id: str = "abs-1",
+    audio_title: str = "Test Audiobook",
+    matches: list[dict] | None = None,
+) -> dict:
+    """Build a minimal suggestion dict for testing."""
+    return {
+        "abs_id": abs_id,
+        "abs_title": abs_title,
+        "audio_source": audio_source,
+        "audio_source_id": audio_source_id,
+        "audio_title": audio_title,
+        "matches": matches or [],
+    }
+
+
+class TestIsSameFolderMatch(unittest.TestCase):
+    """Tests for _is_same_folder_match."""
+
+    def test_same_folder_reason_is_same_folder(self):
+        """A match with match_reason 'same_folder' is reported as same-folder."""
+        match = _make_match(100.0, match_reason="same_folder")
+        self.assertTrue(_is_same_folder_match(match))
+
+    def test_same_folder_ambiguous_reason_is_same_folder(self):
+        """A match with match_reason 'same_folder_ambiguous' is reported as same-folder."""
+        match = _make_match(94.0, match_reason="same_folder_ambiguous")
+        self.assertTrue(_is_same_folder_match(match))
+
+    def test_no_match_reason_is_not_same_folder(self):
+        """A match with no match_reason key is reported as NOT same-folder."""
+        match = _make_match(100.0)  # no match_reason key
+        self.assertFalse(_is_same_folder_match(match))
+
+    def test_none_match_reason_is_not_same_folder(self):
+        """A match with match_reason set to None is reported as NOT same-folder."""
+        match = _make_match(100.0, match_reason=None)
+        self.assertFalse(_is_same_folder_match(match))
+
+    def test_future_same_folder_tier_is_same_folder(self):
+        """A hypothetical future tier 'same_folder_something_new' is also same-folder (prefix rule)."""
+        match = _make_match(100.0, match_reason="same_folder_something_new")
+        self.assertTrue(_is_same_folder_match(match))
+
+
+class TestAutoMatchThreshold(unittest.TestCase):
+    """Tests for _auto_match_threshold."""
+
+    def _set_env(self, key: str, value: str | None):
+        if value is None:
+            if key in os.environ:
+                del os.environ[key]
+        else:
+            os.environ[key] = value
+
+    def _restore_env(self, key: str, old_value: str | None):
+        if old_value is None:
+            if key in os.environ:
+                del os.environ[key]
+        else:
+            os.environ[key] = old_value
+
+    def test_default_threshold_when_absent(self):
+        """Returns 100.0 when SUGGESTIONS_AUTO_MATCH_THRESHOLD is absent."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_THRESHOLD")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", None)
+            self.assertEqual(_auto_match_threshold(), 100.0)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", old)
+
+    def test_returns_parsed_value_when_set(self):
+        """Returns the parsed float value when the variable is set."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_THRESHOLD")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", "95.5")
+            self.assertEqual(_auto_match_threshold(), 95.5)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", old)
+
+    def test_fallback_to_default_on_unparseable(self):
+        """Falls back to 100.0 when the value is unparseable."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_THRESHOLD")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", "abc")
+            self.assertEqual(_auto_match_threshold(), 100.0)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", old)
+
+    def test_clamps_negative_to_zero(self):
+        """Clamps a negative value to 0.0."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_THRESHOLD")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", "-10")
+            self.assertEqual(_auto_match_threshold(), 0.0)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", old)
+
+    def test_clamps_above_100_to_100(self):
+        """Clamps a value above 100 to 100.0."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_THRESHOLD")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", "150")
+            self.assertEqual(_auto_match_threshold(), 100.0)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", old)
+
+
+class TestAutoMatchSuggestions(unittest.TestCase):
+    """Tests for _auto_match_suggestions."""
+
+    def _set_env(self, key: str, value: str | None):
+        if value is None:
+            if key in os.environ:
+                del os.environ[key]
+        else:
+            os.environ[key] = value
+
+    def _restore_env(self, key: str, old_value: str | None):
+        if old_value is None:
+            if key in os.environ:
+                del os.environ[key]
+        else:
+            os.environ[key] = old_value
+
+    @patch("src.web_server.container")
+    def test_disabled_by_default(self, mock_container):
+        """With SUGGESTIONS_AUTO_MATCH_ENABLED absent, a perfect 100 match is returned untouched."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", None)
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            mock_mapping.create_audio_mapping_from_match.assert_not_called()
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_enabled_with_ordinary_100_match(self, mock_container):
+        """Enabled with an ordinary 100-scoring match: mapping created once, suggestion removed, auto_matched=1."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 0)
+            mock_mapping.create_audio_mapping_from_match.assert_called_once()
+            self.assertEqual(out["stats"].get("auto_matched"), 1)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_same_folder_100_not_auto_linked(self, mock_container):
+        """
+        HEADLINE REGRESSION: a same-folder 100 is NOT auto-linked.
+
+        _same_folder_tier in src/services/suggestions_service.py awards 100.0 merely for sharing
+        a folder when the folder holds one candidate and the titles agree by a fuzzy ratio of
+        only 45. Those matches are meant to be reviewed behind a 'Same folder?' badge —
+        auto-linking one syncs a reader's position into the wrong book.
+        """
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0, match_reason="same_folder")])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            mock_mapping.create_audio_mapping_from_match.assert_not_called()
+            self.assertNotIn("auto_matched", out.get("stats", {}))
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_same_folder_ambiguous_not_auto_linked_even_at_lower_threshold(self, mock_container):
+        """A same_folder_ambiguous match is not auto-linked even when threshold is lowered to 90 (below its 94)."""
+        old_enabled = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        old_threshold = os.environ.get("SUGGESTIONS_AUTO_MATCH_THRESHOLD")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+            self._set_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", "90")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(94.0, match_reason="same_folder_ambiguous")])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            mock_mapping.create_audio_mapping_from_match.assert_not_called()
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old_enabled)
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_THRESHOLD", old_threshold)
+
+    @patch("src.web_server.container")
+    def test_mixed_candidates_ordinary_match_selected(self, mock_container):
+        """When top match is same-folder 100 but an ordinary match also scores 100, the ordinary one IS auto-linked."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(
+                matches=[
+                    _make_match(100.0, match_reason="same_folder", ebook_filename="same_folder.epub"),
+                    _make_match(100.0, match_reason=None, ebook_filename="ordinary.epub"),
+                ]
+            )
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 0)
+            mock_mapping.create_audio_mapping_from_match.assert_called_once()
+            # Verify the call received the ordinary match's ebook_filename
+            call_kwargs = mock_mapping.create_audio_mapping_from_match.call_args.kwargs
+            self.assertEqual(call_kwargs["ebook_filename"], "ordinary.epub")
+            self.assertEqual(out["stats"].get("auto_matched"), 1)
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_below_threshold_not_auto_matched(self, mock_container):
+        """An ordinary match scoring 99.0 against default threshold 100 is left in the list."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(99.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            mock_mapping.create_audio_mapping_from_match.assert_not_called()
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_exception_from_mapping_service_logs_warning(self, mock_container):
+        """A raised exception from create_audio_mapping_from_match leaves the suggestion and logs a warning."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.side_effect = RuntimeError("DB error")
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            with self.assertLogs("src.web_server", level="WARNING") as cm:
+                out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            mock_mapping.create_audio_mapping_from_match.assert_called_once()
+            self.assertTrue(any("Auto-match failed" in msg for msg in cm.output))
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_falsy_return_from_mapping_service_leaves_suggestion(self, mock_container):
+        """A falsy return (service reports it did not save) leaves the suggestion and does not count toward auto_matched."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = False
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            self.assertNotIn("auto_matched", out.get("stats", {}))
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_empty_matches_list_passed_through(self, mock_container):
+        """A suggestion with an empty matches list is passed through untouched without error."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 1)
+            self.assertEqual(out["suggestions"][0], suggestion)
+            mock_mapping.create_audio_mapping_from_match.assert_not_called()
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_enabled_true_spelling(self, mock_container):
+        """SUGGESTIONS_AUTO_MATCH_ENABLED='true' enables auto-match."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "true")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 0)
+            mock_mapping.create_audio_mapping_from_match.assert_called_once()
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+    @patch("src.web_server.container")
+    def test_enabled_on_spelling(self, mock_container):
+        """SUGGESTIONS_AUTO_MATCH_ENABLED='on' enables auto-match (checkboxes POST 'on')."""
+        old = os.environ.get("SUGGESTIONS_AUTO_MATCH_ENABLED")
+        try:
+            self._set_env("SUGGESTIONS_AUTO_MATCH_ENABLED", "on")
+
+            mock_mapping = MagicMock()
+            mock_mapping.create_audio_mapping_from_match.return_value = True
+            mock_container.book_mapping_service.return_value = mock_mapping
+
+            suggestion = _make_suggestion(matches=[_make_match(100.0)])
+            results = {"suggestions": [suggestion], "stats": {}}
+
+            out = _auto_match_suggestions(results, user_id=1)
+
+            self.assertEqual(len(out["suggestions"]), 0)
+            mock_mapping.create_audio_mapping_from_match.assert_called_once()
+        finally:
+            self._restore_env("SUGGESTIONS_AUTO_MATCH_ENABLED", old)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up hardening for the two features merged in #374 and #375. Both are off by
default, so nothing here changes behavior for users who have not opted in.

## #374 — completion propagation

- **Self-echo.** ABS was finished via `abs_client.mark_finished()`, which bypasses
  `ABSSyncClient.update_progress` and therefore the write tracker. The ABS Socket.IO
  listener checks `is_own_write('ABS', abs_id)` before reacting, so our own PATCH came
  back as external movement and triggered a spurious instant sync. Now records the
  write on success.
- **Wrote to the write-only trackers.** StoryGraph and Hardcover are driven
  exclusively by `_handle_tracker_cooldown`, which already bypasses the cooldown and
  posts immediately at completion — writing to them here was both a layering
  violation and redundant. `ABSEbook` is excluded too: it rejects a percentage-only
  locator (`cfi is None`), and `mark_finished` already finishes the whole ABS item.
- **State never recorded the completion.** Propagation runs after the per-client
  `results` dict is built and its writes never reached it, so the `State` rows kept
  the pre-propagation position; the client read ~100% back next cycle as fresh
  movement and completion could re-fire.
- **Failures reported as success.** A client returning `SyncResult(success=False)` no
  longer logs success or persists a 1.0 snapshot for a write that never landed.

## #375 — suggestions auto-match

The feature is presented as safe at its default threshold of 100 on the premise that
only an identifier agreement or an identical title and author can score 100. That
premise does not hold: `_same_folder_tier` awards a flat 100.0 whenever an audiobook
and an ebook merely share a folder, that folder holds one candidate, and the titles
agree by a fuzzy ratio of only 45. Those matches are tagged `same_folder` /
`same_folder_ambiguous` and are deliberately surfaced for review behind a
"Same folder?" badge — the score is a presentation pin, not a confidence claim.
Auto-match linked them silently, and a wrong link syncs a reader's position into the
wrong book.

Candidate **selection** now skips any `match_reason` beginning with `same_folder`, so
a future tier cannot silently become auto-linkable, and a suggestion whose best
overall candidate is same-folder is still considered on its best remaining eligible
candidate.

## Also

`exc_info=True` on the new `except` blocks and type hints on the new functions.

## Tests

2745 -> **2781 passed, 4 skipped**. New: `tests/test_propagate_completion.py` (15),
`tests/test_suggestions_auto_match.py` (21). The seven behavior tests in the first
and the three same-folder tests in the second fail with their respective fix reverted
(verified by reverting, not by assertion). Passes in deterministic and random order.

Deploy requirement: restart (bind-mounted `./src` + `./templates`; no migration).