### PR TITLE
[Perf] Persist and prewarm KoSync XPath ordering

### DIFF
--- a/alembic/versions/f7c2a9d41b63_add_kosync_xpath_order_cache.py
+++ b/alembic/versions/f7c2a9d41b63_add_kosync_xpath_order_cache.py
@@ -1,0 +1,56 @@
+"""persist KoSync canonical XPath ordering cache
+
+Revision ID: f7c2a9d41b63
+Revises: e1f4a7c9d2b5
+Create Date: 2026-08-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f7c2a9d41b63"
+down_revision = "e1f4a7c9d2b5"
+branch_labels = None
+depends_on = None
+
+_TABLE = "kosync_xpath_order_cache"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        return
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("key_hash", sa.String(length=64), nullable=False),
+        sa.Column("document_hash", sa.String(length=32), nullable=False),
+        sa.Column("filename", sa.String(length=500), nullable=False),
+        sa.Column("device_xpath", sa.Text(), nullable=False),
+        sa.Column("synced_xpath", sa.Text(), nullable=False),
+        sa.Column("device_index", sa.Integer(), nullable=False),
+        sa.Column("synced_index", sa.Integer(), nullable=False),
+        sa.Column("file_key", sa.String(length=64), nullable=False),
+        sa.Column("updated_at", sa.Float(), nullable=False),
+        sa.UniqueConstraint("key_hash", name="uq_kosync_xpath_order_cache_key"),
+    )
+    op.create_index(
+        "ix_kosync_xpath_order_cache_document_hash",
+        _TABLE,
+        ["document_hash"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_kosync_xpath_order_cache_updated_at",
+        _TABLE,
+        ["updated_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        op.drop_table(_TABLE)

--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -6,10 +6,17 @@ import re
 from src.api.api_clients import KoSyncClient
 from src.db.models import Book, State
 from src.utils.ebook_utils import EbookParser
+from src.utils.config_loader import env_truthy
+from src.utils.kosync_canonical import (
+    install_persistent_xpath_cache,
+    prewarm_xpath_order_cache,
+    resolve_canonical_position,
+)
 from src.utils.progress_metadata import parse_service_timestamp
 from src.sync_clients.sync_client_interface import SyncClient, SyncResult, UpdateProgressRequest, ServiceState
 
 logger = logging.getLogger(__name__)
+
 
 class KoSyncSyncClient(SyncClient):
     _KOSYNC_BLOCK_TAGS = {
@@ -24,6 +31,7 @@ class KoSyncSyncClient(SyncClient):
         self.kosync_client = kosync_client
         self.ebook_parser = ebook_parser
         self.delta_kosync_thresh = float(os.getenv("SYNC_DELTA_KOSYNC_PERCENT", 1)) / 100.0
+        install_persistent_xpath_cache(self.ebook_parser)
 
     def is_configured(self) -> bool:
         return self.kosync_client.is_configured()
@@ -175,9 +183,39 @@ class KoSyncSyncClient(SyncClient):
                 updated_state={'pct': pct, 'xpath': None, 'skipped': True}
             )
 
+        canonical_index = None
+        canonical_file_key = None
+        if env_truthy("KOSYNC_XPATH_ORDER_ENABLED") and epub and safe_xpath:
+            try:
+                canonical_index, canonical_file_key = resolve_canonical_position(
+                    self.ebook_parser,
+                    epub,
+                    safe_xpath,
+                )
+            except Exception as exc:
+                # Canonical metadata is an optimization/safety hint. A failure
+                # must not block the existing KoSync write path.
+                logger.debug(
+                    "KoSync canonical position unavailable for '%s': %s",
+                    book.abs_title if book else "unknown",
+                    exc,
+                    exc_info=True,
+                )
+
         success = self.kosync_client.update_progress(ko_id, pct, safe_xpath)
         updated_state = {
             'pct': pct,
             'xpath': safe_xpath
         }
+        if canonical_index is not None and canonical_file_key:
+            # Pre-resolve the current device-vs-new-bridge pair off the GET path.
+            # Failure is contained; #386's existing GET fallback remains intact.
+            if success:
+                prewarm_xpath_order_cache(
+                    book,
+                    self.ebook_parser,
+                    safe_xpath,
+                    canonical_index,
+                    canonical_file_key,
+                )
         return SyncResult(pct, success, updated_state)

--- a/src/utils/kosync_canonical.py
+++ b/src/utils/kosync_canonical.py
@@ -1,0 +1,341 @@
+"""Persistent/prewarmed canonical XPath ordering for KoSync.
+
+#386 bounds XPath ordering tightly but still resolves both XPaths from the EPUB
+on a cache miss in the KoSync GET path.  This module keeps that decision logic
+unchanged while moving the expensive work off the request path whenever
+possible:
+
+* bridge-generated KoSync writes already have the target XPath and a hot parser;
+  resolve that target immediately and prewarm the current device-vs-synced pair
+  in the background;
+* safely prewarmed pairs are persisted in a tiny SQLite cache so a restart or
+  the in-memory cache TTL does not force the same pair to be parsed again;
+* persisted entries are tied to the local EPUB cache identity (path + mtime_ns +
+  size, hashed before storage).  A normal changed/replaced EPUB is a miss.
+
+If any lookup, DB operation, or background resolution fails, callers fall back
+to the existing #386 behavior.  Canonical caching is therefore an optimization,
+not a new source of truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TABLE = "kosync_xpath_order_cache"
+_INSTALL_LOCK = threading.Lock()
+_INSTALLED = False
+_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="kosync-canonical")
+_PREWARM_LOCK = threading.Lock()
+_PENDING_PREWARMS: dict[tuple, tuple] = {}
+_ACTIVE_PREWARMS: set[tuple] = set()
+_PERSISTED_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60
+_PERSISTED_MAX_PER_DOCUMENT = 64
+
+
+def canonical_file_key(parser, filename: str) -> Optional[str]:
+    """Return an opaque identity matching the parser cache file invariants."""
+    filename = str(filename or "").strip()
+    if not filename:
+        return None
+    try:
+        path = Path(parser.resolve_book_path(filename)).resolve()
+        stat = path.stat()
+    except (OSError, TypeError, ValueError):
+        return None
+    material = f"{path}|{stat.st_mtime_ns}|{stat.st_size}".encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def resolve_canonical_position(parser, filename: str, progress: str) -> tuple[Optional[int], Optional[str]]:
+    """Resolve one XPath and bind the result to one unchanged EPUB version."""
+    filename = str(filename or "").strip()
+    progress = str(progress or "").strip()
+    if not filename or not progress:
+        return None, None
+
+    before_key = canonical_file_key(parser, filename)
+    if not before_key:
+        return None, None
+
+    index = parser.resolve_xpath_to_index(filename, progress)
+    if index is None:
+        return None, before_key
+    try:
+        index = int(index)
+    except (TypeError, ValueError):
+        return None, before_key
+    if index < 0:
+        return None, before_key
+
+    after_key = canonical_file_key(parser, filename)
+    if not after_key or after_key != before_key:
+        logger.debug("KoSync canonical result discarded because '%s' changed during parse", filename)
+        return None, None
+    return index, before_key
+
+
+def _pair_hash(cache_key: tuple) -> str:
+    document_hash, filename, device_xpath, synced_xpath = cache_key
+    material = "\0".join((
+        str(document_hash or ""),
+        str(filename or ""),
+        str(device_xpath or ""),
+        str(synced_xpath or ""),
+    )).encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _server_module():
+    # Import lazily: kosync_server imports many application services and this
+    # helper is also unit-tested in isolation.
+    from src.api import kosync_server
+    return kosync_server
+
+
+def _database_service():
+    try:
+        return getattr(_server_module(), "_database_service", None)
+    except Exception:
+        return None
+
+
+def _persist_pair(cache_key: tuple, device_index: Optional[int], synced_index: Optional[int], file_key: str) -> None:
+    # #386 intentionally caches failed resolutions in RAM for ten minutes.  Do
+    # not persist those failures across restarts/software upgrades: a newer
+    # parser may be able to resolve the exact same pair later.
+    if device_index is None or synced_index is None:
+        return
+    try:
+        device_index = int(device_index)
+        synced_index = int(synced_index)
+    except (TypeError, ValueError):
+        return
+    if device_index < 0 or synced_index < 0:
+        return
+
+    db = _database_service()
+    if db is None or not file_key:
+        return
+    try:
+        now = time.time()
+        document_hash = str(cache_key[0])
+        with db.get_session() as session:
+            session.execute(text(f"""
+                INSERT INTO {_CACHE_TABLE}
+                    (key_hash, document_hash, filename, device_xpath, synced_xpath,
+                     device_index, synced_index, file_key, updated_at)
+                VALUES
+                    (:key_hash, :document_hash, :filename, :device_xpath, :synced_xpath,
+                     :device_index, :synced_index, :file_key, :updated_at)
+                ON CONFLICT(key_hash) DO UPDATE SET
+                    device_index = excluded.device_index,
+                    synced_index = excluded.synced_index,
+                    file_key = excluded.file_key,
+                    updated_at = excluded.updated_at
+            """), {
+                "key_hash": _pair_hash(cache_key),
+                "document_hash": document_hash,
+                "filename": str(cache_key[1]),
+                "device_xpath": str(cache_key[2]),
+                "synced_xpath": str(cache_key[3]),
+                "device_index": device_index,
+                "synced_index": synced_index,
+                "file_key": file_key,
+                "updated_at": now,
+            })
+
+            # Page turns can create a lot of exact pairs over time.  Keep the
+            # persistent layer bounded; the in-memory #386 cache remains the
+            # short-lived cache for everything else.
+            session.execute(text(f"""
+                DELETE FROM {_CACHE_TABLE}
+                WHERE updated_at < :cutoff
+            """), {"cutoff": now - _PERSISTED_CACHE_TTL_SECONDS})
+            session.execute(text(f"""
+                DELETE FROM {_CACHE_TABLE}
+                WHERE document_hash = :document_hash
+                  AND id NOT IN (
+                      SELECT id FROM {_CACHE_TABLE}
+                      WHERE document_hash = :document_hash
+                      ORDER BY updated_at DESC, id DESC
+                      LIMIT :keep
+                  )
+            """), {
+                "document_hash": document_hash,
+                "keep": _PERSISTED_MAX_PER_DOCUMENT,
+            })
+    except Exception as exc:
+        # Old DB before migration, transient locks, etc. must never affect sync.
+        logger.debug("KoSync persistent canonical cache write unavailable: %s", exc)
+
+
+def _load_pair(cache_key: tuple, parser) -> Optional[tuple[Optional[int], Optional[int]]]:
+    db = _database_service()
+    if db is None:
+        return None
+    try:
+        current_key = canonical_file_key(parser, str(cache_key[1]))
+        if not current_key:
+            return None
+        with db.get_session() as session:
+            row = session.execute(text(f"""
+                SELECT device_index, synced_index, file_key
+                FROM {_CACHE_TABLE}
+                WHERE key_hash = :key_hash
+            """), {"key_hash": _pair_hash(cache_key)}).first()
+        if not row or str(row.file_key or "") != current_key:
+            return None
+        return row.device_index, row.synced_index
+    except Exception as exc:
+        logger.debug("KoSync persistent canonical cache read unavailable: %s", exc)
+        return None
+
+
+def install_persistent_xpath_cache(parser) -> None:
+    """Layer persistent lookup/storage underneath #386's in-memory pair cache.
+
+    This wraps only the cache helpers.  ``_respond_from_book_states`` and all of
+    its safety gates (feature flag, same-file check, percentage bound) remain
+    byte-for-byte unchanged.
+    """
+    global _INSTALLED
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return
+        try:
+            server = _server_module()
+            original_get = server._xpath_index_cache_get
+            original_put = server._xpath_index_cache_put
+        except Exception as exc:
+            logger.debug("KoSync persistent canonical cache install unavailable: %s", exc)
+            return
+
+        def wrapped_get(cache_key):
+            cached = original_get(cache_key)
+            if cached is not None:
+                return cached
+            if not isinstance(cache_key, tuple) or len(cache_key) != 4:
+                return None
+            persisted = _load_pair(cache_key, parser)
+            if persisted is None:
+                return None
+            original_put(cache_key, persisted[0], persisted[1])
+            return persisted
+
+        # Deliberately leave #386's put helper untouched.  A pair resolved by
+        # the existing GET path does not carry a before/after file-version key,
+        # so persisting it here could bind pre-replacement indices to a file that
+        # changed during that parse.  Only the explicitly prewarmed path below
+        # persists pairs after both XPath resolutions pass the file-stability
+        # checks in ``resolve_canonical_position``.
+        server._xpath_index_cache_get = wrapped_get
+        _INSTALLED = True
+
+
+def _current_user_id():
+    try:
+        from src.utils.user_context import get_current_user_id
+        return get_current_user_id()
+    except Exception:
+        return None
+
+
+def _drain_prewarm(key: tuple, parser) -> None:
+    while True:
+        with _PREWARM_LOCK:
+            payload = _PENDING_PREWARMS.pop(key, None)
+            if payload is None:
+                _ACTIVE_PREWARMS.discard(key)
+                return
+        try:
+            _prewarm_once(parser, *payload)
+        except Exception as exc:
+            logger.debug("KoSync canonical prewarm failed for %s: %s", key[0], exc, exc_info=True)
+
+
+def _prewarm_once(parser, book, synced_xpath: str, synced_index: int, synced_file_key: str, user_id) -> bool:
+    server = _server_module()
+    db = getattr(server, "_database_service", None)
+    if db is None:
+        return False
+
+    doc_id = str(getattr(book, "kosync_doc_id", "") or "").strip()
+    if not doc_id:
+        return False
+    document = db.get_kosync_document(doc_id)
+    filename = str(getattr(document, "filename", "") or "").strip() if document else ""
+    if not filename:
+        return False
+
+    book_files = {
+        str(getattr(book, "ebook_filename", "") or "").strip(),
+        str(getattr(book, "original_ebook_filename", "") or "").strip(),
+    }
+    book_files.discard("")
+    if filename not in book_files:
+        return False
+
+    current_file_key = canonical_file_key(parser, filename)
+    if not current_file_key or current_file_key != synced_file_key:
+        return False
+
+    row = db.get_user_kosync_progress(doc_id, user_id)
+    if row is None and document is not None:
+        doc_user_id = getattr(document, "user_id", None)
+        if user_id is None or doc_user_id in (None, user_id):
+            row = document
+    device_xpath = str(getattr(row, "progress", "") or "").strip() if row else ""
+    if not device_xpath:
+        return False
+
+    device_index, device_file_key = resolve_canonical_position(parser, filename, device_xpath)
+    if device_index is None or device_file_key != synced_file_key:
+        return False
+
+    cache_key = (doc_id, filename, device_xpath, synced_xpath)
+    server._xpath_index_cache_put(cache_key, device_index, synced_index)
+    # This function already runs on the background executor, and both canonical
+    # resolutions have verified the same unchanged file identity.
+    _persist_pair(cache_key, device_index, synced_index, synced_file_key)
+    return True
+
+
+def prewarm_xpath_order_cache(book, parser, synced_xpath: str, synced_index: Optional[int], synced_file_key: Optional[str]) -> bool:
+    """Queue a coalesced device-vs-new-synced pair before the next KoSync GET."""
+    try:
+        synced_index = int(synced_index) if synced_index is not None else None
+    except (TypeError, ValueError):
+        return False
+    synced_xpath = str(synced_xpath or "").strip()
+    synced_file_key = str(synced_file_key or "").strip()
+    doc_id = str(getattr(book, "kosync_doc_id", "") or "").strip() if book else ""
+    if not doc_id or not synced_xpath or synced_index is None or synced_index < 0 or not synced_file_key:
+        return False
+
+    user_id = _current_user_id()
+    key = (doc_id, user_id)
+    payload = (book, synced_xpath, synced_index, synced_file_key, user_id)
+    with _PREWARM_LOCK:
+        _PENDING_PREWARMS[key] = payload
+        if key in _ACTIVE_PREWARMS:
+            return True
+        _ACTIVE_PREWARMS.add(key)
+    try:
+        _EXECUTOR.submit(_drain_prewarm, key, parser)
+    except RuntimeError:
+        with _PREWARM_LOCK:
+            _ACTIVE_PREWARMS.discard(key)
+            _PENDING_PREWARMS.pop(key, None)
+        return False
+    return True

--- a/tests/test_kosync_canonical_cache.py
+++ b/tests/test_kosync_canonical_cache.py
@@ -1,0 +1,237 @@
+import os
+import sys
+import tempfile
+import time
+import types
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import sqlalchemy as sa
+from sqlalchemy.pool import StaticPool
+
+from src.utils import kosync_canonical as mod
+
+
+class FakeParser:
+    def __init__(self, path, mapping=None):
+        self.path = Path(path)
+        self.mapping = mapping or {}
+        self.calls = []
+
+    def resolve_book_path(self, filename):
+        return self.path
+
+    def resolve_xpath_to_index(self, filename, xpath):
+        self.calls.append((filename, xpath))
+        return self.mapping.get(xpath)
+
+
+class FakeDB:
+    def __init__(self):
+        self.engine = sa.create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+        with self.engine.begin() as conn:
+            conn.exec_driver_sql("""
+                CREATE TABLE kosync_xpath_order_cache (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key_hash VARCHAR(64) NOT NULL UNIQUE,
+                    document_hash VARCHAR(32) NOT NULL,
+                    filename VARCHAR(500) NOT NULL,
+                    device_xpath TEXT NOT NULL,
+                    synced_xpath TEXT NOT NULL,
+                    device_index INTEGER NOT NULL,
+                    synced_index INTEGER NOT NULL,
+                    file_key VARCHAR(64) NOT NULL,
+                    updated_at FLOAT NOT NULL
+                )
+            """)
+        self.document = None
+        self.user_progress = None
+
+    @contextmanager
+    def get_session(self):
+        with self.engine.begin() as conn:
+            class Session:
+                def execute(self, statement, params=None):
+                    return conn.execute(statement, params or {})
+            yield Session()
+
+    def get_kosync_document(self, doc_id):
+        return self.document
+
+    def get_user_kosync_progress(self, doc_id, user_id=None):
+        return self.user_progress
+
+
+class CanonicalCacheTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.write(b"epub-v1")
+        tmp.close()
+        self.path = Path(tmp.name)
+        self.parser = FakeParser(self.path, {"/device": 100, "/synced": 200})
+        self.db = FakeDB()
+        self.memory = {}
+
+        self._old_api_pkg = sys.modules.get("src.api")
+        api_pkg = self._old_api_pkg or types.ModuleType("src.api")
+        sys.modules["src.api"] = api_pkg
+        server = types.ModuleType("src.api.kosync_server")
+        server._database_service = self.db
+
+        def cache_get(key):
+            return self.memory.get(key)
+
+        def cache_put(key, device_index, synced_index):
+            self.memory[key] = (device_index, synced_index)
+
+        server._xpath_index_cache_get = cache_get
+        server._xpath_index_cache_put = cache_put
+        sys.modules["src.api.kosync_server"] = server
+        self._old_server_attr = getattr(api_pkg, "kosync_server", None)
+        api_pkg.kosync_server = server
+
+        # Reset module singleton state between tests.
+        mod._INSTALLED = False
+
+    def tearDown(self):
+        self.path.unlink(missing_ok=True)
+        self.db.engine.dispose()
+        sys.modules.pop("src.api.kosync_server", None)
+        api_pkg = sys.modules.get("src.api")
+        if api_pkg is not None:
+            if self._old_server_attr is None:
+                try:
+                    delattr(api_pkg, "kosync_server")
+                except AttributeError:
+                    pass
+            else:
+                api_pkg.kosync_server = self._old_server_attr
+        if self._old_api_pkg is None:
+            sys.modules.pop("src.api", None)
+        else:
+            sys.modules["src.api"] = self._old_api_pkg
+
+    def _wait_for_persisted(self, key_hash, timeout=1.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self.db.engine.begin() as conn:
+                count = conn.exec_driver_sql(
+                    "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE key_hash = ?",
+                    (key_hash,),
+                ).scalar_one()
+            if count:
+                return True
+            time.sleep(0.01)
+        return False
+
+    def test_file_key_changes_when_epub_changes(self):
+        first = mod.canonical_file_key(self.parser, "book.epub")
+        time.sleep(0.002)
+        self.path.write_bytes(b"epub-v2-longer")
+        os.utime(self.path, None)
+        second = mod.canonical_file_key(self.parser, "book.epub")
+        self.assertEqual(len(first), 64)
+        self.assertNotEqual(first, second)
+
+    def test_persisted_pair_survives_memory_cache_clear(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+        mod.install_persistent_xpath_cache(self.parser)
+        server = sys.modules["src.api.kosync_server"]
+        file_key = mod.canonical_file_key(self.parser, "book.epub")
+        mod._persist_pair(key, 100, 200, file_key)
+
+        self.memory.clear()
+        self.assertEqual(server._xpath_index_cache_get(key), (100, 200))
+        self.assertEqual(self.memory[key], (100, 200))
+
+    def test_get_path_put_is_not_persisted_without_file_stability_proof(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+        mod.install_persistent_xpath_cache(self.parser)
+        server = sys.modules["src.api.kosync_server"]
+        server._xpath_index_cache_put(key, 100, 200)
+        time.sleep(0.05)
+
+        with self.db.engine.begin() as conn:
+            count = conn.exec_driver_sql(
+                "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE key_hash = ?",
+                (mod._pair_hash(key),),
+            ).scalar_one()
+        self.assertEqual(count, 0)
+        self.assertEqual(self.memory[key], (100, 200))
+
+    def test_failed_resolution_is_not_persisted(self):
+        key = ("a" * 32, "book.epub", "/device", "/unresolved")
+        file_key = mod.canonical_file_key(self.parser, "book.epub")
+        mod._persist_pair(key, None, None, file_key)
+
+        with self.db.engine.begin() as conn:
+            count = conn.exec_driver_sql(
+                "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE key_hash = ?",
+                (mod._pair_hash(key),),
+            ).scalar_one()
+        self.assertEqual(count, 0)
+
+    def test_persistent_cache_is_bounded_per_document(self):
+        file_key = mod.canonical_file_key(self.parser, "book.epub")
+        doc_id = "a" * 32
+        old_limit = mod._PERSISTED_MAX_PER_DOCUMENT
+        mod._PERSISTED_MAX_PER_DOCUMENT = 3
+        try:
+            for idx in range(6):
+                key = (doc_id, "book.epub", f"/device-{idx}", f"/synced-{idx}")
+                mod._persist_pair(key, idx, idx + 100, file_key)
+            with self.db.engine.begin() as conn:
+                count = conn.exec_driver_sql(
+                    "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE document_hash = ?",
+                    (doc_id,),
+                ).scalar_one()
+            self.assertEqual(count, 3)
+        finally:
+            mod._PERSISTED_MAX_PER_DOCUMENT = old_limit
+
+    def test_persisted_pair_is_ignored_after_epub_replacement(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+        mod.install_persistent_xpath_cache(self.parser)
+        server = sys.modules["src.api.kosync_server"]
+        file_key = mod.canonical_file_key(self.parser, "book.epub")
+        mod._persist_pair(key, 100, 200, file_key)
+        self.memory.clear()
+
+        time.sleep(0.002)
+        self.path.write_bytes(b"changed-version-longer")
+        os.utime(self.path, None)
+        self.assertIsNone(server._xpath_index_cache_get(key))
+
+    def test_bridge_write_prewarm_resolves_device_xpath_off_get_path(self):
+        mod.install_persistent_xpath_cache(self.parser)
+        self.db.document = SimpleNamespace(
+            filename="book.epub",
+            user_id=7,
+            progress="/device",
+        )
+        self.db.user_progress = SimpleNamespace(progress="/device")
+        book = SimpleNamespace(
+            kosync_doc_id="a" * 32,
+            ebook_filename="book.epub",
+            original_ebook_filename=None,
+        )
+        file_key = mod.canonical_file_key(self.parser, "book.epub")
+        old_user_id = mod._current_user_id
+        mod._current_user_id = lambda: 7
+        try:
+            self.assertTrue(mod.prewarm_xpath_order_cache(book, self.parser, "/synced", 200, file_key))
+            key = ("a" * 32, "book.epub", "/device", "/synced")
+            deadline = time.time() + 1
+            while key not in self.memory and time.time() < deadline:
+                time.sleep(0.01)
+            self.assertEqual(self.memory.get(key), (100, 200))
+            self.assertTrue(self._wait_for_persisted(mod._pair_hash(key)))
+            self.assertIn(("book.epub", "/device"), self.parser.calls)
+        finally:
+            mod._current_user_id = old_user_id
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kosync_canonical_migration.py
+++ b/tests/test_kosync_canonical_migration.py
@@ -1,0 +1,61 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION = Path(__file__).resolve().parents[1] / 'alembic/versions/f7c2a9d41b63_add_kosync_xpath_order_cache.py'
+spec = importlib.util.spec_from_file_location('canonical_migration', MIGRATION)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class MigrationTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = sa.create_engine('sqlite:///:memory:')
+
+    def tearDown(self):
+        self.engine.dispose()
+
+    def _run(self, fn):
+        with self.engine.begin() as conn:
+            ctx = MigrationContext.configure(conn)
+            operations = Operations(ctx)
+            old_op = mod.op
+            try:
+                mod.op = operations
+                fn()
+            finally:
+                mod.op = old_op
+
+    def test_upgrade_creates_persistent_pair_cache(self):
+        self._run(mod.upgrade)
+        inspector = sa.inspect(self.engine)
+        self.assertIn(mod._TABLE, inspector.get_table_names())
+        columns = {c['name'] for c in inspector.get_columns(mod._TABLE)}
+        self.assertTrue({
+            'key_hash', 'document_hash', 'filename', 'device_xpath', 'synced_xpath',
+            'device_index', 'synced_index', 'file_key', 'updated_at',
+        }.issubset(columns))
+        nullable = {c['name']: c['nullable'] for c in inspector.get_columns(mod._TABLE)}
+        self.assertFalse(nullable['device_index'])
+        self.assertFalse(nullable['synced_index'])
+        indexes = {idx['name'] for idx in inspector.get_indexes(mod._TABLE)}
+        self.assertIn('ix_kosync_xpath_order_cache_document_hash', indexes)
+        self.assertIn('ix_kosync_xpath_order_cache_updated_at', indexes)
+
+    def test_upgrade_is_idempotent(self):
+        self._run(mod.upgrade)
+        self._run(mod.upgrade)
+        self.assertIn(mod._TABLE, sa.inspect(self.engine).get_table_names())
+
+    def test_downgrade_removes_cache_table(self):
+        self._run(mod.upgrade)
+        self._run(mod.downgrade)
+        self.assertNotIn(mod._TABLE, sa.inspect(self.engine).get_table_names())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_kosync_sync_client_canonical.py
+++ b/tests/test_kosync_sync_client_canonical.py
@@ -1,0 +1,210 @@
+import importlib
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def install_stubs():
+    api_clients = types.ModuleType("src.api.api_clients")
+    api_clients.KoSyncClient = object
+    sys.modules[api_clients.__name__] = api_clients
+
+    models = types.ModuleType("src.db.models")
+    models.Book = object
+    models.State = object
+    sys.modules[models.__name__] = models
+
+    ebook_utils = types.ModuleType("src.utils.ebook_utils")
+    ebook_utils.EbookParser = object
+    sys.modules[ebook_utils.__name__] = ebook_utils
+
+    config_loader = types.ModuleType("src.utils.config_loader")
+    config_loader.env_truthy = lambda key: True
+    sys.modules[config_loader.__name__] = config_loader
+
+    progress_metadata = types.ModuleType("src.utils.progress_metadata")
+    progress_metadata.parse_service_timestamp = lambda value: value
+    sys.modules[progress_metadata.__name__] = progress_metadata
+
+    iface = types.ModuleType("src.sync_clients.sync_client_interface")
+
+    class SyncClient:
+        def __init__(self, ebook_parser):
+            self.ebook_parser = ebook_parser
+
+        def supports_book(self, book):
+            return True
+
+    class SyncResult:
+        def __init__(self, location=None, success=False, updated_state=None):
+            self.location = location
+            self.success = success
+            self.updated_state = updated_state
+
+    class UpdateProgressRequest:
+        def __init__(self, locator_result):
+            self.locator_result = locator_result
+
+    class ServiceState:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    iface.SyncClient = SyncClient
+    iface.SyncResult = SyncResult
+    iface.UpdateProgressRequest = UpdateProgressRequest
+    iface.ServiceState = ServiceState
+    sys.modules[iface.__name__] = iface
+
+
+class FakeParser:
+    def __init__(self, path):
+        self.path = Path(path)
+        self.resolve_calls = []
+
+    def resolve_book_path(self, filename):
+        return self.path
+
+    def get_sentence_level_ko_xpath(self, epub, pct):
+        return "/body/DocFragment[2]/body/div/p[3]/span[1]/text().17"
+
+    def resolve_xpath_to_index(self, epub, xpath):
+        self.resolve_calls.append((epub, xpath))
+        return 4242
+
+
+class FakeKoSync:
+    def __init__(self, success=True):
+        self.success = success
+        self.calls = []
+
+    def is_configured(self):
+        return True
+
+    def update_progress(self, doc_id, pct, xpath):
+        self.calls.append((doc_id, pct, xpath))
+        return self.success
+
+
+class KoSyncSyncClientCanonicalTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._stub_names = (
+            "src.api.api_clients",
+            "src.db.models",
+            "src.utils.ebook_utils",
+            "src.utils.config_loader",
+            "src.utils.progress_metadata",
+            "src.sync_clients.sync_client_interface",
+            "src.sync_clients.kosync_sync_client",
+        )
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._stub_names}
+        install_stubs()
+        sys.modules.pop("src.sync_clients.kosync_sync_client", None)
+        cls.mod = importlib.import_module("src.sync_clients.kosync_sync_client")
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, previous in cls._saved_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+    def setUp(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.write(b"epub")
+        tmp.close()
+        self.path = Path(tmp.name)
+
+    def tearDown(self):
+        self.path.unlink(missing_ok=True)
+
+    def _request(self, pct):
+        return SimpleNamespace(locator_result=SimpleNamespace(percentage=pct))
+
+    def _book(self):
+        return SimpleNamespace(
+            kosync_doc_id="a" * 32,
+            original_ebook_filename="book.epub",
+            ebook_filename=None,
+            abs_title="Book",
+        )
+
+    def _client(self, transport, parser):
+        # Construct without modifying the real kosync_server module/cache hooks;
+        # this test covers only the SyncClient integration point.
+        original = self.mod.install_persistent_xpath_cache
+        self.mod.install_persistent_xpath_cache = lambda _parser: None
+        try:
+            return self.mod.KoSyncSyncClient(transport, parser)
+        finally:
+            self.mod.install_persistent_xpath_cache = original
+
+    def test_bridge_write_resolves_and_prewarms_exact_safe_xpath(self):
+        parser = FakeParser(self.path)
+        transport = FakeKoSync()
+        client = self._client(transport, parser)
+        book = self._book()
+        prewarm_calls = []
+        old_prewarm = self.mod.prewarm_xpath_order_cache
+        self.mod.prewarm_xpath_order_cache = lambda *args: prewarm_calls.append(args) or True
+        try:
+            result = client.update_progress(book, self._request(0.42))
+        finally:
+            self.mod.prewarm_xpath_order_cache = old_prewarm
+
+        expected_xpath = "/body/DocFragment[2]/body/div/p[3].0"
+        self.assertTrue(result.success)
+        self.assertEqual(transport.calls, [("a" * 32, 0.42, expected_xpath)])
+        self.assertEqual(parser.resolve_calls, [("book.epub", expected_xpath)])
+        self.assertEqual(result.updated_state, {"pct": 0.42, "xpath": expected_xpath})
+        self.assertEqual(len(prewarm_calls), 1)
+        self.assertIs(prewarm_calls[0][0], book)
+        self.assertIs(prewarm_calls[0][1], parser)
+        self.assertEqual(prewarm_calls[0][2], expected_xpath)
+        self.assertEqual(prewarm_calls[0][3], 4242)
+        self.assertEqual(len(prewarm_calls[0][4]), 64)
+
+    def test_disabled_xpath_ordering_adds_no_write_side_parse(self):
+        parser = FakeParser(self.path)
+        transport = FakeKoSync()
+        client = self._client(transport, parser)
+        old_env_truthy = self.mod.env_truthy
+        self.mod.env_truthy = lambda key: False
+        try:
+            result = client.update_progress(self._book(), self._request(0.42))
+        finally:
+            self.mod.env_truthy = old_env_truthy
+
+        self.assertTrue(result.success)
+        self.assertEqual(parser.resolve_calls, [])
+
+    def test_canonical_failure_does_not_block_existing_write(self):
+        parser = FakeParser(self.path)
+        parser.resolve_xpath_to_index = lambda epub, xpath: None
+        transport = FakeKoSync()
+        client = self._client(transport, parser)
+
+        result = client.update_progress(self._book(), self._request(0.42))
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(transport.calls), 1)
+        self.assertEqual(result.updated_state["pct"], 0.42)
+
+    def test_clear_progress_does_not_create_canonical_metadata(self):
+        parser = FakeParser(self.path)
+        transport = FakeKoSync()
+        client = self._client(transport, parser)
+
+        result = client.update_progress(self._book(), self._request(0.0))
+
+        self.assertEqual(transport.calls, [("a" * 32, 0.0, "")])
+        self.assertEqual(result.updated_state, {"pct": 0.0, "xpath": ""})
+        self.assertEqual(parser.resolve_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #380 and the hardening in #386.

#386 correctly bounds canonical XPath ordering, but an in-memory cache miss can still parse the EPUB on the KoSync GET request path. The hardening PR measured cold parses in the multi-second range. This keeps the existing ordering policy and all #386 safety gates unchanged, while prewarming the common bridge-write -> device-GET case and making those safely prewarmed pairs reusable across RAM-cache expiry/restarts.

## What changes

- adds a small persistent `kosync_xpath_order_cache` table for **safely prewarmed exact XPath pairs**
- layers persistent lookup underneath #386's existing in-memory pair cache; `_respond_from_book_states` itself is unchanged
- binds persisted pairs to the local EPUB parser-cache identity (`resolved path + mtime_ns + size`, hashed before storage), so a normal replaced/changed EPUB is a cache miss
- resolves the bridge-generated safe XPath while the ebook parser is already hot, then asynchronously resolves the current device XPath and prewarms that exact device-XPath vs new synced-XPath pair
- performs that write-side canonical work only when `KOSYNC_XPATH_ORDER_ENABLED` is enabled; the default-off path adds no XPath parse
- persists only when both XPath resolutions passed before/after file-stability checks; pairs produced by the existing GET-time resolver are deliberately left RAM-only because that path has no file-version proof spanning its parse
- keeps failed/unresolvable pairs non-persistent, so a parser improvement cannot be hidden by a stored negative result
- bounds persistent storage to 64 recent pairs per document and 30 days, with indexes for per-document and age pruning
- degrades to the current #386 GET resolution path on any cache/migration/background failure

## Deliberately unchanged

- `KOSYNC_XPATH_ORDER_ENABLED` remains opt-in
- percentage delta guard remains unchanged
- same-document / same-file checks remain unchanged
- furthest-wins semantics remain unchanged
- empty/missing XPath behavior remains unchanged
- the first unseen pair can still fall back to the existing GET-time resolution; this PR does not claim to remove every possible GET parse

## Tests

Focused tests cover persisted-pair reuse, EPUB replacement invalidation, GET-path pairs staying RAM-only without file-stability proof, non-persistence of failed resolutions, cache bounding, bridge-write prewarming, the disabled-feature no-parse path, migration schema/indexes/idempotence/downgrade, write-failure fallback, clear-progress behavior, and test-module isolation.

Local focused result: **14 passed**, plus `py_compile` for the changed production/migration modules.

Migration is additive and creates only the cache table.
