### PR TITLE
Fix KoSync progress ordering when XPath and percentage disagree

### DIFF
--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -2891,6 +2891,45 @@ def _respond_from_book_states(doc_id, book):
             )
         )
         sibling_is_ahead = sibling_pct > synced_pct + 0.0001
+
+        # KOReader's reported percentage and the bridge-synced percentage can
+        # use different position scales even for the same EPUB. The synced State
+        # XPath is generated for book.kosync_doc_id, so only compare resolved text
+        # positions when the request and device row refer to that exact hash.
+        # If resolution is unavailable, keep the existing percentage-based behavior.
+        state_doc_id = str(getattr(book, "kosync_doc_id", "") or "").strip()
+        same_document = (
+            getattr(best_doc, "document_hash", None) == doc_id
+            and state_doc_id == doc_id
+        )
+        sibling_xpath = str(getattr(best_doc, "progress", "") or "").strip()
+        synced_xpath = str(getattr(kosync_state, "xpath", "") or "").strip() if kosync_state else ""
+
+        if same_document and sibling_xpath and synced_xpath:
+            try:
+                document = _database_service.get_kosync_document(doc_id)
+                filename = getattr(document, "filename", None) if document else None
+
+                if filename:
+                    parser = _container.ebook_parser()
+                    sibling_index = parser.resolve_xpath_to_index(filename, sibling_xpath)
+                    synced_index = parser.resolve_xpath_to_index(filename, synced_xpath)
+
+                    if sibling_index is not None and synced_index is not None:
+                        sibling_is_ahead = sibling_index > synced_index
+                        logger.debug(
+                            "KOSync: canonical XPath order for %s: device=%d synced=%d",
+                            doc_id,
+                            sibling_index,
+                            synced_index,
+                        )
+            except Exception as e:
+                logger.debug(
+                    "KOSync: canonical XPath comparison unavailable for %s: %s",
+                    doc_id,
+                    e,
+                )
+
         sibling_is_equal_fallback = (
             abs(sibling_pct - synced_pct) <= 0.0001
             and not synced_has_locator

--- a/tests/test_kosync_get_fallback.py
+++ b/tests/test_kosync_get_fallback.py
@@ -13,6 +13,7 @@ import shutil
 import time
 import hashlib
 import unittest
+from unittest.mock import MagicMock, patch
 
 # Set test environment BEFORE importing web_server
 TEST_DIR = '/tmp/test_kosync_get'
@@ -96,7 +97,12 @@ class TestKosyncGetEqualPercentageFallback(unittest.TestCase):
         """Helper to create a book with KoSync State and optional sibling doc."""
         db = self._db()
 
-        book = Book(abs_id="test-book-equal", abs_title="Test Book Equal", status="active")
+        book = Book(
+            abs_id="test-book-equal",
+            abs_title="Test Book Equal",
+            kosync_doc_id="a" * 32,
+            status="active",
+        )
         db.save_book(book)
 
         # KoSync State (the bridge-synced position)
@@ -223,6 +229,122 @@ class TestKosyncGetEqualPercentageFallback(unittest.TestCase):
         # Should return the ahead sibling's data
         self.assertEqual(data['progress'], "/body/ahead/path")
         self.assertAlmostEqual(float(data['percentage']), 0.90)
+
+    def test_same_hash_xpath_order_overrides_misleading_percentage(self):
+        """Same EPUB: resolved XPath order wins when raw percentages disagree."""
+        from src.api import kosync_server
+
+        synced_xpath = "/body/DocFragment[20]/body/p[20]/text().0"
+        device_xpath = "/body/DocFragment[20]/body/p[15]/text().0"
+
+        _, primary_doc = self._setup_book_with_states(
+            kosync_state_pct=0.23,
+            kosync_xpath=synced_xpath,
+            sibling_exists=False,
+        )
+
+        # Reproduce the bug: the stale KOReader locator has a numerically higher
+        # percentage even though it resolves to an earlier text position.
+        primary_doc.percentage = 0.24
+        primary_doc.progress = device_xpath
+        primary_doc.filename = "test.epub"
+        self._db().save_kosync_document(primary_doc)
+
+        parser = MagicMock()
+        parser.resolve_xpath_to_index.side_effect = lambda _filename, xpath: {
+            device_xpath: 100,
+            synced_xpath: 200,
+        }[xpath]
+
+        container = MagicMock()
+        container.ebook_parser.return_value = parser
+
+        with patch.object(kosync_server, "_container", container):
+            response = self.client.get(
+                "/syncs/progress/" + ("a" * 32),
+                headers=self.auth_headers,
+            )
+
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        data = response.get_json()
+        self.assertEqual(data["progress"], synced_xpath)
+        self.assertAlmostEqual(float(data["percentage"]), 0.23)
+
+    def test_same_hash_unresolved_xpath_keeps_percentage_fallback(self):
+        """Unresolvable XPaths preserve the existing percentage comparison."""
+        from src.api import kosync_server
+
+        synced_xpath = "/body/DocFragment[20]/body/p[20]/text().0"
+        device_xpath = "/body/DocFragment[20]/body/p[15]/text().0"
+
+        _, primary_doc = self._setup_book_with_states(
+            kosync_state_pct=0.23,
+            kosync_xpath=synced_xpath,
+            sibling_exists=False,
+        )
+
+        primary_doc.percentage = 0.24
+        primary_doc.progress = device_xpath
+        primary_doc.filename = "test.epub"
+        self._db().save_kosync_document(primary_doc)
+
+        parser = MagicMock()
+        parser.resolve_xpath_to_index.return_value = None
+
+        container = MagicMock()
+        container.ebook_parser.return_value = parser
+
+        with patch.object(kosync_server, "_container", container):
+            response = self.client.get(
+                "/syncs/progress/" + ("a" * 32),
+                headers=self.auth_headers,
+            )
+
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        data = response.get_json()
+        self.assertEqual(data["progress"], device_xpath)
+        self.assertAlmostEqual(float(data["percentage"]), 0.24)
+
+    def test_sibling_hash_keeps_percentage_fallback(self):
+        """A sibling EPUB must not resolve the primary State XPath against its file."""
+        from src.api import kosync_server
+
+        synced_xpath = "/body/DocFragment[20]/body/p[20]/text().0"
+        sibling_xpath = "/body/DocFragment[20]/body/p[15]/text().0"
+
+        self._setup_book_with_states(
+            kosync_state_pct=0.23,
+            kosync_xpath=synced_xpath,
+            sibling_pct=0.24,
+            sibling_progress=sibling_xpath,
+        )
+
+        sibling_doc = self._db().get_kosync_document("b" * 32)
+        sibling_doc.filename = "sibling.epub"
+        self._db().save_kosync_document(sibling_doc)
+
+        # If the primary State XPath were incorrectly compared against this
+        # sibling EPUB, these positions would make the synced State appear ahead.
+        parser = MagicMock()
+        parser.resolve_xpath_to_index.side_effect = lambda _filename, xpath: {
+            sibling_xpath: 100,
+            synced_xpath: 200,
+        }[xpath]
+
+        container = MagicMock()
+        container.ebook_parser.return_value = parser
+
+        with patch.object(kosync_server, "_container", container):
+            response = self.client.get(
+                "/syncs/progress/" + ("b" * 32),
+                headers=self.auth_headers,
+            )
+
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        data = response.get_json()
+        self.assertEqual(data["progress"], sibling_xpath)
+        self.assertAlmostEqual(float(data["percentage"]), 0.24)
+        parser.resolve_xpath_to_index.assert_not_called()
 
     def test_no_valid_locator_returns_404(self):
         """No valid locator anywhere returns defensive 404."""


### PR DESCRIPTION
## Summary

- Compare resolved XPath text positions when KoSync device progress and the bridge-synced State refer to the exact same EPUB hash.
- Keep the existing percentage-based behavior for sibling/different EPUB hashes, CFIs, missing filenames, unresolved XPaths, or resolver failures.
- Add regression coverage for misleading percentages, unresolved-XPath fallback, and the cross-hash safety boundary.

## Why

KOReader's reported percentage and BookBridge's bridge-synced percentage can use different position scales even for the same EPUB. During the KoSync GET furthest-wins path, a stale device locator can therefore have a numerically higher percentage while its XPath resolves to an earlier text position.

For the exact primary KoSync document (`best_doc.document_hash == doc_id == book.kosync_doc_id`), both XPaths are resolved against that document's recorded filename and their canonical text offsets determine which position is actually ahead. If that exact-hash condition is not met, or either locator cannot be resolved, the existing percentage comparison is left unchanged.

This is intentionally limited to GET progress selection. It does not change PUT behavior, sibling selection, CFI handling, cross-EPUB ordering, database schema, or settings.

## Tests

- `pytest tests/test_kosync_get_fallback.py -v` — 13 passed
- Full suite on Python 3.11 — 2775 passed, 2 skipped
- Full suite on Python 3.12 — 2775 passed, 2 skipped
- Hard-failure flake8 check (`E9,F63,F7,F82`) — 0 errors on both versions
- `git diff --check` — clean

Manually validated with a KOReader ↔ Audiobookshelf sync case where a stale KOReader locator had a higher raw percentage but resolved to an earlier text position.