### PR TITLE
[Fix] BridgeSync: stop forking a subprocess inside a subprocess (#370, #401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@
 
 All notable changes to BookBridge will be documented in this file.
 
+## [7.4.2] - 2026-08-21
+
+A hotfix for the BridgeSync KOReader plugin. Every network operation in plugin
+versions 0.6.1 through 0.6.4 ran itself twice over: it crashed KOReader outright
+on Kindle, and on Android it made Test Connection, plugin update checks, book
+sync, reading-stats sync and highlight sync all fail regardless of your settings.
+Nothing on the server changed.
+
+### Fixed
+
+- **BridgeSync no longer crashes your Kindle when you tap Test Connection, and
+  authentication works again.** Since 0.6.1 the plugin ran every non-download
+  request inside a second background process nested inside the first one. On
+  Kindle that left two copies of KOReader running against the same screen and
+  the same input devices, which crashed the device and restarted it. On Android
+  the inner process died before it could report anything back, so the plugin
+  answered "Authentication failed" or "Version check failed" no matter how
+  correct your server URL and credentials were. Book sync, reading-stats sync
+  and highlight sync all travelled the same path. Plugin updated to **0.6.5**.
+  (#370, #401)
+
+- **A background operation that crashes no longer reports itself as a rejected
+  login.** When one exited without returning a result, the plugin read that as
+  success-with-nothing-in-it and fell back to its generic wording, so a hard
+  crash reached you as a wrong username and password. It now reports the
+  operation as failed, and says so.
+
+### Operational Notes
+
+- **Re-download the plugin by hand — it cannot update itself out of this.**
+  "Check for Plugin Update" is one of the operations the bug breaks, so no
+  device on 0.6.1-0.6.4 can pull the fix through the plugin. Go to your
+  BookBridge account page, download the zip, unzip it into `koreader/plugins/`
+  replacing the existing `bridgesync.koplugin` folder, and restart KOReader.
+  Do this on every device.
+- No database migration, and no settings changes. The server rebuilds the
+  plugin zip automatically when the files change.
+
 ## [7.4.1] - 2026-08-21
 
 A maintenance release for 7.4.0: five opt-in additions, and fixes across Hardcover,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,88 +1,51 @@
-# Release Notes - 7.4.1
+# Release Notes - 7.4.2
 
-A maintenance release for 7.4.0. The headline is **the BridgeSync plugin starts on a
-fresh install again** — 0.6.3 crashed before it ever ran on any device that did not
-already have a BridgeSync log file, which meant every new KOReader setup. It also
-stops Hardcover losing the read you already finished, keeps a stock Kobo from
-dragging CWA progress back, and adds five opt-in settings, four of them from
-contributors.
+A hotfix for the BridgeSync KOReader plugin. If you installed the plugin from
+7.4.0 or 7.4.1, this is the one you want.
 
-## What's New
+Every network operation in plugin versions **0.6.1 through 0.6.4** ran itself
+twice over — the plugin started a background process to do the work, and then
+that process started another one to make the actual request. On Kindle that left
+two copies of KOReader running against the same screen and the same input
+devices: tapping **Test Connection** crashed the device and restarted it. On
+Android the inner process died before it could report back, so the plugin
+answered **"Authentication failed"** or **"Version check failed"** no matter how
+correct your server URL and credentials were. Book sync, reading-stats sync and
+highlight sync all travelled the same path.
 
-- **Share an existing library with the people who already have accounts.** *Shared
-  Library* only ever applied going forward. Settings → Users now has a **Share
-  library with all users** button that hands the whole catalog to every active user
-  at once. Visibility only — progress, KoSync documents and stats stay per-user.
-  (#384)
-- **Change an existing account between user and admin.** Settings → Users gains a
-  *Make admin* / *Make user* button, so widening or restricting someone's access no
-  longer means deleting and recreating them and losing their progress and saved
-  logins. A promoted admin keeps using their own service accounts. (#385)
-- **Propagate Completion.** Percentages never agree at the end of a book, so a title
-  you finished in one app can sit at 92–97% in another. Turn it on under
-  Settings → Sync and finishing anywhere marks the book finished everywhere. Off by
-  default. Contributed by [@benjitobz](https://github.com/benjitobz). (#374)
-- **Auto-match suggestions.** High-confidence candidates link themselves as a scan
-  finds them instead of waiting on the Suggestions page. Off by default; loose title
-  matches and same-folder candidates are never linked automatically. Contributed by
-  [@benjitobz](https://github.com/benjitobz). (#375)
-- **Cross-device rewind policy.** The protection that ignores a *lower* percentage
-  from a second device is now a setting under Settings → KOSync, still on by
-  default. Contributed by [@Kyomorie](https://github.com/Kyomorie). (#391)
-- **Compare text positions when percentages disagree.** Your reader and BookBridge
-  can measure the same EPUB on slightly different scales, letting a stale spot win
-  on the number alone. Off by default, because comparing means opening the book.
-  Contributed by [@Kyomorie](https://github.com/Kyomorie). (#380)
+The plugin is now **0.6.5**. Nothing on the server side changed in this release.
 
 ## Fixed
 
-- **BridgeSync 0.6.4: the KOReader plugin starts on a fresh install.** 0.6.3 crashed
-  during startup on any device without an existing log file, so the plugin appeared
-  in KOReader's list but never actually ran. Managed-folder detection and error
-  reporting are improved in the same version. Reported in #370, fixed by
-  [@theryanmc](https://github.com/theryanmc). (#373, #377)
-- **Re-reading a book no longer overwrites the read you already finished**, and a
-  stale reader no longer invents one — a re-read is recorded only once the position
-  really moves forward. Contributed by [@Kyomorie](https://github.com/Kyomorie).
-  (#398, #390)
-- **Saving settings no longer writes junk rows into your configuration.** The handler
-  persisted every field the form posted, including the CSRF token every form carries,
-  so each save stored one as if it were config. Only registered settings are saved now.
-- **A broken Hardcover connection reports itself once, clearly, with the next step**
-  instead of repeating its whole HTML error page every attempt; transient errors are
-  retried and recovery is announced.
-- **Startup stops reporting a connection failure you cannot fix.** It now checks the
-  admin's own account credentials rather than the abandoned global copies left
-  behind by the multi-user upgrade.
-- **Positions at the very start of a chapter no longer drift forward** — in one
-  reported case by about 7,900 characters. Contributed by
-  [@Kyomorie](https://github.com/Kyomorie). (#382, #276)
-- **CWA progress no longer snaps back when a stock Kobo opens the book** (#364), and
-  **Audiobookshelf item lookups ask for the expanded record** so audio files and
-  chapters are present. The latter contributed by
-  [@TheSingularis](https://github.com/TheSingularis). (#371)
-- **Mark Complete works on titles containing an apostrophe**, the source badge stays
-  visible on long Add Book titles (#381), and StoryGraph/Hardcover cooldowns fire
-  when their timer expires instead of waiting for the next full sync cycle.
-- **KOReader position comparisons survive a restart**, now that the XPath ordering is
-  persisted and prewarmed. Contributed by
-  [@Kyomorie](https://github.com/Kyomorie). (#389)
+- **Test Connection no longer crashes Kindles, and authentication works again.**
+  A background process is no longer allowed to start another one; when it is
+  already running as one, it does the work directly instead. (#370, #401)
+- **A background operation that crashes no longer reports itself as a rejected
+  login.** When one exited without returning a result, the plugin read that as
+  success-with-nothing-in-it and fell back to its generic wording, so a hard
+  crash reached you as a wrong username and password. It now reports the
+  operation as failed, and says so.
+
+## Upgrading
+
+**You have to re-download the plugin by hand. It cannot update itself out of
+this** — "Check for Plugin Update" is one of the operations the bug breaks, so
+no device running 0.6.1-0.6.4 can pull the fix through the plugin.
+
+On each device:
+
+1. Update BookBridge to 7.4.2 and let it restart.
+2. Open your BookBridge **account page** and use **Download plugin (.zip)**, or
+   take `bridgesync-0.6.5.zip` from the GitHub release.
+3. Unzip it into `koreader/plugins/`, replacing the existing
+   `bridgesync.koplugin` folder.
+4. Restart KOReader, and confirm the account page shows **v0.6.5**.
 
 ## Operational Notes
 
-**Deploy: pull the new image, restart (the database migration runs automatically on
-start), then re-download the BridgeSync plugin on each KOReader device.** The
-migration is additive — one table caching KOReader XPath ordering.
-
-- **Re-download BridgeSync on every device.** 0.6.3 cannot update itself: the crash
-  happens before the updater runs. Get 0.6.4 from *Settings → KOSync* and copy it
-  over the existing `bridgesync.koplugin` folder.
-- **Every new setting defaults to current behavior**, so an install that changes
-  nothing behaves as it did.
-- **Admins no longer inherit the global service credentials.** Those settings are
-  the primary admin's own logins mirrored outward, so a *second* admin with blank
-  integration fields used to sync against the primary admin's Audiobookshelf,
-  Grimmory, BookOrbit and CWA accounts. Only the primary admin inherits now. If you
-  created a second admin account and left its Integrations blank, fill them in under
-  *Settings → Users → Integrations* — that account's services are skipped until you
-  do. Single-admin installs are unaffected.
+- No database migration and no settings changes.
+- The server rebuilds the downloadable plugin zip automatically when the plugin
+  files change, so no extra step is needed on the server.
+- If you were pointing BridgeSync at something other than BookBridge's KoSync
+  address, that is a separate misconfiguration — the plugin's server URL must be
+  your BookBridge KoSync URL (port 5758 by default), not another reader's.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@ For the full history of changes, please refer to the **[GitHub Releases](https:/
 
 ---
 
+## [7.4.2]
+
+A hotfix for the BridgeSync KOReader plugin. Every network operation in plugin versions 0.6.1 through 0.6.4 ran itself twice over — it crashed KOReader outright on Kindle, and on Android it made Test Connection, plugin update checks, book sync, stats sync and highlight sync fail no matter how correct your settings were. Nothing on the server changed.
+
+### Fixed
+
+- **BridgeSync no longer crashes your Kindle on Test Connection, and authentication works again (#370, #401).** Since 0.6.1 the plugin ran every non-download request inside a second background process nested inside the first, leaving two copies of KOReader on the same screen and input devices. Plugin updated to **0.6.5**.
+- **A background operation that crashes no longer reports itself as a rejected login.** A crash that returned no result was read as success-with-nothing-in-it, so it reached you as a wrong username and password.
+
+### Operational Notes
+
+- **Re-download the plugin by hand — it cannot update itself out of this.** "Check for Plugin Update" is one of the broken operations, so no device on 0.6.1–0.6.4 can pull the fix through the plugin. Download the zip from your BookBridge account page, unzip it into `koreader/plugins/` over the existing `bridgesync.koplugin` folder, and restart KOReader on every device.
+
+---
+
 ## [7.4.1]
 
 A maintenance release for 7.4.0. The headline is **the BridgeSync plugin starts on a fresh install again** — 0.6.3 crashed before it ever ran on any device without an existing BridgeSync log file, which meant every new KOReader setup. It also stops Hardcover losing the read you already finished, keeps a stock Kobo from dragging CWA progress back, and adds five opt-in settings.

--- a/plugins/bridgesync.koplugin/_meta.lua
+++ b/plugins/bridgesync.koplugin/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "bridgesync",
     fullname = _("Bridge Sync"),
     description = _([[Mirror active bridge matches into a managed KOReader folder, sync reading stats between devices, and sync highlights/notes across devices and BookOrbit's web reader through the bridge.]]),
-    version = "0.6.4",
+    version = "0.6.5",
 }

--- a/plugins/bridgesync.koplugin/main.lua
+++ b/plugins/bridgesync.koplugin/main.lua
@@ -709,12 +709,21 @@ function BridgeSync:_showManagedFolderChooser(touchmenu_instance)
 end
 
 function BridgeSync:_runInSubprocess(task)
+    -- Forked child: it must never fork again. The child inherits the running
+    -- coroutine, so a nested call would fork a grandchild and then yield the
+    -- child back into a copy of the parent's UIManager loop, leaving a second
+    -- instance of the app running against the same screen and input devices.
+    if self._in_subprocess then
+        return true, task()
+    end
+
     local co, is_main = coroutine.running()
     if not co or is_main then
         return true, task()
     end
 
     local pid, parent_read_fd = FFIUtil.runInSubProcess(function(_, child_write_fd)
+        self._in_subprocess = true
         if self.sqlite_available then
             -- Forked child: a SQLite handle must never be shared across a
             -- fork, so replace the inherited one with the child's own.
@@ -786,7 +795,10 @@ function BridgeSync:_runInSubprocess(task)
     if ret_values then
         return true, table.unpack(ret_values, 1, ret_values.n or #ret_values)
     end
-    return true
+    -- The child exited without writing a result. Reporting success here hands
+    -- the caller an empty result set, which it renders as its generic failure
+    -- text, so a crashed subprocess reads as a rejected login.
+    return false, "subprocess produced no result"
 end
 
 function BridgeSync:_promptForSetting(title, current_value, hint, setter, is_password, after_save)

--- a/tests/lua/test_bridgesync_init.lua
+++ b/tests/lua/test_bridgesync_init.lua
@@ -535,4 +535,75 @@ assert(#bridge.pending_sessions == 1
         and bridge.pending_sessions[1].session_id == "session-rejected",
     "server-rejected sessions must remain queued for recovery")
 
+-- A forked child must never fork again. BridgeSync wires bridge_api_client's
+-- request_runner to _runInSubprocess, so every non-download HTTP request issued
+-- from inside an already-forked child re-entered this function. The child
+-- inherits the running coroutine, so it forked a grandchild and then yielded
+-- itself back into a copy of the parent's UIManager loop, leaving a second
+-- instance of the app on the same screen and input devices: an outright crash
+-- on Kindle (#401), and on Android a child that died before writing a result,
+-- which surfaced as a bare "Authentication failed" (#370).
+local FFIUtilStub = require("ffi/util")
+local fork_calls = 0
+local child_output = nil
+
+local function stub_fork(run_child)
+    FFIUtilStub.runInSubProcess = function(child_func)
+        fork_calls = fork_calls + 1
+        child_output = nil
+        -- The child body runs in-process, which is what makes a nested fork
+        -- observable: the coroutine is still running, exactly as it is inside
+        -- a real forked child.
+        if run_child then child_func(4242, 7) end
+        return 4242, 8
+    end
+end
+FFIUtilStub.writeToFD = function(_, payload) child_output = payload end
+FFIUtilStub.isSubProcessDone = function() return true end
+FFIUtilStub.getNonBlockingReadSize = function()
+    return (child_output and #child_output > 0) and 1 or 0
+end
+FFIUtilStub.readAllFromFD = function() return child_output end
+
+-- Stands in for UIManager: _runInSubprocess yields between polls and expects
+-- something outside the coroutine to resume it.
+local function drive(fn)
+    local co = coroutine.create(fn)
+    local results = table.pack(coroutine.resume(co))
+    while coroutine.status(co) == "suspended" do
+        results = table.pack(coroutine.resume(co, true))
+    end
+    assert(results[1], "subprocess driver errored: " .. tostring(results[2]))
+    return table.unpack(results, 2, results.n)
+end
+
+stub_fork(true)
+bridge._in_subprocess = nil
+local nested_ok, nested_value = drive(function()
+    return bridge:_runInSubprocess(function()
+        -- What bridge_api_client does for every non-download request.
+        local inner_ok, inner_result = bridge:_runInSubprocess(function()
+            return "http-result"
+        end)
+        return inner_ok and inner_result or nil
+    end)
+end)
+assert(fork_calls == 1,
+    "a forked child must run nested subprocess work inline instead of forking again")
+assert(nested_ok and nested_value == "http-result",
+    "the nested inline result must still reach the caller")
+
+-- A child that dies without writing must not read as success. Returning a bare
+-- true handed callers an empty result set, which testConnection renders as its
+-- generic "Authentication failed" and the update check as "Version check
+-- failed" - a crashed subprocess disguised as a rejected login (#370).
+stub_fork(false)
+bridge._in_subprocess = nil
+local dead_ok, dead_reason = drive(function()
+    return bridge:_runInSubprocess(function() return "unreachable" end)
+end)
+assert(dead_ok == false and dead_reason == "subprocess produced no result",
+    "a subprocess that exits without a result must be reported as a failure")
+bridge._in_subprocess = nil
+
 print("BridgeSync Lua init regression test passed")


### PR DESCRIPTION
Hotfix cut from `main`, not `dev` — `dev` has 13 commits still in beta and none of them touch the plugin, so nothing else rides along. `plugins/bridgesync.koplugin/` was byte-identical between `main` and `dev` at cut time.

## The bug

Plugin 0.6.1 (`11f8fb0`) gave `bridge_api_client` a `request_runner` and calls it for every non-download request. `main.lua` wires that runner to `BridgeSync:_runInSubprocess`. But every entry point *already* wraps the whole operation in `_runInSubprocess` from inside a `Trapper:wrap` coroutine — Test Connection at `main.lua:3643`, and every job via `_submitSyncJob` at `main.lua:921`.

So the forked child re-entered `_runInSubprocess`. `coroutine.running()` inside the child still reports the inherited coroutine, so it forked a **grandchild** and then `coroutine.yield()`ed itself back into a copy of the parent's UIManager loop. KOReader's `runInSubProcess` runs the child body as `xpcall(...)` then `C._exit(0)`, so yielding out of it leaves a second live instance of the app on the same framebuffer and input devices.

| Platform | Symptom |
|---|---|
| Kindle (#401) | Test Connection crashes the device and restarts it |
| Android (#370) | child dies before writing to its pipe → "Authentication failed" / "Version check failed" on a correct URL and credentials |

Book sync, reading-stats sync and highlight sync all take the same path — `_requestJSON` passes `background = true` unconditionally. Only `downloadBook`/`downloadPluginZip` escaped it, because a sink sets `background = false`.

0.5.3/0.5.4 predate the runner, which is exactly the working/broken boundary both reporters describe.

## The fix

1. **Re-entrancy guard.** The forked child sets `self._in_subprocess` as its first statement; `_runInSubprocess` checks it before the coroutine test and runs nested work inline. This covers every call site, so `bridge_api_client.lua` and the `request_runner` wiring are unchanged.
2. **Stop laundering crashes as failed logins.** The no-result path returned a bare `true`, handing callers success-with-no-values, which they rendered as their generic fallback text. It now returns `false, "subprocess produced no result"`. All five call sites already had an error branch for a false flag.

`_meta.lua` 0.6.4 → **0.6.5**.

## Testing

- `+2` assertions in `tests/lua/test_bridgesync_init.lua` (fork-simulating `ffi/util` stub, plus a coroutine driver standing in for UIManager). **Each verified to fail with its own half of the fix reverted** — `assert 1 == 0` on the fork count, and the no-result assertion respectively.
- Full suite: **2922 passed, 4 skipped**. Unchanged count — assertions added to an existing test, nothing deleted or weakened.
- `luac -p` clean on both changed Lua files.

## Deploy

**Plugin re-download on every device.** The self-update path is itself broken by this bug, so no device on 0.6.1–0.6.4 can pull the fix through "Check for Plugin Update". Called out in `CHANGELOG.md` and `RELEASE_NOTES.md`.

No migration, no settings changes, no `src/` change. The server rebuilds the downloadable zip automatically on mtime change.

Closes #370, closes #401.
