### PR TITLE
[Fix] Route the KoSync XPath-order cache through DatabaseService

### DIFF
--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -24,6 +24,7 @@ from src.api.booklore_client import BookloreClient
 from src.api.hardcover_client import HardcoverClient
 from src.utils.cache_paths import safe_cache_path
 from src.utils.config_loader import env_truthy
+from src.utils.kosync_canonical import load_persisted_pair
 from src.utils.kosync_headers import hash_kosync_key
 from src.utils.time_utils import utcnow
 from src.utils.user_context import set_current_user_id, reset_current_user_id
@@ -125,18 +126,34 @@ def _xpath_index_cache_get(
 
     A pair that failed to resolve is cached as ``(None, None)`` and returned as
     such, so an unresolvable locator does not re-parse the EPUB on every GET.
-    A cache miss (absent or expired) returns None."""
+    A cache miss (absent or expired) falls through to the persistent per-file
+    cache before giving up; only pairs prewarmed by the write path are ever
+    persisted there, so a GET-time resolution stays RAM-only."""
     now = time.monotonic()
     with _XPATH_INDEX_CACHE_LOCK:
         entry = _XPATH_INDEX_CACHE.get(key)
-        if entry is None:
-            return None
-        device_index, synced_index, stored_at = entry
-        if now - stored_at > _XPATH_INDEX_CACHE_TTL_SECONDS:
+        if entry is not None:
+            device_index, synced_index, stored_at = entry
+            if now - stored_at <= _XPATH_INDEX_CACHE_TTL_SECONDS:
+                _XPATH_INDEX_CACHE.move_to_end(key)
+                return device_index, synced_index
             _XPATH_INDEX_CACHE.pop(key, None)
+
+    # RAM miss. The persistent lookup runs OUTSIDE the cache lock — that lock is
+    # never held across I/O. A cache read must not raise into the GET path.
+    if not isinstance(key, tuple) or len(key) != 4:
+        return None
+    try:
+        if _container is None:
             return None
-        _XPATH_INDEX_CACHE.move_to_end(key)
-        return device_index, synced_index
+        parser = _container.ebook_parser()
+    except Exception:
+        return None
+    persisted = load_persisted_pair(key, parser)
+    if persisted is None:
+        return None
+    _xpath_index_cache_put(key, persisted[0], persisted[1])
+    return persisted
 
 
 def _xpath_index_cache_put(

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -7,10 +7,11 @@ import json
 import logging
 import os
 import re
+import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from contextlib import contextmanager
 from zoneinfo import ZoneInfo
 
@@ -24,6 +25,7 @@ from .models import (
     Setting,
     KosyncDocument,
     KosyncUserProgress,
+    KosyncXpathOrderCache,
     PendingSuggestion,
     BookloreBook,
     ReadingSession,
@@ -1877,6 +1879,102 @@ class DatabaseService:
             for row in rows:
                 session.expunge(row)
             return rows
+
+    def get_kosync_xpath_order(self, key_hash: str, file_key: str) -> Optional[Tuple[int, int]]:
+        """Get the cached (device_index, synced_index) tuple for a key_hash.
+
+        This is a pure cache read. A file_key mismatch is a deliberate miss —
+        the row is only valid for the exact EPUB version it was computed from,
+        so a replaced or edited book must miss rather than return stale indices.
+        """
+        if not key_hash or not file_key:
+            return None
+        with self.get_session() as session:
+            row = session.query(KosyncXpathOrderCache).filter(
+                KosyncXpathOrderCache.key_hash == key_hash
+            ).first()
+            if not row:
+                return None
+            if str(row.file_key or "") != file_key:
+                return None
+            return (row.device_index, row.synced_index)
+
+    def save_kosync_xpath_order(self, key_hash: str, document_hash: str, filename: str,
+                                device_xpath: str, synced_xpath: str, device_index: int,
+                                synced_index: int, file_key: str,
+                                ttl_seconds: float, max_per_document: int) -> bool:
+        """Upsert one xpath order cache row and prune the table.
+
+        Returns True when the row was written, False on invalid input.
+
+        Mirrors the behavior of _persist_pair in kosync_canonical.py:
+        - Rejects falsy key_hash/file_key or None indices
+        - Coerces indices to int, rejects negative values
+        - Uses float unix timestamp for updated_at (not DateTime)
+        - Upserts by key_hash, leaving identity columns (document_hash, filename,
+          device_xpath, synced_xpath) unchanged on conflict
+        - Prunes rows older than ttl_seconds
+        - Keeps only max_per_document most recent rows per document_hash
+        """
+        if not key_hash or not file_key:
+            return False
+        if device_index is None or synced_index is None:
+            return False
+        try:
+            device_index = int(device_index)
+            synced_index = int(synced_index)
+        except (TypeError, ValueError):
+            return False
+        if device_index < 0 or synced_index < 0:
+            return False
+
+        now = time.time()
+        with self.get_session() as session:
+            # Upsert by key_hash
+            existing = session.query(KosyncXpathOrderCache).filter(
+                KosyncXpathOrderCache.key_hash == key_hash
+            ).first()
+            if existing:
+                existing.device_index = device_index
+                existing.synced_index = synced_index
+                existing.file_key = file_key
+                existing.updated_at = now
+            else:
+                new_row = KosyncXpathOrderCache(
+                    key_hash=key_hash,
+                    document_hash=document_hash,
+                    filename=filename,
+                    device_xpath=device_xpath,
+                    synced_xpath=synced_xpath,
+                    device_index=device_index,
+                    synced_index=synced_index,
+                    file_key=file_key,
+                    updated_at=now,
+                )
+                session.add(new_row)
+
+            # Prune: delete rows older than ttl_seconds
+            cutoff = now - ttl_seconds
+            session.query(KosyncXpathOrderCache).filter(
+                KosyncXpathOrderCache.updated_at < cutoff
+            ).delete(synchronize_session=False)
+
+            # Prune: keep only max_per_document most recent rows per document_hash
+            # Select ids to keep
+            keep_ids = session.query(KosyncXpathOrderCache.id).filter(
+                KosyncXpathOrderCache.document_hash == document_hash
+            ).order_by(
+                KosyncXpathOrderCache.updated_at.desc(),
+                KosyncXpathOrderCache.id.desc()
+            ).limit(max_per_document).all()
+            keep_id_set = {row[0] for row in keep_ids}
+            if keep_id_set:
+                session.query(KosyncXpathOrderCache).filter(
+                    KosyncXpathOrderCache.document_hash == document_hash,
+                    ~KosyncXpathOrderCache.id.in_(keep_id_set)
+                ).delete(synchronize_session=False)
+
+            return True
 
     def delete_kosync_data_for_book(self, abs_id: str) -> tuple[int, int]:
         """Delete every KoSync document and per-user progress row for a book.

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -112,6 +112,63 @@ class KosyncUserProgress(Base):
                 f"user_id={self.user_id}, pct={self.percentage})>")
 
 
+class KosyncXpathOrderCache(Base):
+    """
+    Persistent cache of already-resolved XPath <-> character-index pairs for one EPUB.
+
+    This table is a pure cache: every row is derivable by re-parsing the EPUB, and
+    nothing here is a source of truth. The cache is used to keep the KoSync GET path
+    from re-parsing the book on every request.
+
+    `file_key` binds a row to one exact EPUB version (path + mtime + size, hashed),
+    so a replaced or edited book misses the cache rather than returning stale indices.
+    """
+    __tablename__ = 'kosync_xpath_order_cache'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    key_hash = Column(String(64), nullable=False)
+    document_hash = Column(String(32), nullable=False)
+    filename = Column(String(500), nullable=False)
+    device_xpath = Column(Text, nullable=False)
+    synced_xpath = Column(Text, nullable=False)
+    device_index = Column(Integer, nullable=False)
+    synced_index = Column(Integer, nullable=False)
+    file_key = Column(String(64), nullable=False)
+    updated_at = Column(Float, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('key_hash', name='uq_kosync_xpath_order_cache_key'),
+        Index('ix_kosync_xpath_order_cache_document_hash', 'document_hash'),
+        Index('ix_kosync_xpath_order_cache_updated_at', 'updated_at'),
+    )
+
+    def __init__(
+        self,
+        key_hash: str,
+        document_hash: str,
+        filename: str,
+        device_xpath: str,
+        synced_xpath: str,
+        device_index: int,
+        synced_index: int,
+        file_key: str,
+        updated_at: float,
+    ):
+        self.key_hash = key_hash
+        self.document_hash = document_hash
+        self.filename = filename
+        self.device_xpath = device_xpath
+        self.synced_xpath = synced_xpath
+        self.device_index = device_index
+        self.synced_index = synced_index
+        self.file_key = file_key
+        self.updated_at = updated_at
+
+    def __repr__(self):
+        return (f"<KosyncXpathOrderCache(key_hash='{self.key_hash[:12]}...', "
+                f"doc_hash='{self.document_hash}', file_key='{self.file_key[:12]}...')>")
+
+
 class Book(Base):
     """
     Book model storing book metadata and mapping information.

--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -8,7 +8,6 @@ from src.db.models import Book, State
 from src.utils.ebook_utils import EbookParser
 from src.utils.config_loader import env_truthy
 from src.utils.kosync_canonical import (
-    install_persistent_xpath_cache,
     prewarm_xpath_order_cache,
     resolve_canonical_position,
 )
@@ -31,7 +30,6 @@ class KoSyncSyncClient(SyncClient):
         self.kosync_client = kosync_client
         self.ebook_parser = ebook_parser
         self.delta_kosync_thresh = float(os.getenv("SYNC_DELTA_KOSYNC_PERCENT", 1)) / 100.0
-        install_persistent_xpath_cache(self.ebook_parser)
 
     def is_configured(self) -> bool:
         return self.kosync_client.is_configured()

--- a/src/utils/kosync_canonical.py
+++ b/src/utils/kosync_canonical.py
@@ -23,18 +23,13 @@ from __future__ import annotations
 import hashlib
 import logging
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Optional
 
-from sqlalchemy import text
+from src.utils.logging_utils import get_persistent_condition_logger
 
 logger = logging.getLogger(__name__)
-
-_CACHE_TABLE = "kosync_xpath_order_cache"
-_INSTALL_LOCK = threading.Lock()
-_INSTALLED = False
 _EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="kosync-canonical")
 _PREWARM_LOCK = threading.Lock()
 _PENDING_PREWARMS: dict[tuple, tuple] = {}
@@ -116,71 +111,48 @@ def _persist_pair(cache_key: tuple, device_index: Optional[int], synced_index: O
     # parser may be able to resolve the exact same pair later.
     if device_index is None or synced_index is None:
         return
-    try:
-        device_index = int(device_index)
-        synced_index = int(synced_index)
-    except (TypeError, ValueError):
-        return
-    if device_index < 0 or synced_index < 0:
-        return
 
     db = _database_service()
     if db is None or not file_key:
         return
     try:
-        now = time.time()
         document_hash = str(cache_key[0])
-        with db.get_session() as session:
-            session.execute(text(f"""
-                INSERT INTO {_CACHE_TABLE}
-                    (key_hash, document_hash, filename, device_xpath, synced_xpath,
-                     device_index, synced_index, file_key, updated_at)
-                VALUES
-                    (:key_hash, :document_hash, :filename, :device_xpath, :synced_xpath,
-                     :device_index, :synced_index, :file_key, :updated_at)
-                ON CONFLICT(key_hash) DO UPDATE SET
-                    device_index = excluded.device_index,
-                    synced_index = excluded.synced_index,
-                    file_key = excluded.file_key,
-                    updated_at = excluded.updated_at
-            """), {
-                "key_hash": _pair_hash(cache_key),
-                "document_hash": document_hash,
-                "filename": str(cache_key[1]),
-                "device_xpath": str(cache_key[2]),
-                "synced_xpath": str(cache_key[3]),
-                "device_index": device_index,
-                "synced_index": synced_index,
-                "file_key": file_key,
-                "updated_at": now,
-            })
-
-            # Page turns can create a lot of exact pairs over time.  Keep the
-            # persistent layer bounded; the in-memory #386 cache remains the
-            # short-lived cache for everything else.
-            session.execute(text(f"""
-                DELETE FROM {_CACHE_TABLE}
-                WHERE updated_at < :cutoff
-            """), {"cutoff": now - _PERSISTED_CACHE_TTL_SECONDS})
-            session.execute(text(f"""
-                DELETE FROM {_CACHE_TABLE}
-                WHERE document_hash = :document_hash
-                  AND id NOT IN (
-                      SELECT id FROM {_CACHE_TABLE}
-                      WHERE document_hash = :document_hash
-                      ORDER BY updated_at DESC, id DESC
-                      LIMIT :keep
-                  )
-            """), {
-                "document_hash": document_hash,
-                "keep": _PERSISTED_MAX_PER_DOCUMENT,
-            })
+        success = db.save_kosync_xpath_order(
+            key_hash=_pair_hash(cache_key),
+            document_hash=document_hash,
+            filename=str(cache_key[1]),
+            device_xpath=str(cache_key[2]),
+            synced_xpath=str(cache_key[3]),
+            device_index=device_index,
+            synced_index=synced_index,
+            file_key=file_key,
+            ttl_seconds=_PERSISTED_CACHE_TTL_SECONDS,
+            max_per_document=_PERSISTED_MAX_PER_DOCUMENT,
+        )
+        if success:
+            get_persistent_condition_logger().resolve(
+                logger,
+                "kosync_xpath_order_cache",
+                "✅ KoSync XPath order cache available again",
+            )
     except Exception as exc:
-        # Old DB before migration, transient locks, etc. must never affect sync.
-        logger.debug("KoSync persistent canonical cache write unavailable: %s", exc)
+        get_persistent_condition_logger().warn(
+            logger,
+            "kosync_xpath_order_cache",
+            f"⚠️ KoSync XPath order cache unavailable: {exc}",
+            exc_info=True,
+        )
 
 
-def _load_pair(cache_key: tuple, parser) -> Optional[tuple[Optional[int], Optional[int]]]:
+def load_persisted_pair(cache_key: tuple, parser) -> Optional[tuple[Optional[int], Optional[int]]]:
+    """Load a persisted XPath order pair from the cache.
+
+    Pairs resolved by the GET path are **not** persisted, because that path has
+    no before/after file-version proof spanning its parse, so persisting them
+    could bind pre-replacement indices to a file that changed mid-parse.
+    Only `_prewarm_once`, whose two resolutions both pass
+    `resolve_canonical_position`'s file-stability checks, persists.
+    """
     db = _database_service()
     if db is None:
         return None
@@ -188,59 +160,22 @@ def _load_pair(cache_key: tuple, parser) -> Optional[tuple[Optional[int], Option
         current_key = canonical_file_key(parser, str(cache_key[1]))
         if not current_key:
             return None
-        with db.get_session() as session:
-            row = session.execute(text(f"""
-                SELECT device_index, synced_index, file_key
-                FROM {_CACHE_TABLE}
-                WHERE key_hash = :key_hash
-            """), {"key_hash": _pair_hash(cache_key)}).first()
-        if not row or str(row.file_key or "") != current_key:
-            return None
-        return row.device_index, row.synced_index
+        result = db.get_kosync_xpath_order(_pair_hash(cache_key), current_key)
+        if result is not None:
+            get_persistent_condition_logger().resolve(
+                logger,
+                "kosync_xpath_order_cache",
+                "✅ KoSync XPath order cache available again",
+            )
+        return result
     except Exception as exc:
-        logger.debug("KoSync persistent canonical cache read unavailable: %s", exc)
+        get_persistent_condition_logger().warn(
+            logger,
+            "kosync_xpath_order_cache",
+            f"⚠️ KoSync XPath order cache unavailable: {exc}",
+            exc_info=True,
+        )
         return None
-
-
-def install_persistent_xpath_cache(parser) -> None:
-    """Layer persistent lookup/storage underneath #386's in-memory pair cache.
-
-    This wraps only the cache helpers.  ``_respond_from_book_states`` and all of
-    its safety gates (feature flag, same-file check, percentage bound) remain
-    byte-for-byte unchanged.
-    """
-    global _INSTALLED
-    with _INSTALL_LOCK:
-        if _INSTALLED:
-            return
-        try:
-            server = _server_module()
-            original_get = server._xpath_index_cache_get
-            original_put = server._xpath_index_cache_put
-        except Exception as exc:
-            logger.debug("KoSync persistent canonical cache install unavailable: %s", exc)
-            return
-
-        def wrapped_get(cache_key):
-            cached = original_get(cache_key)
-            if cached is not None:
-                return cached
-            if not isinstance(cache_key, tuple) or len(cache_key) != 4:
-                return None
-            persisted = _load_pair(cache_key, parser)
-            if persisted is None:
-                return None
-            original_put(cache_key, persisted[0], persisted[1])
-            return persisted
-
-        # Deliberately leave #386's put helper untouched.  A pair resolved by
-        # the existing GET path does not carry a before/after file-version key,
-        # so persisting it here could bind pre-replacement indices to a file that
-        # changed during that parse.  Only the explicitly prewarmed path below
-        # persists pairs after both XPath resolutions pass the file-stability
-        # checks in ``resolve_canonical_position``.
-        server._xpath_index_cache_get = wrapped_get
-        _INSTALLED = True
 
 
 def _current_user_id():

--- a/tests/test_kosync_canonical_cache.py
+++ b/tests/test_kosync_canonical_cache.py
@@ -1,16 +1,22 @@
+"""Persistent KoSync XPath-order cache (#389, hardened).
+
+The cache is a pure optimization: every row is derivable by re-parsing the EPUB.
+These tests pin the properties that make it safe to keep — a row is bound to one
+exact EPUB version, failed resolutions are never persisted, the table is bounded,
+and the KoSync GET path consults it explicitly rather than through a monkey patch.
+"""
+
 import os
+import shutil
 import sys
 import tempfile
 import time
 import types
 import unittest
-from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
-import sqlalchemy as sa
-from sqlalchemy.pool import StaticPool
-
+from src.db.database_service import DatabaseService
 from src.utils import kosync_canonical as mod
 
 
@@ -28,76 +34,45 @@ class FakeParser:
         return self.mapping.get(xpath)
 
 
-class FakeDB:
-    def __init__(self):
-        self.engine = sa.create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
-        with self.engine.begin() as conn:
-            conn.exec_driver_sql("""
-                CREATE TABLE kosync_xpath_order_cache (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    key_hash VARCHAR(64) NOT NULL UNIQUE,
-                    document_hash VARCHAR(32) NOT NULL,
-                    filename VARCHAR(500) NOT NULL,
-                    device_xpath TEXT NOT NULL,
-                    synced_xpath TEXT NOT NULL,
-                    device_index INTEGER NOT NULL,
-                    synced_index INTEGER NOT NULL,
-                    file_key VARCHAR(64) NOT NULL,
-                    updated_at FLOAT NOT NULL
-                )
-            """)
-        self.document = None
-        self.user_progress = None
-
-    @contextmanager
-    def get_session(self):
-        with self.engine.begin() as conn:
-            class Session:
-                def execute(self, statement, params=None):
-                    return conn.execute(statement, params or {})
-            yield Session()
-
-    def get_kosync_document(self, doc_id):
-        return self.document
-
-    def get_user_kosync_progress(self, doc_id, user_id=None):
-        return self.user_progress
+def _temp_epub(tmpdir, content=b"epub-v1"):
+    path = Path(tmpdir) / "book.epub"
+    path.write_bytes(content)
+    return path
 
 
 class CanonicalCacheTests(unittest.TestCase):
+    """The module's own persistence helpers, against a real SQLite DatabaseService.
+
+    `kosync_canonical` finds the database through `kosync_server._database_service`,
+    so a stand-in module is installed for that lookup only — the database itself is
+    real, and the table comes from the ORM model, which is what proves the model and
+    the shipped migration agree.
+    """
+
     def setUp(self):
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.write(b"epub-v1")
-        tmp.close()
-        self.path = Path(tmp.name)
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        self.path = _temp_epub(self.tmpdir)
         self.parser = FakeParser(self.path, {"/device": 100, "/synced": 200})
-        self.db = FakeDB()
-        self.memory = {}
+        self.db = DatabaseService(str(Path(self.tmpdir) / "test.db"))
+        self.document = None
+        self.user_progress = None
+        self.db.get_kosync_document = lambda _doc_id: self.document
+        self.db.get_user_kosync_progress = lambda _doc_id, _user_id=None: self.user_progress
 
         self._old_api_pkg = sys.modules.get("src.api")
         api_pkg = self._old_api_pkg or types.ModuleType("src.api")
         sys.modules["src.api"] = api_pkg
         server = types.ModuleType("src.api.kosync_server")
         server._database_service = self.db
-
-        def cache_get(key):
-            return self.memory.get(key)
-
-        def cache_put(key, device_index, synced_index):
-            self.memory[key] = (device_index, synced_index)
-
-        server._xpath_index_cache_get = cache_get
-        server._xpath_index_cache_put = cache_put
+        self.memory = {}
+        server._xpath_index_cache_put = lambda key, d, s: self.memory.__setitem__(key, (d, s))
+        server._xpath_index_cache_get = lambda key: self.memory.get(key)
         sys.modules["src.api.kosync_server"] = server
         self._old_server_attr = getattr(api_pkg, "kosync_server", None)
         api_pkg.kosync_server = server
 
-        # Reset module singleton state between tests.
-        mod._INSTALLED = False
-
     def tearDown(self):
-        self.path.unlink(missing_ok=True)
-        self.db.engine.dispose()
         sys.modules.pop("src.api.kosync_server", None)
         api_pkg = sys.modules.get("src.api")
         if api_pkg is not None:
@@ -113,18 +88,10 @@ class CanonicalCacheTests(unittest.TestCase):
         else:
             sys.modules["src.api"] = self._old_api_pkg
 
-    def _wait_for_persisted(self, key_hash, timeout=1.0):
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            with self.db.engine.begin() as conn:
-                count = conn.exec_driver_sql(
-                    "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE key_hash = ?",
-                    (key_hash,),
-                ).scalar_one()
-            if count:
-                return True
-            time.sleep(0.01)
-        return False
+    def _stored(self, key):
+        return self.db.get_kosync_xpath_order(
+            mod._pair_hash(key), mod.canonical_file_key(self.parser, "book.epub")
+        )
 
     def test_file_key_changes_when_epub_changes(self):
         first = mod.canonical_file_key(self.parser, "book.epub")
@@ -135,43 +102,33 @@ class CanonicalCacheTests(unittest.TestCase):
         self.assertEqual(len(first), 64)
         self.assertNotEqual(first, second)
 
-    def test_persisted_pair_survives_memory_cache_clear(self):
+    def test_persisted_pair_round_trips(self):
         key = ("a" * 32, "book.epub", "/device", "/synced")
-        mod.install_persistent_xpath_cache(self.parser)
-        server = sys.modules["src.api.kosync_server"]
+        file_key = mod.canonical_file_key(self.parser, "book.epub")
+
+        mod._persist_pair(key, 100, 200, file_key)
+
+        self.assertEqual(mod.load_persisted_pair(key, self.parser), (100, 200))
+
+    def test_persisted_pair_is_ignored_after_epub_replacement(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
         file_key = mod.canonical_file_key(self.parser, "book.epub")
         mod._persist_pair(key, 100, 200, file_key)
 
-        self.memory.clear()
-        self.assertEqual(server._xpath_index_cache_get(key), (100, 200))
-        self.assertEqual(self.memory[key], (100, 200))
+        time.sleep(0.002)
+        self.path.write_bytes(b"changed-version-longer")
+        os.utime(self.path, None)
 
-    def test_get_path_put_is_not_persisted_without_file_stability_proof(self):
-        key = ("a" * 32, "book.epub", "/device", "/synced")
-        mod.install_persistent_xpath_cache(self.parser)
-        server = sys.modules["src.api.kosync_server"]
-        server._xpath_index_cache_put(key, 100, 200)
-        time.sleep(0.05)
-
-        with self.db.engine.begin() as conn:
-            count = conn.exec_driver_sql(
-                "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE key_hash = ?",
-                (mod._pair_hash(key),),
-            ).scalar_one()
-        self.assertEqual(count, 0)
-        self.assertEqual(self.memory[key], (100, 200))
+        self.assertIsNone(mod.load_persisted_pair(key, self.parser))
 
     def test_failed_resolution_is_not_persisted(self):
+        """A newer parser may resolve the same pair later — never store a negative."""
         key = ("a" * 32, "book.epub", "/device", "/unresolved")
         file_key = mod.canonical_file_key(self.parser, "book.epub")
+
         mod._persist_pair(key, None, None, file_key)
 
-        with self.db.engine.begin() as conn:
-            count = conn.exec_driver_sql(
-                "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE key_hash = ?",
-                (mod._pair_hash(key),),
-            ).scalar_one()
-        self.assertEqual(count, 0)
+        self.assertIsNone(self._stored(key))
 
     def test_persistent_cache_is_bounded_per_document(self):
         file_key = mod.canonical_file_key(self.parser, "book.epub")
@@ -182,55 +139,140 @@ class CanonicalCacheTests(unittest.TestCase):
             for idx in range(6):
                 key = (doc_id, "book.epub", f"/device-{idx}", f"/synced-{idx}")
                 mod._persist_pair(key, idx, idx + 100, file_key)
-            with self.db.engine.begin() as conn:
-                count = conn.exec_driver_sql(
-                    "SELECT COUNT(*) FROM kosync_xpath_order_cache WHERE document_hash = ?",
-                    (doc_id,),
-                ).scalar_one()
-            self.assertEqual(count, 3)
+                time.sleep(0.002)
+            kept = [
+                idx for idx in range(6)
+                if self._stored((doc_id, "book.epub", f"/device-{idx}", f"/synced-{idx}")) is not None
+            ]
+            self.assertEqual(kept, [3, 4, 5])
         finally:
             mod._PERSISTED_MAX_PER_DOCUMENT = old_limit
 
-    def test_persisted_pair_is_ignored_after_epub_replacement(self):
+    def test_cache_failure_degrades_to_a_miss(self):
+        """An unusable cache must never raise into the caller."""
         key = ("a" * 32, "book.epub", "/device", "/synced")
-        mod.install_persistent_xpath_cache(self.parser)
-        server = sys.modules["src.api.kosync_server"]
         file_key = mod.canonical_file_key(self.parser, "book.epub")
-        mod._persist_pair(key, 100, 200, file_key)
-        self.memory.clear()
 
-        time.sleep(0.002)
-        self.path.write_bytes(b"changed-version-longer")
-        os.utime(self.path, None)
-        self.assertIsNone(server._xpath_index_cache_get(key))
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("cache table missing")
+
+        self.db.get_kosync_xpath_order = boom
+        self.db.save_kosync_xpath_order = boom
+
+        self.assertIsNone(mod.load_persisted_pair(key, self.parser))
+        mod._persist_pair(key, 100, 200, file_key)  # must not raise
 
     def test_bridge_write_prewarm_resolves_device_xpath_off_get_path(self):
-        mod.install_persistent_xpath_cache(self.parser)
-        self.db.document = SimpleNamespace(
-            filename="book.epub",
-            user_id=7,
-            progress="/device",
-        )
-        self.db.user_progress = SimpleNamespace(progress="/device")
+        self.document = SimpleNamespace(filename="book.epub", user_id=7, progress="/device")
+        self.user_progress = SimpleNamespace(progress="/device")
         book = SimpleNamespace(
             kosync_doc_id="a" * 32,
             ebook_filename="book.epub",
             original_ebook_filename=None,
         )
         file_key = mod.canonical_file_key(self.parser, "book.epub")
+        key = ("a" * 32, "book.epub", "/device", "/synced")
         old_user_id = mod._current_user_id
         mod._current_user_id = lambda: 7
         try:
-            self.assertTrue(mod.prewarm_xpath_order_cache(book, self.parser, "/synced", 200, file_key))
-            key = ("a" * 32, "book.epub", "/device", "/synced")
-            deadline = time.time() + 1
-            while key not in self.memory and time.time() < deadline:
+            self.assertTrue(
+                mod.prewarm_xpath_order_cache(book, self.parser, "/synced", 200, file_key)
+            )
+            deadline = time.time() + 2
+            while self._stored(key) is None and time.time() < deadline:
                 time.sleep(0.01)
+            self.assertEqual(self._stored(key), (100, 200))
             self.assertEqual(self.memory.get(key), (100, 200))
-            self.assertTrue(self._wait_for_persisted(mod._pair_hash(key)))
             self.assertIn(("book.epub", "/device"), self.parser.calls)
         finally:
             mod._current_user_id = old_user_id
+
+
+class GetPathWiringTests(unittest.TestCase):
+    """The real `kosync_server._xpath_index_cache_get` consults the persistent cache.
+
+    #389 originally achieved this by reassigning the module's function from
+    `KoSyncSyncClient.__init__`. It is now an explicit call, so these tests exercise
+    the real function. Module globals are saved and restored so the suite still
+    passes in any order.
+    """
+
+    def setUp(self):
+        from src.api import kosync_server
+
+        self.server = kosync_server
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        self.path = _temp_epub(self.tmpdir)
+        self.parser = FakeParser(self.path, {"/device": 100, "/synced": 200})
+        self.db = DatabaseService(str(Path(self.tmpdir) / "test.db"))
+
+        self._saved_db = kosync_server._database_service
+        self._saved_container = kosync_server._container
+        self._saved_cache = dict(kosync_server._XPATH_INDEX_CACHE)
+        kosync_server._database_service = self.db
+        kosync_server._container = SimpleNamespace(ebook_parser=lambda: self.parser)
+        kosync_server._XPATH_INDEX_CACHE.clear()
+
+    def tearDown(self):
+        self.server._database_service = self._saved_db
+        self.server._container = self._saved_container
+        self.server._XPATH_INDEX_CACHE.clear()
+        self.server._XPATH_INDEX_CACHE.update(self._saved_cache)
+
+    def _persist(self, key):
+        mod._persist_pair(key, 100, 200, mod.canonical_file_key(self.parser, "book.epub"))
+
+    def test_ram_miss_falls_through_to_the_persistent_cache(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+        self._persist(key)
+
+        self.assertEqual(self.server._xpath_index_cache_get(key), (100, 200))
+
+    def test_persistent_hit_repopulates_the_in_memory_cache(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+        self._persist(key)
+
+        self.server._xpath_index_cache_get(key)
+
+        self.assertIn(key, self.server._XPATH_INDEX_CACHE)
+        # A second read is served from RAM without touching the database at all.
+        self.db.get_kosync_xpath_order = lambda *_a, **_k: self.fail("second read hit the DB")
+        self.assertEqual(self.server._xpath_index_cache_get(key), (100, 200))
+
+    def test_cached_failed_resolution_is_returned_from_ram(self):
+        """#386 caches an unresolvable pair as (None, None); that must not fall through."""
+        key = ("a" * 32, "book.epub", "/device", "/unresolvable")
+        self.server._xpath_index_cache_put(key, None, None)
+        self.db.get_kosync_xpath_order = lambda *_a, **_k: self.fail("consulted DB for a RAM-cached failure")
+
+        self.assertEqual(self.server._xpath_index_cache_get(key), (None, None))
+
+    def test_get_path_resolutions_are_never_persisted(self):
+        """The GET path has no before/after file-version proof, so it stays RAM-only."""
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+
+        self.server._xpath_index_cache_put(key, 100, 200)
+
+        stored = self.db.get_kosync_xpath_order(
+            mod._pair_hash(key), mod.canonical_file_key(self.parser, "book.epub")
+        )
+        self.assertIsNone(stored)
+
+    def test_miss_with_no_persisted_pair_returns_none(self):
+        key = ("a" * 32, "book.epub", "/device", "/never-seen")
+
+        self.assertIsNone(self.server._xpath_index_cache_get(key))
+
+    def test_unexpected_key_shape_is_a_miss(self):
+        self.assertIsNone(self.server._xpath_index_cache_get(("too", "short")))
+
+    def test_missing_container_is_a_miss_not_an_error(self):
+        key = ("a" * 32, "book.epub", "/device", "/synced")
+        self._persist(key)
+        self.server._container = None
+
+        self.assertIsNone(self.server._xpath_index_cache_get(key))
 
 
 if __name__ == "__main__":

--- a/tests/test_kosync_canonical_migration.py
+++ b/tests/test_kosync_canonical_migration.py
@@ -56,6 +56,38 @@ class MigrationTests(unittest.TestCase):
         self._run(mod.downgrade)
         self.assertNotIn(mod._TABLE, sa.inspect(self.engine).get_table_names())
 
+    def test_orm_model_matches_the_shipped_migration(self):
+        """The table shipped migration-only, with no model, so `create_all` built a
+        schema without it. A model exists now; if the two ever drift, a migrated
+        install and a freshly created one stop agreeing."""
+        from src.db.models import Base
+
+        self._run(mod.upgrade)
+        migrated = sa.inspect(self.engine)
+        mig_cols = [
+            (c['name'], str(c['type']), c['nullable'])
+            for c in migrated.get_columns(mod._TABLE)
+        ]
+        mig_indexes = sorted(i['name'] for i in migrated.get_indexes(mod._TABLE))
+
+        model_engine = sa.create_engine('sqlite:///:memory:')
+        try:
+            Base.metadata.create_all(model_engine)
+            built = sa.inspect(model_engine)
+            self.assertIn(mod._TABLE, built.get_table_names())
+            model_cols = [
+                (c['name'], str(c['type']), c['nullable'])
+                for c in built.get_columns(mod._TABLE)
+            ]
+            model_indexes = sorted(i['name'] for i in built.get_indexes(mod._TABLE))
+            uniques = {u['name'] for u in built.get_unique_constraints(mod._TABLE)}
+        finally:
+            model_engine.dispose()
+
+        self.assertEqual(model_cols, mig_cols)
+        self.assertEqual(model_indexes, mig_indexes)
+        self.assertIn('uq_kosync_xpath_order_cache_key', uniques)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_kosync_sync_client_canonical.py
+++ b/tests/test_kosync_sync_client_canonical.py
@@ -134,14 +134,9 @@ class KoSyncSyncClientCanonicalTests(unittest.TestCase):
         )
 
     def _client(self, transport, parser):
-        # Construct without modifying the real kosync_server module/cache hooks;
-        # this test covers only the SyncClient integration point.
-        original = self.mod.install_persistent_xpath_cache
-        self.mod.install_persistent_xpath_cache = lambda _parser: None
-        try:
-            return self.mod.KoSyncSyncClient(transport, parser)
-        finally:
-            self.mod.install_persistent_xpath_cache = original
+        # Construction no longer has global side effects: the persistent cache is
+        # consulted explicitly by kosync_server, not installed from __init__.
+        return self.mod.KoSyncSyncClient(transport, parser)
 
     def test_bridge_write_resolves_and_prewarms_exact_safe_xpath(self):
         parser = FakeParser(self.path)


### PR DESCRIPTION
## Summary

Follow-up hardening of #389, which added the persistent KoSync XPath-order cache.

**No behaviour change.** The cache is still opt-in behind `KOSYNC_XPATH_ORDER_ENABLED`, still bound to one exact EPUB version, still never persists a failed resolution, and GET-path resolutions still stay RAM-only. Four structural problems are addressed.

## 1. The table had no ORM model

It shipped migration-only, so `Base.metadata` did not know it and a `create_all`-built schema lacked it entirely — every read then failed into a swallowed `debug`, leaving the feature silently dead.

`KosyncXpathOrderCache` now mirrors the shipped migration exactly. **No new migration is needed** — the model matches what already ships, verified by building both schemas and diffing columns, nullability, types, index names and the named unique constraint. A new test fails if the two ever drift.

## 2. Persistence bypassed DatabaseService

`_persist_pair`/`_load_pair` used hand-written `session.execute(text(...))` from `src/utils/`. New `get_kosync_xpath_order` / `save_kosync_xpath_order` own the `file_key` staleness rule, the rejection of `None`/negative indices, and both prunes (30-day TTL sweep, 64-per-document cap).

## 3. The monkey patch is gone

`install_persistent_xpath_cache` reassigned `kosync_server._xpath_index_cache_get` from `KoSyncSyncClient.__init__` — process-global, never uninstalled, invisible to anyone reading `kosync_server`, and order-dependent through an `_INSTALLED` flag the tests set in `setUp` but never restored.

`_xpath_index_cache_get` now calls `load_persisted_pair` itself: explicit, greppable, and with the database call **outside** `_XPATH_INDEX_CACHE_LOCK`, so that lock is never held across I/O. A RAM-cached failed resolution still returns `(None, None)` without consulting the database, pinned by a test that fails the DB call outright. `_xpath_index_cache_put` is untouched, so GET-path pairs stay RAM-only for the same file-version reason #389 gave.

## 4. A permanently dead cache was silent

Every failure path was `logger.debug` with no `exc_info`. Failures now report through `get_persistent_condition_logger()` under one stable key, with recovery announced (`resolve()` is a silent no-op when nothing warned, so per-hit calls are free). Behaviour still degrades to the existing GET-path resolution.

## Review question resolved

`src/utils/ebook_utils.py` imports neither `user_setting` nor `user_context`, so the prewarm `ThreadPoolExecutor` thread cannot read per-user config — the contextvars concern does not apply here. `_current_user_id()` is still captured explicitly and passed through.

## Tests

Full suite **2,839 passed, 4 skipped** (+8).

- `test_kosync_canonical_cache.py` rewritten 7 → 14. `FakeDB`'s hand-rolled raw-SQL session is replaced by a real temp-SQLite `DatabaseService`, which also proves the model creates the table. A new `GetPathWiringTests` class exercises the **real** `kosync_server` function with module globals saved and restored.
- `test_orm_model_matches_the_shipped_migration` fails if model and migration drift.
- **Reverting only the explicit GET-path wiring fails exactly the two wiring tests.**
- The sync-client test's `_client` helper existed only to neutralise the monkey patch; removing the patch simplified it away.

Fatal flake8 selection clean; zero `session.execute` / `text(` left in `kosync_canonical.py`.

## Live verification

Deployed and verified **before** commit, against the running container.

Startup clean, `/api/health` 200, container healthy. An in-container probe against the **deployed** modules confirmed: no raw SQL in the module, `install_persistent_xpath_cache` gone, `load_persisted_pair` present and referenced from `_xpath_index_cache_get`, both DatabaseService methods present, the **live database schema identical to the ORM model**, and the real chain resolving `(100, 200)` through `_xpath_index_cache_get` after a RAM clear with RAM repopulated — then returning `None` once the EPUB was replaced.

```
live schema == model   : True
persisted then loaded  : (100, 200)
GET after RAM clear    : (100, 200)
RAM repopulated        : True
after EPUB replaced    : None
live cache rows        : 0 (was 0) -> UNCHANGED
LIVE VERIFICATION: PASS
```

The chain was driven against a **throwaway** DatabaseService, so the live cache table was never written.

## Deploy

**Restart** — only bind-mounted `./src` touched. **No new migration**, no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
