### PR TITLE
[Feature] Share the existing library with existing users (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to BookBridge will be documented in this file.
 
 ### Added
 
+- **You can now share an existing library with the people who already have
+  accounts.** *Shared Library* only ever applied going forward: it gave the full
+  catalog to accounts created after you switched it on, and shared each book as it
+  was matched. Anyone already signed up kept seeing only their own books, and the
+  only way to widen their access was to delete and recreate them — which throws
+  away their reading progress and their saved logins. Settings > Users now has a
+  **Share library with all users** button that hands every book already in the
+  catalog to every active user in one go, no deletions involved. It needs *Shared
+  Library* switched on first, since otherwise books matched from then on would
+  drift straight back out of sync. Only visibility is shared: everyone keeps their
+  own progress, their own KoSync documents and their own stats. Note that it is
+  one-way — there is no bulk un-share — so the button asks for confirmation.
+  (#384)
+
 - **Finishing a book on one service can now mark it finished everywhere.** Raw
   percentages never agree at the end of a book — an ebook's back matter is not
   narrated — so a title you finished in one app could sit at 92-97% in another and

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -870,6 +870,41 @@ class DatabaseService:
                 session.add(UserBook(user_id=user_id, abs_id=abs_id))
             return len(missing)
 
+    def share_all_books_with_active_users(self) -> dict:
+        """Claim every catalog book for every active user. Returns {"users": <count>, "links": <count>}.
+
+        This is the bulk reconcile counterpart to:
+        - backfill_user_books_for_user (one user gets all books)
+        - link_book_to_all_active_users (one book goes to all users)
+
+        Idempotent: only creates missing UserBook visibility links. Progress, KoSync
+        documents, and stats remain per-user and are not affected.
+        """
+        with self.get_session() as session:
+            all_book_ids = {row[0] for row in session.query(Book.abs_id).all()}
+            if not all_book_ids:
+                user_count = session.query(User.id).filter(User.active == 1).count()
+                return {"users": user_count, "links": 0}
+
+            active_user_ids = {
+                row[0] for row in session.query(User.id).filter(User.active == 1).all()
+            }
+            if not active_user_ids:
+                return {"users": 0, "links": 0}
+
+            by_user: dict[int, set[str]] = defaultdict(set)
+            for user_id, abs_id in session.query(UserBook.user_id, UserBook.abs_id).all():
+                by_user[user_id].add(abs_id)
+
+            links_created = 0
+            for user_id in active_user_ids:
+                missing = all_book_ids - by_user.get(user_id, set())
+                for abs_id in missing:
+                    session.add(UserBook(user_id=user_id, abs_id=abs_id))
+                    links_created += 1
+
+            return {"users": len(active_user_ids), "links": links_created}
+
     def unlink_user_book(self, user_id: int, abs_id: str) -> int:
         """Remove a user's claim on a book. Returns rows deleted."""
         if user_id is None or not abs_id:

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1424,7 +1424,7 @@ def account_booklore_libraries():
 
 # User-management actions accepted by both the legacy /admin/users page and the
 # Settings → Users tab (which posts to /settings).
-_USER_ADMIN_ACTIONS = {'create', 'reset_password', 'toggle_active', 'delete'}
+_USER_ADMIN_ACTIONS = {'create', 'reset_password', 'toggle_active', 'delete', 'share_library'}
 
 
 def _apply_user_admin_action(form):
@@ -1509,6 +1509,21 @@ def _apply_user_admin_action(form):
                     message = f"Deleted '{target.username}'"
                 else:
                     error = "User not found"
+        elif action == 'share_library':
+            if not env_truthy('SHARE_ALL_BOOKS_WITH_ALL_USERS'):
+                error = "Enable Features → Shared Library first, then share the existing catalog."
+            else:
+                result = database_service.share_all_books_with_active_users()
+                links = result.get('links', 0)
+                users = result.get('users', 0)
+                logger.info(
+                    "🔗 Shared %d existing book link(s) across %d active user(s) (share-all-books reconcile)",
+                    links, users,
+                )
+                if links:
+                    message = f"Shared {links} book link(s) across {users} user(s)"
+                else:
+                    message = f"All {users} user(s) already see the full library"
     except Exception as e:
         error = f"Action failed: {e}"
     return message, error

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -78,6 +78,15 @@
     </div>
 
     <div class="card">
+        <h2>Shared library</h2>
+        <p>Shares the existing catalog with all active users. Requires the Shared Library setting (Features → Shared Library). This is one-way and cannot be undone in bulk.</p>
+        <form method="POST" onsubmit="return confirm('This will give every active user visibility of every book in the catalog. This cannot be undone in bulk.');">
+            <input type="hidden" name="action" value="share_library">
+            <button type="submit" class="btn btn-secondary btn-sm">📚 Share library with all users</button>
+        </form>
+    </div>
+
+    <div class="card">
         <h2>Create user</h2>
         <form method="POST" class="create-grid">
             <input type="hidden" name="action" value="create">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2496,6 +2496,9 @@
                         Each user has their own progress and credentials but shares the book catalog.
                         To make every matched book visible to everyone automatically, enable
                         <a href="{{ url_for('settings') }}#features" style="color:#aab4f5;">Features → Shared Library</a>.
+                        Enabling that setting only affects books matched from then on; the button below shares the
+                        <strong>existing</strong> catalog with <strong>existing</strong> users. Sharing is <strong>one-way</strong> —
+                        it cannot be un-shared in bulk.
                     </div>
                     <table class="users-table full-width">
                         <tr>
@@ -2537,6 +2540,10 @@
                         </tr>
                         {% endfor %}
                     </table>
+                    <form method="POST" action="/settings" style="margin-top: 14px;" onsubmit="return confirm('This will give every active user visibility of every book in the catalog. This cannot be undone in bulk.');">
+                        <input type="hidden" name="action" value="share_library">
+                        <button type="submit" class="u-btn u-btn-primary">📚 Share library with all users</button>
+                    </form>
                 </div>
             </div>
 

--- a/tests/test_mapping_status_reuse.py
+++ b/tests/test_mapping_status_reuse.py
@@ -329,6 +329,54 @@ class TestSharedCatalogDatabaseHelpers(unittest.TestCase):
         self.assertTrue(self.db.is_user_linked(self.bob.id, "ab-2"))
         self.assertEqual(self.db.backfill_user_books_for_user(self.bob.id), 0)
 
+    def test_share_all_books_with_active_users_skips_inactive(self):
+        """Share all books with active users; inactive carol should not get links."""
+        result = self.db.share_all_books_with_active_users()
+
+        self.assertEqual(result, {"users": 2, "links": 4})
+        self.assertTrue(self.db.is_user_linked(self.alice.id, "ab-1"))
+        self.assertTrue(self.db.is_user_linked(self.alice.id, "ab-2"))
+        self.assertTrue(self.db.is_user_linked(self.bob.id, "ab-1"))
+        self.assertTrue(self.db.is_user_linked(self.bob.id, "ab-2"))
+        self.assertFalse(self.db.is_user_linked(self.carol.id, "ab-1"))
+        self.assertFalse(self.db.is_user_linked(self.carol.id, "ab-2"))
+
+    def test_share_all_books_with_active_users_is_idempotent(self):
+        """Second call should return links == 0 while users remains 2."""
+        self.db.share_all_books_with_active_users()
+        result = self.db.share_all_books_with_active_users()
+
+        self.assertEqual(result["links"], 0)
+        self.assertEqual(result["users"], 2)
+
+    def test_share_all_books_with_active_users_counts_only_missing_links(self):
+        """Pre-link bob to ab-1; only 3 new links should be created."""
+        self.db.link_user_book(self.bob.id, "ab-1")
+
+        result = self.db.share_all_books_with_active_users()
+
+        self.assertEqual(result["links"], 3)
+        self.assertEqual(result["users"], 2)
+        self.assertTrue(self.db.is_user_linked(self.bob.id, "ab-1"))
+        self.assertTrue(self.db.is_user_linked(self.bob.id, "ab-2"))
+        self.assertTrue(self.db.is_user_linked(self.alice.id, "ab-1"))
+        self.assertTrue(self.db.is_user_linked(self.alice.id, "ab-2"))
+
+    def test_share_all_books_with_active_users_with_no_active_users(self):
+        """Disable alice and bob; result should be 0 users, 0 links."""
+        self.db.set_user_active(self.alice.id, False)
+        self.db.set_user_active(self.bob.id, False)
+
+        result = self.db.share_all_books_with_active_users()
+
+        self.assertEqual(result, {"users": 0, "links": 0})
+        self.assertFalse(self.db.is_user_linked(self.alice.id, "ab-1"))
+        self.assertFalse(self.db.is_user_linked(self.alice.id, "ab-2"))
+        self.assertFalse(self.db.is_user_linked(self.bob.id, "ab-1"))
+        self.assertFalse(self.db.is_user_linked(self.bob.id, "ab-2"))
+        self.assertFalse(self.db.is_user_linked(self.carol.id, "ab-1"))
+        self.assertFalse(self.db.is_user_linked(self.carol.id, "ab-2"))
+
 
 class TestPublicLinkBase(unittest.TestCase):
     """PR #366 added *_WEB_URL, but only some rendered links honoured it.

--- a/tests/test_share_library_reconcile.py
+++ b/tests/test_share_library_reconcile.py
@@ -1,0 +1,122 @@
+"""Issue #384 — share_library admin action reconcile.
+
+Enabling SHARE_ALL_BOOKS_WITH_ALL_USERS only fanned out books matched afterwards
+and only backfilled newly created accounts, so an operator had to delete and
+recreate existing users (destroying their progress and credentials) to widen
+access. The share_library admin action reconciles the existing catalog against
+existing users instead.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import src.web_server as web_server
+
+
+class ShareLibraryReconcileTestCase(unittest.TestCase):
+    def setUp(self):
+        self._saved_db = web_server.database_service
+        self.db = Mock()
+        web_server.database_service = self.db
+
+        self._saved_setting = os.environ.get("SHARE_ALL_BOOKS_WITH_ALL_USERS")
+        os.environ.pop("SHARE_ALL_BOOKS_WITH_ALL_USERS", None)
+
+    def tearDown(self):
+        web_server.database_service = self._saved_db
+        if self._saved_setting is None:
+            os.environ.pop("SHARE_ALL_BOOKS_WITH_ALL_USERS", None)
+        else:
+            os.environ["SHARE_ALL_BOOKS_WITH_ALL_USERS"] = self._saved_setting
+
+
+class TestShareLibraryAdminAction(ShareLibraryReconcileTestCase):
+    def test_disabled_setting_reports_an_error_and_does_not_touch_the_db(self):
+        """Setting unset; should error and not call the DB method."""
+        message, error = web_server._apply_user_admin_action({'action': 'share_library'})
+
+        self.assertTrue(error, "expected an error when SHARE_ALL_BOOKS_WITH_ALL_USERS is disabled")
+        self.assertIn("Shared Library", error, "error should mention the Shared Library setting")
+        self.assertIsNone(message)
+        self.db.share_all_books_with_active_users.assert_not_called()
+
+    def test_explicit_false_is_also_gated(self):
+        """Setting 'false' should also gate the action."""
+        os.environ["SHARE_ALL_BOOKS_WITH_ALL_USERS"] = "false"
+
+        message, error = web_server._apply_user_admin_action({'action': 'share_library'})
+
+        self.assertTrue(error, "expected an error when SHARE_ALL_BOOKS_WITH_ALL_USERS is 'false'")
+        self.assertIn("Shared Library", error)
+        self.assertIsNone(message)
+        self.db.share_all_books_with_active_users.assert_not_called()
+
+    def test_enabled_shares_and_reports_the_counts(self):
+        """Setting 'true' should call the DB method and report counts."""
+        os.environ["SHARE_ALL_BOOKS_WITH_ALL_USERS"] = "true"
+        self.db.share_all_books_with_active_users.return_value = {"users": 3, "links": 12}
+
+        message, error = web_server._apply_user_admin_action({'action': 'share_library'})
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(message)
+        self.assertIn("12", message)
+        self.assertIn("3", message)
+        self.db.share_all_books_with_active_users.assert_called_once_with()
+
+    def test_checkbox_on_spelling_is_honoured(self):
+        """Settings checkboxes POST 'on', not 'true' — the recurring bug in this repo."""
+        os.environ["SHARE_ALL_BOOKS_WITH_ALL_USERS"] = "on"
+        self.db.share_all_books_with_active_users.return_value = {"users": 1, "links": 5}
+
+        message, error = web_server._apply_user_admin_action({'action': 'share_library'})
+
+        self.assertIsNone(error, "checkbox 'on' should be truthy")
+        self.assertIsNotNone(message)
+        self.db.share_all_books_with_active_users.assert_called_once_with()
+
+    def test_already_reconciled_reports_no_new_links(self):
+        """When links == 0, message should report already-shared state, not 'Shared 0'."""
+        os.environ["SHARE_ALL_BOOKS_WITH_ALL_USERS"] = "true"
+        self.db.share_all_books_with_active_users.return_value = {"users": 2, "links": 0}
+
+        message, error = web_server._apply_user_admin_action({'action': 'share_library'})
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(message)
+        self.assertNotIn("Shared 0", message, "message must not claim 'Shared 0'")
+        self.assertIn("already see the full library", message.lower())
+
+    def test_db_failure_becomes_an_error_message(self):
+        """DB exception should be caught and returned as error, not propagated."""
+        os.environ["SHARE_ALL_BOOKS_WITH_ALL_USERS"] = "true"
+        self.db.share_all_books_with_active_users.side_effect = RuntimeError("boom")
+
+        message, error = web_server._apply_user_admin_action({'action': 'share_library'})
+
+        self.assertIsNone(message)
+        self.assertTrue(error, "DB failure should become an error message")
+        self.assertIn("boom", error.lower())
+
+    def test_action_is_registered_for_both_post_handlers(self):
+        """Without this, /settings POST would fall through to full settings save."""
+        self.assertIn('share_library', web_server._USER_ADMIN_ACTIONS)
+
+    def test_both_user_management_templates_expose_the_action(self):
+        """Both settings.html and admin_users.html must have the share_library form."""
+        templates_dir = Path(web_server.__file__).parent.parent / 'templates'
+
+        settings_html = (templates_dir / 'settings.html').read_text(encoding='utf-8')
+        admin_users_html = (templates_dir / 'admin_users.html').read_text(encoding='utf-8')
+
+        self.assertIn('share_library', settings_html, "settings.html must have share_library action")
+        self.assertIn('share_library', admin_users_html, "admin_users.html must have share_library action")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #384.

The 7.4.0 `SHARE_ALL_BOOKS_WITH_ALL_USERS` setting only ever applied going forward, so an operator could not widen access for accounts that already existed. The reporter's only workaround was to delete every user but the creator and recreate them — which destroys their progress and credentials.

The gap is slightly wider than reported. The setting was consulted in exactly two places, and neither reconciles history:

- `_apply_user_admin_action`'s `create` branch backfilled **newly created accounts only**
- `_claim_book_for_user_id` fans a claim out to all active users only for books matched **while the flag is on**

So books matched *before* the flag was enabled stayed owned by whoever matched them, even for users created afterwards.

## What changes

- `DatabaseService.share_all_books_with_active_users()` — claims every catalog book for every active user in **one session pass** (all `Book.abs_id`s, the `User.active == 1` ids, and the existing `UserBook` pairs grouped by user once), inserting only the missing links and returning `{"users": n, "links": m}`. Idempotent.
- A `share_library` admin action wired into `_apply_user_admin_action`, added to `_USER_ADMIN_ACTIONS` so the Settings → Users POST routes it instead of falling through to a full settings save.
- A button in both user-management UIs (`templates/settings.html` Users tab and `templates/admin_users.html`), with a `confirm()` and updated help text.

Visibility only — progress, KoSync documents and stats stay per-user, exactly as before.

## Design decisions

- **Gated on the setting.** With `SHARE_ALL_BOOKS_WITH_ALL_USERS` off the action refuses rather than sharing, because a one-time fan-out with the flag off would drift straight back out as new books were matched.
- **An explicit button, not a side effect of enabling the setting.** `POST /settings` does know the old value, but hiding a bulk write inside a settings save is worse to reason about, and the button reports a count.
- **One-way.** `unlink_user_book` cannot distinguish links created by sharing from claims that predate it, so there is no bulk revoke; both UIs say so.

## Tests

Full suite **2,809 passed, 4 skipped** (~70s), a delta of **+12**. All 12 new tests were verified to fail with the production changes stashed.

- new `tests/test_share_library_reconcile.py` (8) — the setting gate including the `'on'` checkbox spelling, the counts message, the already-reconciled message, DB-failure-to-error, action registration, and both templates
- 4 real-SQLite methods added to `test_mapping_status_reuse.py::TestSharedCatalogDatabaseHelpers` — inactive users skipped, idempotence, only-missing-links counting, no-active-users

Also passes with the touched files run in both orders, and CI's fatal flake8 selection (`E9,F63,F7,F82`) is clean on every changed file.

## Live verification

Verified against real data **without sharing anything**, since the bulk share has no undo. The live 1.99 GB `database.db` was opened read-only and its `books`/`users`/`user_books` rows replayed into a throwaway DB in the container, where the bind mount already serves the new code to a fresh process:

```
books=394, active users=2 (admin claims=389, user claims=7), user_books rows=396
PREDICTED  : users=2 links=394
returned   : {'users': 2, 'links': 394}
second call: {'users': 2, 'links': 0}      # idempotent
both active users end at 394/394 real catalog books
LIVE user_books rows: 396 before -> 396 after (UNCHANGED)
```

After `docker compose restart`, the gate was driven through the real `_apply_user_admin_action` with the live setting value and `database_service` replaced by a tripwire that raises on any attribute access:

```
live setting = 'false'
error = 'Enable Features → Shared Library first, then share the existing catalog.'
GATE REFUSED WITHOUT TOUCHING THE DB: PASS
```

Startup was clean — existing revision `e1f4a7c9d2b5`, no new migration, `/api/health` 200.

## Deploy

**Restart** (`docker compose restart`) — only bind-mounted `./src` and `./templates` touched. **No migration**, no rebuild, no plugin re-download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
