### PR TITLE
[Fix] Resolve empty KOReader element-boundary XPaths

### DIFF
--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -1959,7 +1959,11 @@ class EbookParser:
 
             node_text = target_node.text_content().strip()
             clean_anchor = " ".join(node_text.split())
-            if not clean_anchor:
+            # An empty element-node locator such as ``p[1].0`` still identifies
+            # a structural text boundary. Let zero-offset boundaries reach the
+            # existing LXML positional fallback; non-zero offsets on a textless
+            # node cannot be mapped safely.
+            if not clean_anchor and target_offset > 0:
                 return None
             chapter_len = max(0, target_item['end'] - target_item['start'])
             chapter_base = target_item['start']

--- a/tests/test_resolve_xpath_to_index_bs4_fallback.py
+++ b/tests/test_resolve_xpath_to_index_bs4_fallback.py
@@ -208,3 +208,25 @@ def test_resolve_xpath_to_index_falls_back_to_nearby_spine_when_docfragment_drif
         "mapped reported DocFragment[13] to spine 12" in record.message
         for record in caplog.records
     )
+
+
+
+def test_resolve_xpath_to_index_empty_element_boundary_uses_lxml_position(caplog):
+    # Observed KOReader form: a chapter-opening empty <p> inside a structural
+    # <div> is reported as an element boundary (``p[1].0``), not a text node.
+    caplog.set_level(logging.DEBUG)
+    html_content = (
+        "<html><body><div>"
+        "<p></p>"
+        "<p>3.4</p>"
+        "<p>Readable text starts here.</p>"
+        "</div></body></html>"
+    )
+    parser = _parser_for_single_spine(html_content, start=50)
+
+    index = parser.resolve_xpath_to_index(
+        "book.epub", "/body/DocFragment[1]/body/div/p[1].0"
+    )
+
+    assert index == 50
+    assert any("lxml_position_fallback" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

KOReader can report a valid element-boundary locator such as `.../div/p[1].0` when the current position sits on an empty structural element. BookBridge already parses the `.0` suffix and resolves the DOM node, but `resolve_xpath_to_index()` currently returns `None` as soon as that node has no text.

That prevents the existing LXML positional fallback from running and causes KoSync normalization to fall back to the reader's raw percentage instead.

This change lets **zero-offset** element boundaries with no text reach the existing positional fallback. A textless element with a non-zero offset still returns `None`, because there is no text coordinate to apply that offset to safely.

## Why

Related to #276.

I reproduced this with KOReader sending:

```text
/body/DocFragment[22]/body/div/p[1].0
```

The XPath resolved to a real empty `<p>`, but `resolve_xpath_to_index()` returned `None`. In the same EPUB, the resulting percentage fallback landed roughly 7,900 canonical characters ahead of the structural boundary. That was enough to move the Audiobookshelf position noticeably forward.

The resolver already has a structural LXML fallback for cases where text anchoring is ambiguous. The empty-anchor early return is the only thing preventing that same fallback from handling this narrower case.

`resolve_xpath()` is intentionally unchanged because it returns text, and a textless element has no text to return. This also does not address cases where KoSync provides no XPath at all (`xpath == ""`).

## Tests

- Added a regression test for the observed `.../div/p[1].0` form on an empty chapter-opening `<p>`.
- The regression fails on current `dev` because the resolver returns `None`.
- `tests/test_resolve_xpath_to_index_bs4_fallback.py`: 10 passed with the fix.
- `py_compile`: passed.
- `git diff --check`: clean.

No schema, settings, API, percentage-threshold, sync-write, or locator-generation behavior is changed.