### PR TITLE
[Feature] Add on-demand reading position preview

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,2 +1,6 @@
 # API package
 
+# Dashboard position-preview routes decorate the already-registered KoSync admin
+# blueprint. Import them here so the decorators run before web_server registers
+# that blueprint with Flask during dependency setup.
+from src.api import reading_position_preview_routes as _reading_position_preview_routes  # noqa: F401,E402

--- a/src/api/reading_position_preview_routes.py
+++ b/src/api/reading_position_preview_routes.py
@@ -1,0 +1,49 @@
+"""Dashboard API for the on-demand reading-position text preview.
+
+The route is attached to the existing KoSync admin blueprint because that
+blueprint already hosts authenticated dashboard-management endpoints around
+reader positions.  Unlike the device-facing ``kosync`` blueprint, it is not
+exempt from the web-session auth guard.
+"""
+from flask import jsonify
+
+from src.api import kosync_server
+from src.api.kosync_server import kosync_admin_bp
+from src.services.reading_position_preview import build_reading_position_preview
+from src.utils.user_context import get_current_user_id
+
+
+@kosync_admin_bp.route("/api/books/<abs_id>/position-preview", methods=["GET"])
+def api_book_position_preview(abs_id: str):
+    """Return a bounded text excerpt around the current user's saved position."""
+    database_service = kosync_server._database_service
+    manager = kosync_server._manager
+    user_id = get_current_user_id()
+
+    if user_id is None:
+        return jsonify({"error": "authentication required"}), 401
+    if database_service is None or manager is None:
+        return jsonify({"error": "reading position service unavailable"}), 503
+
+    book = database_service.get_book(abs_id)
+    if book is None:
+        return jsonify({"error": "book not found"}), 404
+    if not database_service.is_user_linked(user_id, abs_id):
+        return jsonify({"error": "book not available for this user"}), 403
+
+    states = database_service.get_states_for_book(abs_id, user_id=user_id)
+    reading_stats = database_service.get_reading_stats(abs_id, user_id=user_id) or {}
+
+    payload = build_reading_position_preview(
+        book=book,
+        states=states,
+        last_leader=reading_stats.get("last_leader"),
+        ebook_parser=manager.ebook_parser,
+        alignment_service=manager.alignment_service,
+    )
+    response = jsonify(payload)
+    # The payload contains copyrighted book text and should never be retained by
+    # a shared proxy/browser cache.  The parser's own in-process EPUB cache is
+    # sufficient for repeated requests.
+    response.headers["Cache-Control"] = "private, no-store"
+    return response

--- a/src/services/reading_position_preview.py
+++ b/src/services/reading_position_preview.py
@@ -1,0 +1,270 @@
+"""Resolve a saved BookBridge reading position into a bounded text preview.
+
+This module is intentionally UI-agnostic.  It selects the same per-user progress
+state the dashboard considers current, resolves precise ebook locators when they
+exist, maps audio time through the stored alignment when necessary, and only then
+falls back to an explicitly approximate percentage position.
+
+The returned payload never contains a raw ebook path, locator, or character index.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+_AUDIO_CLIENTS = {"abs", "bookloreaudio", "bookorbitaudio"}
+_SOURCE_LABELS = {
+    "abs": "Audiobookshelf",
+    "kosync": "KoSync",
+    "storyteller": "Storyteller",
+    "booklore": "Grimmory",
+    "bookloreaudio": "Grimmory Audio",
+    "bookorbit": "BookOrbit",
+    "bookorbitaudio": "BookOrbit Audio",
+    "bookfusion": "BookFusion",
+    "cwa": "CWA",
+    "readest": "Readest",
+}
+
+
+@dataclass(frozen=True)
+class _ResolvedPosition:
+    index: int
+    status: str
+    confidence: str
+    detail: str = ""
+
+
+def _client_key(name: str | None) -> str:
+    key = str(name or "").strip().lower()
+    if key.startswith("kosync") or key == "bridgesync_plugin":
+        return "kosync"
+    if key in {"abs", "absebook"}:
+        return "abs"
+    return key
+
+
+def _source_label(name: str | None) -> str:
+    key = _client_key(name)
+    if key in _SOURCE_LABELS:
+        return _SOURCE_LABELS[key]
+    raw = str(name or "").strip()
+    return raw or "BookBridge"
+
+
+def _as_float(value) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _select_state(states: Iterable, last_leader: str | None):
+    states = list(states or [])
+    if not states:
+        return None
+
+    by_key = {}
+    for state in states:
+        key = _client_key(getattr(state, "client_name", None))
+        if not key:
+            continue
+        existing = by_key.get(key)
+        if existing is None or (_as_float(getattr(state, "last_updated", None)) or 0) > (
+            _as_float(getattr(existing, "last_updated", None)) or 0
+        ):
+            by_key[key] = state
+
+    leader_key = _client_key(last_leader)
+    if leader_key and leader_key in by_key:
+        return by_key[leader_key]
+
+    # ReadingSession data can be absent for old/imported rows.  In that case the
+    # newest observed state is the least surprising display-only fallback.
+    return max(
+        states,
+        key=lambda state: _as_float(getattr(state, "last_updated", None)) or 0,
+    )
+
+
+def _resolve_filename(book, ebook_parser) -> Optional[str]:
+    candidates = []
+    for value in (
+        getattr(book, "original_ebook_filename", None),
+        getattr(book, "ebook_filename", None),
+    ):
+        value = str(value or "").strip()
+        if value and value not in candidates:
+            candidates.append(value)
+
+    for filename in candidates:
+        try:
+            ebook_parser.resolve_book_path(filename)
+            return filename
+        except (FileNotFoundError, OSError):
+            continue
+    return None
+
+
+def _resolve_precise_or_mapped_position(
+    *,
+    state,
+    filename: str,
+    book,
+    ebook_parser,
+    alignment_service,
+) -> tuple[Optional[_ResolvedPosition], list[str]]:
+    failures: list[str] = []
+
+    xpath = str(getattr(state, "xpath", None) or "").strip()
+    if xpath:
+        index = ebook_parser.resolve_xpath_to_index(filename, xpath)
+        if index is not None:
+            return _ResolvedPosition(index, "exact", "Exact · XPath"), failures
+        failures.append("XPath")
+
+    cfi = str(getattr(state, "cfi", None) or "").strip()
+    if cfi.startswith("epubcfi("):
+        index = ebook_parser.resolve_cfi_to_index(filename, cfi)
+        if index is not None:
+            return _ResolvedPosition(index, "exact", "Exact · CFI"), failures
+        failures.append("CFI")
+
+    client_key = _client_key(getattr(state, "client_name", None))
+    timestamp = _as_float(getattr(state, "timestamp", None))
+    if client_key in _AUDIO_CLIENTS and timestamp is not None and alignment_service is not None:
+        try:
+            index = alignment_service.get_char_for_time(getattr(book, "abs_id", ""), timestamp)
+        except Exception:
+            index = None
+        if index is not None:
+            return _ResolvedPosition(index, "mapped", "Mapped · audio alignment"), failures
+
+    return None, failures
+
+
+def _bounded_excerpt(full_text: str, index: int, context: int) -> tuple[str, str]:
+    if not full_text:
+        return "", ""
+    index = max(0, min(int(index), len(full_text)))
+    context = max(80, min(int(context), 300))
+
+    before = full_text[max(0, index - context):index]
+    after = full_text[index:min(len(full_text), index + context)]
+
+    # The canonical parser already normalizes chapter text substantially, but
+    # collapse remaining line breaks/tabs for a compact dashboard excerpt.  Do it
+    # independently on both sides so the marker still represents the boundary.
+    before = re.sub(r"\s+", " ", before).strip()
+    after = re.sub(r"\s+", " ", after).strip()
+    return before, after
+
+
+def unavailable_preview(message: str, *, source: str = "BookBridge", percentage=None) -> dict:
+    result = {
+        "status": "unavailable",
+        "source": source,
+        "confidence": "Unavailable",
+        "before": "",
+        "after": "",
+        "message": message,
+    }
+    if percentage is not None:
+        result["percentage"] = round(float(percentage) * 100, 1)
+    return result
+
+
+def build_reading_position_preview(
+    *,
+    book,
+    states: Iterable,
+    last_leader: str | None,
+    ebook_parser,
+    alignment_service=None,
+    context_chars: int = 220,
+) -> dict:
+    """Return a small human-readable preview for one book's current user state.
+
+    Resolution order is deliberately confidence-first:
+      XPath -> EPUB CFI -> stored audio alignment -> percentage estimate.
+
+    A failed precise locator never disappears: if percentage fallback is possible
+    the payload remains explicitly ``approximate`` and explains that the precise
+    locator could not be resolved.
+    """
+    state = _select_state(states, last_leader)
+    if state is None:
+        return unavailable_preview("No saved reading position is available for this book.")
+
+    source = _source_label(getattr(state, "client_name", None))
+    percentage = _as_float(getattr(state, "percentage", None))
+    filename = _resolve_filename(book, ebook_parser)
+    if not filename:
+        return unavailable_preview(
+            "The linked ebook file is not available to resolve this position.",
+            source=source,
+            percentage=percentage,
+        )
+
+    try:
+        book_path = ebook_parser.resolve_book_path(filename)
+        full_text, _spine_map = ebook_parser.extract_text_and_map(book_path)
+    except Exception:
+        full_text = ""
+
+    if not full_text:
+        return unavailable_preview(
+            "BookBridge could not read text from the linked ebook.",
+            source=source,
+            percentage=percentage,
+        )
+
+    resolved, precise_failures = _resolve_precise_or_mapped_position(
+        state=state,
+        filename=filename,
+        book=book,
+        ebook_parser=ebook_parser,
+        alignment_service=alignment_service,
+    )
+
+    detail = ""
+    if resolved is None and percentage is not None:
+        pct = max(0.0, min(1.0, percentage))
+        index = int(round(pct * max(0, len(full_text) - 1)))
+        if precise_failures:
+            detail = (
+                f"Stored {' and '.join(precise_failures)} could not be resolved; "
+                "showing the saved percentage as an estimate."
+            )
+        else:
+            detail = "No exact ebook locator is available; showing the saved percentage as an estimate."
+        resolved = _ResolvedPosition(index, "approximate", "Approximate · percentage", detail)
+
+    if resolved is None:
+        message = "No reliable ebook text position can be resolved from the saved state."
+        if precise_failures:
+            message = f"Stored {' and '.join(precise_failures)} could not be resolved safely."
+        return unavailable_preview(message, source=source, percentage=percentage)
+
+    index = max(0, min(int(resolved.index), len(full_text)))
+    before, after = _bounded_excerpt(full_text, index, context_chars)
+    if not before and not after:
+        return unavailable_preview(
+            "The saved position resolved, but no surrounding ebook text is available.",
+            source=source,
+            percentage=percentage,
+        )
+
+    payload = {
+        "status": resolved.status,
+        "source": source,
+        "confidence": resolved.confidence,
+        "before": before,
+        "after": after,
+        "message": resolved.detail,
+    }
+    if percentage is not None:
+        payload["percentage"] = round(max(0.0, min(1.0, percentage)) * 100, 1)
+    return payload

--- a/static/css/reading-position-preview.css
+++ b/static/css/reading-position-preview.css
@@ -1,0 +1,117 @@
+.position-preview-toggle {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    min-height: 24px;
+    padding: 2px 5px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--muted-soft);
+    font: inherit;
+    font-size: 10px;
+    font-weight: 600;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.position-preview-toggle:hover {
+    background: var(--panel-soft);
+    color: var(--text);
+}
+
+.position-preview-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.position-preview-toggle:disabled {
+    cursor: wait;
+    opacity: 0.65;
+}
+
+.position-preview-panel {
+    min-width: 0;
+    margin: 0 0 8px;
+    padding: 9px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--panel-soft);
+}
+
+.position-preview-panel[hidden] {
+    display: none;
+}
+
+.position-preview-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 5px;
+    flex-wrap: wrap;
+}
+
+.position-preview-title {
+    color: var(--text);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.position-preview-meta {
+    color: var(--muted-soft);
+    font-size: 10px;
+    line-height: 1.3;
+}
+
+.position-preview-text {
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 11px;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+}
+
+.position-preview-marker {
+    display: inline-block;
+    margin: 0 2px;
+    color: var(--accent);
+    font-weight: 800;
+}
+
+.position-preview-message {
+    margin-top: 5px;
+    color: var(--muted-soft);
+    font-size: 10px;
+    line-height: 1.4;
+}
+
+.position-preview-panel[data-state="approximate"] .position-preview-meta {
+    color: var(--warning);
+}
+
+.position-preview-panel[data-state="unavailable"] .position-preview-text,
+.position-preview-panel[data-state="error"] .position-preview-text,
+.position-preview-panel[data-state="loading"] .position-preview-text {
+    display: none;
+}
+
+.position-preview-panel[data-state="error"] .position-preview-meta {
+    color: var(--danger);
+}
+
+@media (max-width: 480px) {
+    .unified-progress {
+        flex-wrap: wrap;
+    }
+
+    .position-preview-toggle {
+        margin-left: auto;
+    }
+
+    .position-preview-header {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 2px;
+    }
+}

--- a/static/js/reading-position-preview.js
+++ b/static/js/reading-position-preview.js
@@ -1,31 +1,51 @@
 (function () {
     'use strict';
 
+    function makeElement(tag, className, dataAttribute) {
+        const element = document.createElement(tag);
+        if (className) element.className = className;
+        if (dataAttribute) element.setAttribute(dataAttribute, '');
+        return element;
+    }
+
     function createPreviewUi(card) {
         if (!card || card.querySelector('[data-position-preview-toggle]')) return;
+        if (card.dataset.syncMode === 'audiobook_only') return;
         const absId = card.dataset.absId || '';
         if (!absId) return;
-        const panelId = `position-preview-${absId.replace(/[^A-Za-z0-9_-]/g, '-')}`;
         const info = card.querySelector('.book-info');
         if (!info) return;
+        const panelId = `position-preview-${absId.replace(/[^A-Za-z0-9_-]/g, '-')}`;
 
-        const button = document.createElement('button');
+        const button = makeElement('button', 'position-preview-toggle', 'data-position-preview-toggle');
         button.type = 'button';
-        button.className = 'position-preview-toggle';
-        button.setAttribute('data-position-preview-toggle', '');
         button.setAttribute('aria-expanded', 'false');
         button.setAttribute('aria-controls', panelId);
         button.textContent = 'Show position';
 
-        const panel = document.createElement('div');
+        const panel = makeElement('div', 'position-preview-panel', 'data-position-preview');
         panel.id = panelId;
-        panel.className = 'position-preview';
-        panel.setAttribute('data-position-preview', '');
         panel.hidden = true;
-        panel.innerHTML = '<div class="position-preview-heading"><strong data-position-preview-title>Current reading position</strong><span data-position-preview-meta></span></div><div class="position-preview-context"><span data-position-preview-before></span><mark data-position-preview-marker hidden>▌</mark><span data-position-preview-after></span></div><div class="position-preview-message" data-position-preview-message></div>';
+        panel.setAttribute('role', 'status');
+        panel.setAttribute('aria-live', 'polite');
 
-        info.appendChild(button);
-        info.appendChild(panel);
+        const header = makeElement('div', 'position-preview-header');
+        const title = makeElement('strong', 'position-preview-title', 'data-position-preview-title');
+        title.textContent = 'Current reading position';
+        const meta = makeElement('span', 'position-preview-meta', 'data-position-preview-meta');
+        header.append(title, meta);
+
+        const text = makeElement('div', 'position-preview-text');
+        const before = makeElement('span', '', 'data-position-preview-before');
+        const marker = makeElement('span', 'position-preview-marker', 'data-position-preview-marker');
+        marker.hidden = true;
+        marker.textContent = '▌';
+        const after = makeElement('span', '', 'data-position-preview-after');
+        text.append(before, marker, after);
+
+        const message = makeElement('div', 'position-preview-message', 'data-position-preview-message');
+        panel.append(header, text, message);
+        info.append(button, panel);
     }
 
     function initPreviewUi() {

--- a/static/js/reading-position-preview.js
+++ b/static/js/reading-position-preview.js
@@ -1,6 +1,37 @@
 (function () {
     'use strict';
 
+    function createPreviewUi(card) {
+        if (!card || card.querySelector('[data-position-preview-toggle]')) return;
+        const absId = card.dataset.absId || '';
+        if (!absId) return;
+        const panelId = `position-preview-${absId.replace(/[^A-Za-z0-9_-]/g, '-')}`;
+        const info = card.querySelector('.book-info');
+        if (!info) return;
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'position-preview-toggle';
+        button.setAttribute('data-position-preview-toggle', '');
+        button.setAttribute('aria-expanded', 'false');
+        button.setAttribute('aria-controls', panelId);
+        button.textContent = 'Show position';
+
+        const panel = document.createElement('div');
+        panel.id = panelId;
+        panel.className = 'position-preview';
+        panel.setAttribute('data-position-preview', '');
+        panel.hidden = true;
+        panel.innerHTML = '<div class="position-preview-heading"><strong data-position-preview-title>Current reading position</strong><span data-position-preview-meta></span></div><div class="position-preview-context"><span data-position-preview-before></span><mark data-position-preview-marker hidden>▌</mark><span data-position-preview-after></span></div><div class="position-preview-message" data-position-preview-message></div>';
+
+        info.appendChild(button);
+        info.appendChild(panel);
+    }
+
+    function initPreviewUi() {
+        document.querySelectorAll('.book-card[data-abs-id]').forEach(createPreviewUi);
+    }
+
     function setExpanded(button, panel, expanded) {
         button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         button.textContent = expanded ? 'Hide position' : 'Show position';
@@ -61,13 +92,9 @@
                 { cache: 'no-store', headers: { Accept: 'application/json' } }
             );
             const payload = await response.json().catch(function () { return {}; });
-            if (!response.ok) {
-                throw new Error('preview request failed');
-            }
+            if (!response.ok) throw new Error('preview request failed');
             renderPayload(panel, payload);
         } catch (_error) {
-            // Deliberately do not log payloads or excerpts: the response contains
-            // copyrighted book text and should not leak into browser diagnostics.
             renderError(panel);
         }
     }
@@ -75,21 +102,21 @@
     document.addEventListener('click', function (event) {
         const button = event.target.closest('[data-position-preview-toggle]');
         if (!button) return;
-
         const card = button.closest('.book-card');
         if (!card) return;
         const panelId = button.getAttribute('aria-controls');
         const panel = panelId ? document.getElementById(panelId) : null;
         const absId = card.dataset.absId || '';
         if (!panel || !absId) return;
-
         const isExpanded = button.getAttribute('aria-expanded') === 'true';
-        if (isExpanded) {
-            setExpanded(button, panel, false);
-            return;
-        }
-
+        if (isExpanded) return setExpanded(button, panel, false);
         setExpanded(button, panel, true);
         loadPreview(panel, absId);
     });
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initPreviewUi, { once: true });
+    } else {
+        initPreviewUi();
+    }
 })();

--- a/static/js/reading-position-preview.js
+++ b/static/js/reading-position-preview.js
@@ -1,0 +1,95 @@
+(function () {
+    'use strict';
+
+    function setExpanded(button, panel, expanded) {
+        button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        button.textContent = expanded ? 'Hide position' : 'Show position';
+        panel.hidden = !expanded;
+    }
+
+    function setLoading(panel) {
+        panel.dataset.state = 'loading';
+        panel.querySelector('[data-position-preview-title]').textContent = 'Current reading position';
+        panel.querySelector('[data-position-preview-meta]').textContent = 'Resolving saved position…';
+        panel.querySelector('[data-position-preview-before]').textContent = '';
+        panel.querySelector('[data-position-preview-after]').textContent = '';
+        panel.querySelector('[data-position-preview-marker]').hidden = true;
+        panel.querySelector('[data-position-preview-message]').textContent = '';
+    }
+
+    function renderPayload(panel, payload) {
+        const state = payload && payload.status ? payload.status : 'error';
+        const source = payload && payload.source ? String(payload.source) : 'BookBridge';
+        const confidence = payload && payload.confidence ? String(payload.confidence) : 'Unavailable';
+        const percentage = payload && Number.isFinite(Number(payload.percentage))
+            ? `${Number(payload.percentage).toFixed(1)}%`
+            : '';
+        const meta = [source, percentage, confidence].filter(Boolean).join(' · ');
+        const before = payload && payload.before ? String(payload.before) : '';
+        const after = payload && payload.after ? String(payload.after) : '';
+        const hasText = Boolean(before || after);
+
+        panel.dataset.state = state;
+        panel.querySelector('[data-position-preview-title]').textContent =
+            state === 'approximate' ? 'Approximate reading position' :
+            state === 'unavailable' ? 'Reading position unavailable' :
+            'Current reading position';
+        panel.querySelector('[data-position-preview-meta]').textContent = meta;
+        panel.querySelector('[data-position-preview-before]').textContent = before ? `…${before}` : '';
+        panel.querySelector('[data-position-preview-after]').textContent = after ? `${after}…` : '';
+        panel.querySelector('[data-position-preview-marker]').hidden = !hasText;
+        panel.querySelector('[data-position-preview-message]').textContent =
+            payload && payload.message ? String(payload.message) : '';
+    }
+
+    function renderError(panel) {
+        panel.dataset.state = 'error';
+        panel.querySelector('[data-position-preview-title]').textContent = 'Reading position unavailable';
+        panel.querySelector('[data-position-preview-meta]').textContent = 'Could not load the preview';
+        panel.querySelector('[data-position-preview-before]').textContent = '';
+        panel.querySelector('[data-position-preview-after]').textContent = '';
+        panel.querySelector('[data-position-preview-marker]').hidden = true;
+        panel.querySelector('[data-position-preview-message]').textContent =
+            'Try again. Your saved progress was not changed.';
+    }
+
+    async function loadPreview(panel, absId) {
+        setLoading(panel);
+        try {
+            const response = await fetch(
+                `/api/books/${encodeURIComponent(absId)}/position-preview`,
+                { cache: 'no-store', headers: { Accept: 'application/json' } }
+            );
+            const payload = await response.json().catch(function () { return {}; });
+            if (!response.ok) {
+                throw new Error('preview request failed');
+            }
+            renderPayload(panel, payload);
+        } catch (_error) {
+            // Deliberately do not log payloads or excerpts: the response contains
+            // copyrighted book text and should not leak into browser diagnostics.
+            renderError(panel);
+        }
+    }
+
+    document.addEventListener('click', function (event) {
+        const button = event.target.closest('[data-position-preview-toggle]');
+        if (!button) return;
+
+        const card = button.closest('.book-card');
+        if (!card) return;
+        const panelId = button.getAttribute('aria-controls');
+        const panel = panelId ? document.getElementById(panelId) : null;
+        const absId = card.dataset.absId || '';
+        if (!panel || !absId) return;
+
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+        if (isExpanded) {
+            setExpanded(button, panel, false);
+            return;
+        }
+
+        setExpanded(button, panel, true);
+        loadPreview(panel, absId);
+    });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,9 @@
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">
     <link rel="stylesheet" href="/static/css/app.css">
+    {% if active_page == 'library' %}
+    <link rel="stylesheet" href="/static/css/reading-position-preview.css">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>
@@ -15,5 +18,8 @@
     {% endif %}
     {% block content %}{% endblock %}
     {% block scripts %}{% endblock %}
+    {% if active_page == 'library' %}
+    <script src="/static/js/reading-position-preview.js"></script>
+    {% endif %}
 </body>
 </html>

--- a/tests/test_reading_position_preview.py
+++ b/tests/test_reading_position_preview.py
@@ -1,0 +1,175 @@
+from types import SimpleNamespace
+
+from src.services.reading_position_preview import build_reading_position_preview
+
+
+class FakeParser:
+    def __init__(self, text="abcdefghijklmnopqrstuvwxyz " * 30):
+        self.text = text
+        self.xpath_result = None
+        self.cfi_result = None
+        self.xpath_calls = []
+        self.cfi_calls = []
+
+    def resolve_book_path(self, filename):
+        if filename == "missing.epub":
+            raise FileNotFoundError(filename)
+        return filename
+
+    def extract_text_and_map(self, _path):
+        return self.text, [{"start": 0, "end": len(self.text)}]
+
+    def resolve_xpath_to_index(self, filename, xpath):
+        self.xpath_calls.append((filename, xpath))
+        return self.xpath_result
+
+    def resolve_cfi_to_index(self, filename, cfi):
+        self.cfi_calls.append((filename, cfi))
+        return self.cfi_result
+
+
+class FakeAlignment:
+    def __init__(self, result=None):
+        self.result = result
+        self.calls = []
+
+    def get_char_for_time(self, abs_id, timestamp):
+        self.calls.append((abs_id, timestamp))
+        return self.result
+
+
+def _book(filename="book.epub", **kwargs):
+    values = {
+        "abs_id": "book-1",
+        "original_ebook_filename": filename,
+        "ebook_filename": filename,
+    }
+    values.update(kwargs)
+    return SimpleNamespace(**values)
+
+
+def _state(client="kosync", percentage=0.25, **kwargs):
+    values = {
+        "client_name": client,
+        "percentage": percentage,
+        "timestamp": None,
+        "xpath": None,
+        "cfi": None,
+        "last_updated": 100.0,
+    }
+    values.update(kwargs)
+    return SimpleNamespace(**values)
+
+
+def test_xpath_is_preferred_and_marker_context_is_bounded():
+    parser = FakeParser()
+    parser.xpath_result = 260
+    state = _state(xpath="/body/DocFragment[2]/body/p[3]/text().0")
+
+    result = build_reading_position_preview(
+        book=_book(), states=[state], last_leader="KoSync:kindle", ebook_parser=parser,
+        context_chars=120,
+    )
+
+    assert result["status"] == "exact"
+    assert result["confidence"] == "Exact · XPath"
+    assert result["source"] == "KoSync"
+    assert result["percentage"] == 25.0
+    assert parser.xpath_calls
+    assert parser.cfi_calls == []
+    assert len(result["before"]) <= 120
+    assert len(result["after"]) <= 120
+
+
+def test_cfi_is_used_when_xpath_is_absent():
+    parser = FakeParser()
+    parser.cfi_result = 150
+    state = _state(cfi="epubcfi(/6/4!/4/2:3)")
+
+    result = build_reading_position_preview(
+        book=_book(), states=[state], last_leader="kosync", ebook_parser=parser,
+    )
+
+    assert result["status"] == "exact"
+    assert result["confidence"] == "Exact · CFI"
+    assert parser.cfi_calls == [("book.epub", "epubcfi(/6/4!/4/2:3)")]
+
+
+def test_audio_leader_uses_stored_alignment_instead_of_linear_percentage():
+    parser = FakeParser()
+    alignment = FakeAlignment(result=420)
+    audio = _state(client="abs", percentage=0.10, timestamp=987.5, last_updated=10)
+    newer_but_not_leader = _state(client="kosync", percentage=0.80, last_updated=99)
+
+    result = build_reading_position_preview(
+        book=_book(),
+        states=[newer_but_not_leader, audio],
+        last_leader="ABS",
+        ebook_parser=parser,
+        alignment_service=alignment,
+    )
+
+    assert result["status"] == "mapped"
+    assert result["confidence"] == "Mapped · audio alignment"
+    assert result["source"] == "Audiobookshelf"
+    assert alignment.calls == [("book-1", 987.5)]
+
+
+def test_failed_precise_locator_degrades_visibly_to_percentage_estimate():
+    parser = FakeParser()
+    state = _state(
+        percentage=0.50,
+        xpath="/body/DocFragment[99]/body/p[1].0",
+        cfi="epubcfi(/6/999!/4/2:0)",
+    )
+
+    result = build_reading_position_preview(
+        book=_book(), states=[state], last_leader="KoSync", ebook_parser=parser,
+    )
+
+    assert result["status"] == "approximate"
+    assert result["confidence"] == "Approximate · percentage"
+    assert "XPath and CFI could not be resolved" in result["message"]
+    assert result["before"] or result["after"]
+
+
+def test_non_cfi_locator_is_not_misrepresented_as_exact_cfi():
+    parser = FakeParser()
+    state = _state(cfi='{"href":"chapter.xhtml","locations":{"progression":0.3}}')
+
+    result = build_reading_position_preview(
+        book=_book(), states=[state], last_leader="kosync", ebook_parser=parser,
+    )
+
+    assert result["status"] == "approximate"
+    assert result["confidence"] == "Approximate · percentage"
+    assert parser.cfi_calls == []
+
+
+def test_missing_ebook_is_unavailable_without_trying_to_guess_text():
+    parser = FakeParser()
+    state = _state(percentage=0.75)
+
+    result = build_reading_position_preview(
+        book=_book("missing.epub"), states=[state], last_leader="kosync", ebook_parser=parser,
+    )
+
+    assert result["status"] == "unavailable"
+    assert result["confidence"] == "Unavailable"
+    assert result["before"] == ""
+    assert result["after"] == ""
+    assert result["percentage"] == 75.0
+
+
+def test_without_session_leader_newest_state_is_used_as_display_fallback():
+    parser = FakeParser()
+    older = _state(client="kosync", percentage=0.1, last_updated=10)
+    newer = _state(client="bookorbit", percentage=0.7, last_updated=20)
+
+    result = build_reading_position_preview(
+        book=_book(), states=[older, newer], last_leader=None, ebook_parser=parser,
+    )
+
+    assert result["source"] == "BookOrbit"
+    assert result["percentage"] == 70.0
+    assert result["status"] == "approximate"

--- a/tests/test_reading_position_preview_routes.py
+++ b/tests/test_reading_position_preview_routes.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+
+from flask import Flask
+
+from src.api import kosync_server
+from src.api import reading_position_preview_routes as routes
+from src.utils.user_context import reset_current_user_id, set_current_user_id
+
+
+class FakeDatabase:
+    def __init__(self, *, linked=True):
+        self.linked = linked
+        self.state_calls = []
+        self.stats_calls = []
+
+    def get_book(self, abs_id):
+        if abs_id == "missing":
+            return None
+        return SimpleNamespace(abs_id=abs_id)
+
+    def is_user_linked(self, user_id, abs_id):
+        return self.linked and user_id == 7 and abs_id == "book-1"
+
+    def get_states_for_book(self, abs_id, user_id=None):
+        self.state_calls.append((abs_id, user_id))
+        return [SimpleNamespace(client_name="kosync")]
+
+    def get_reading_stats(self, abs_id, user_id=None):
+        self.stats_calls.append((abs_id, user_id))
+        return {"last_leader": "KoSync:reader"}
+
+
+class FakeManager:
+    ebook_parser = object()
+    alignment_service = object()
+
+
+def _call_with_user(app, user_id, abs_id):
+    token = set_current_user_id(user_id)
+    try:
+        with app.test_request_context():
+            return routes.api_book_position_preview(abs_id)
+    finally:
+        reset_current_user_id(token)
+
+
+def test_preview_api_is_user_scoped_and_private_no_store(monkeypatch):
+    app = Flask(__name__)
+    database = FakeDatabase()
+    monkeypatch.setattr(kosync_server, "_database_service", database)
+    monkeypatch.setattr(kosync_server, "_manager", FakeManager())
+
+    captured = {}
+
+    def fake_preview(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "exact",
+            "source": "KoSync",
+            "confidence": "Exact · XPath",
+            "percentage": 42.0,
+            "before": "before",
+            "after": "after",
+            "message": "",
+        }
+
+    monkeypatch.setattr(routes, "build_reading_position_preview", fake_preview)
+
+    response = _call_with_user(app, 7, "book-1")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.get_json()["confidence"] == "Exact · XPath"
+    assert database.state_calls == [("book-1", 7)]
+    assert database.stats_calls == [("book-1", 7)]
+    assert captured["last_leader"] == "KoSync:reader"
+
+
+def test_preview_api_rejects_book_not_linked_to_current_user(monkeypatch):
+    app = Flask(__name__)
+    database = FakeDatabase(linked=False)
+    monkeypatch.setattr(kosync_server, "_database_service", database)
+    monkeypatch.setattr(kosync_server, "_manager", FakeManager())
+
+    response, status = _call_with_user(app, 7, "book-1")
+
+    assert status == 403
+    assert response.get_json()["error"] == "book not available for this user"
+    assert database.state_calls == []
+    assert database.stats_calls == []
+
+
+def test_preview_api_requires_ambient_authenticated_user(monkeypatch):
+    app = Flask(__name__)
+    monkeypatch.setattr(kosync_server, "_database_service", FakeDatabase())
+    monkeypatch.setattr(kosync_server, "_manager", FakeManager())
+
+    response, status = _call_with_user(app, None, "book-1")
+
+    assert status == 401
+    assert response.get_json()["error"] == "authentication required"

--- a/tests/test_reading_position_preview_ui.py
+++ b/tests/test_reading_position_preview_ui.py
@@ -4,22 +4,27 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_preview_markup_lives_natively_in_library_card():
-    index = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+def test_preview_assets_are_scoped_to_library_page():
     base = (ROOT / "templates" / "base.html").read_text(encoding="utf-8")
+    index = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
 
-    assert 'data-position-preview-toggle' in index
-    assert 'class="position-preview-panel"' in index
-    assert 'aria-controls="position-preview-' in index
-    assert 'role="status"' in index
-    assert 'aria-live="polite"' in index
-    assert "mapping.sync_mode != 'audiobook_only'" in index
-    assert '/static/css/reading-position-preview.css' in index
-    assert '/static/js/reading-position-preview.js' in index
+    assert "{% if active_page == 'library' %}" in base
+    assert '/static/css/reading-position-preview.css' in base
+    assert '/static/js/reading-position-preview.js' in base
+    assert "{% set active_page = 'library' %}" in index
 
-    # Keep the feature local to the Library template.  In particular, do not
-    # reintroduce the base-template/DOM-relocation pattern hardened away in #393.
-    assert 'position-preview' not in base
+
+def test_preview_script_builds_local_accessible_ui_without_dom_relocation():
+    script = (ROOT / "static" / "js" / "reading-position-preview.js").read_text(encoding="utf-8")
+
+    assert "card.querySelector('.book-info')" in script
+    assert "card.dataset.syncMode === 'audiobook_only'" in script
+    assert "panel.setAttribute('role', 'status')" in script
+    assert "panel.setAttribute('aria-live', 'polite')" in script
+    assert "data-position-preview-toggle" in script
+    assert "position-preview-panel" in script
+    assert "append(button, panel)" in script
+    assert "appendChild" not in script
 
 
 def test_preview_script_renders_book_text_as_text_only():

--- a/tests/test_reading_position_preview_ui.py
+++ b/tests/test_reading_position_preview_ui.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_preview_markup_lives_natively_in_library_card():
+    index = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+    base = (ROOT / "templates" / "base.html").read_text(encoding="utf-8")
+
+    assert 'data-position-preview-toggle' in index
+    assert 'class="position-preview-panel"' in index
+    assert 'aria-controls="position-preview-' in index
+    assert 'role="status"' in index
+    assert 'aria-live="polite"' in index
+    assert "mapping.sync_mode != 'audiobook_only'" in index
+    assert '/static/css/reading-position-preview.css' in index
+    assert '/static/js/reading-position-preview.js' in index
+
+    # Keep the feature local to the Library template.  In particular, do not
+    # reintroduce the base-template/DOM-relocation pattern hardened away in #393.
+    assert 'position-preview' not in base
+
+
+def test_preview_script_renders_book_text_as_text_only():
+    script = (ROOT / "static" / "js" / "reading-position-preview.js").read_text(encoding="utf-8")
+
+    assert '.textContent' in script
+    assert '.innerHTML' not in script
+    assert "cache: 'no-store'" in script
+    assert "encodeURIComponent(absId)" in script
+    assert "console.log" not in script
+    assert "console.error" not in script
+
+
+def test_preview_css_uses_existing_bookbridge_tokens_and_has_mobile_layout():
+    css = (ROOT / "static" / "css" / "reading-position-preview.css").read_text(encoding="utf-8")
+
+    assert 'var(--panel-soft)' in css
+    assert 'var(--border)' in css
+    assert 'var(--accent)' in css
+    assert ':focus-visible' in css
+    assert '@media (max-width: 480px)' in css


### PR DESCRIPTION
## Summary

Adds the on-demand reading-position preview proposed in #394 without changing sync policy or leader selection.

- adds a quiet **Show position** action to dashboard mappings that have an ebook
- resolves saved XPath and EPUB CFI positions to exact canonical ebook offsets when possible
- maps audiobook-led progress through the existing audio↔ebook alignment
- labels percentage-only fallback as approximate instead of implying exactness
- returns an explicit unavailable state when no reliable ebook position can be resolved
- loads/parses text only after user interaction and reuses the existing EPUB parser/cache
- keeps the returned context bounded and sends `Cache-Control: private, no-store`
- scopes the endpoint to the signed-in reader and does not expose the action for audiobook-only mappings
- adds no database migration and no new sync behavior

## Tests

Validated on the exact current feature head `0f8d351a46bb712ff074905667935978eb3a32d8` using the repository's existing Python workflow in the fork:

- Python 3.11: dependency install, fatal Flake8 lint, full `pytest tests/` suite — passed
- Python 3.12: dependency install, fatal Flake8 lint, full `pytest tests/` suite — passed
- workflow run `32413013617`

Immediately before opening this PR I re-checked upstream `dev`; its tip was `df691c63a2854cd460bf0d33118044257563ed35`.

Closes #394