### PR TITLE
[Fix] Preserve completed Hardcover reads when re-reading

### DIFF
--- a/src/api/hardcover_client.py
+++ b/src/api/hardcover_client.py
@@ -1060,6 +1060,30 @@ class HardcoverClient:
         # LOGIC: Only set started date if we are past 2%
         should_start = current_percentage > 0.02
 
+        latest_read = None
+        if read_result and read_result.get("user_book_reads"):
+            latest_read = read_result["user_book_reads"][0]
+
+        # Hardcover keeps rereads as separate user_book_read rows. A completed row
+        # is historical data: never rewrite it with a later reading position.
+        if latest_read and latest_read.get("finished_at"):
+            # A repeated completion write is just the same finished state coming
+            # around the sync loop again. Likewise, very small progress can be a
+            # reset/noise signal; wait for the existing >2% start threshold before
+            # treating it as evidence of an actual reread.
+            if is_finished or not should_start:
+                logger.debug(
+                    "Hardcover: preserving completed read %s; no new reread progress yet",
+                    latest_read.get("id"),
+                )
+                return True
+
+            logger.info(
+                "🔄 Hardcover: Starting a new read instead of overwriting completed read %s",
+                latest_read.get("id"),
+            )
+            read_result = {"user_book_reads": []}
+
         if (
             read_result
             and read_result.get("user_book_reads")

--- a/tests/test_hardcover_reread_history.py
+++ b/tests/test_hardcover_reread_history.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.api.hardcover_client import HardcoverClient
+
+
+class TestHardcoverRereadHistory(unittest.TestCase):
+    def setUp(self):
+        self.env_patcher = patch.dict(
+            os.environ,
+            {"HARDCOVER_TOKEN": "test-token", "HARDCOVER_ENABLED": "true"},
+            clear=False,
+        )
+        self.env_patcher.start()
+        self.client = HardcoverClient()
+        self.client._get_today_date = Mock(return_value="2026-08-20")
+
+    def tearDown(self):
+        self.env_patcher.stop()
+
+    @staticmethod
+    def _completed_read():
+        return {
+            "id": 22,
+            "started_at": "2026-07-01",
+            "finished_at": "2026-07-05",
+        }
+
+    def test_reread_progress_creates_new_read_instead_of_overwriting_history(self):
+        self.client.query = Mock(
+            side_effect=[
+                {"user_book_reads": [self._completed_read()]},
+                {
+                    "insert_user_book_read": {
+                        "error": None,
+                        "user_book_read": {"id": 23},
+                    }
+                },
+            ]
+        )
+
+        updated = self.client.update_progress(
+            11,
+            50,
+            edition_id=44,
+            current_percentage=0.25,
+        )
+
+        self.assertTrue(updated)
+        self.assertEqual(self.client.query.call_count, 2)
+        mutation, variables = self.client.query.call_args_list[1].args
+        self.assertIn("InsertUserBookRead", mutation)
+        self.assertNotIn("UpdateBookProgress", mutation)
+        self.assertEqual(variables["id"], 11)
+        self.assertEqual(variables["pages"], 50)
+        self.assertEqual(variables["editionId"], 44)
+        self.assertEqual(variables["startedAt"], "2026-08-20")
+        self.assertIsNone(variables["finishedAt"])
+
+    def test_repeated_finished_sync_does_not_create_phantom_reread(self):
+        self.client.query = Mock(
+            return_value={"user_book_reads": [self._completed_read()]}
+        )
+
+        updated = self.client.update_progress(
+            11,
+            200,
+            edition_id=44,
+            is_finished=True,
+            current_percentage=1.0,
+        )
+
+        self.assertTrue(updated)
+        self.client.query.assert_called_once()
+        query, variables = self.client.query.call_args.args
+        self.assertIn("user_book_reads", query)
+        self.assertEqual(variables, {"userBookId": 11})
+
+    def test_tiny_post_completion_progress_does_not_create_reread(self):
+        self.client.query = Mock(
+            return_value={"user_book_reads": [self._completed_read()]}
+        )
+
+        updated = self.client.update_progress(
+            11,
+            2,
+            edition_id=44,
+            current_percentage=0.01,
+        )
+
+        self.assertTrue(updated)
+        self.client.query.assert_called_once()
+
+    def test_audio_reread_creates_new_seconds_based_read(self):
+        self.client.query = Mock(
+            side_effect=[
+                {"user_book_reads": [self._completed_read()]},
+                {
+                    "insert_user_book_read": {
+                        "error": None,
+                        "user_book_read": {"id": 23},
+                    }
+                },
+            ]
+        )
+
+        updated = self.client.update_progress(
+            11,
+            0,
+            edition_id=44,
+            current_percentage=0.25,
+            audio_seconds=3600,
+        )
+
+        self.assertTrue(updated)
+        mutation, variables = self.client.query.call_args_list[1].args
+        self.assertIn("InsertUserBookRead", mutation)
+        self.assertEqual(variables["seconds"], 900)
+        self.assertEqual(variables["editionId"], 44)
+        self.assertEqual(variables["startedAt"], "2026-08-20")
+        self.assertIsNone(variables["finishedAt"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_hardcover_reread_history.py
+++ b/tests/test_hardcover_reread_history.py
@@ -2,7 +2,7 @@ import os
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 


### PR DESCRIPTION
## Summary

Closes #390.

Hardcover supports multiple `user_book_read` rows per book, but BookBridge currently always updates the newest row. If that row is already finished, starting the book again overwrites historical progress instead of creating a new read.

This keeps a completed Hardcover read immutable:

- if the latest read has `finished_at` and new progress is meaningfully underway (>2%), BookBridge inserts a new read instead of updating the completed one
- repeated finished-state syncs do not create phantom rereads
- tiny post-completion progress at or below the existing 2% start threshold does not create a new read
- page-based and audiobook/seconds-based rereads follow the same rule

No database migration or sync-policy change is involved; this only changes which Hardcover `user_book_read` row receives a write.

## Tests

Validated on exact head `11160b69cab62fee815f76a87c79c3459d7f6c1b` with the repository's existing Python workflow in the fork:

- Python 3.11: dependency install, fatal Flake8, full `pytest tests/` suite — passed
- Python 3.12: dependency install, fatal Flake8, full `pytest tests/` suite — passed
- workflow run `32418600444`

Added focused regression coverage for:

- page-based reread creates a new read
- repeated 100% sync remains a no-op
- <=2% post-completion noise remains a no-op
- audiobook reread creates a new seconds-based read

Immediately before opening this PR, upstream `dev` was re-checked at `df691c63a2854cd460bf0d33118044257563ed35`; the feature branch is `behind_by=0` and differs only in `src/api/hardcover_client.py` (+24/-0) plus the new regression test file.