### PR TITLE
[Feature] Show book language in Add Book and Suggestions

### DIFF
--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -383,7 +383,8 @@ class ABSClient:
                                     "source": "ABS",
                                     "ext": "epub",
                                     "subtitle": metadata.get('subtitle'),
-                                    "seriesName": metadata.get('seriesName')
+                                    "seriesName": metadata.get('seriesName'),
+                                    "language": metadata.get('language')
                                 })
                     else:
                         logger.debug(f"   No items found in library '{lib_name}'")

--- a/src/api/cwa_client.py
+++ b/src/api/cwa_client.py
@@ -251,7 +251,10 @@ class CWAClient:
             # OPDS is Atom-based
             # Namespaces are annoying in ElementTree, ignore them or handle them
             # For simplicity, we'll try to handle standard Atom namespace
-            namespaces = {'atom': 'http://www.w3.org/2005/Atom'}
+            namespaces = {
+                'atom': 'http://www.w3.org/2005/Atom',
+                'dcterms': 'http://purl.org/dc/terms/',
+            }
             
             root = ET.fromstring(xml_content)
             
@@ -268,6 +271,13 @@ class CWAClient:
                 
                 author_elem = entry.find('atom:author/atom:name', namespaces)
                 author = author_elem.text if author_elem is not None else "Unknown"
+
+                language_elem = entry.find('dcterms:language', namespaces)
+                language = (
+                    language_elem.text.strip()
+                    if language_elem is not None and language_elem.text
+                    else ""
+                )
                 
                 # Find EPUB link
                 epub_link = None
@@ -318,6 +328,7 @@ class CWAClient:
                         "id": entry_id,
                         "title": title,
                         "author": author,
+                        "language": language,
                         "download_url": epub_link,
                         "ext": "epub",
                         "source": "CWA"

--- a/src/services/audio_source_adapters.py
+++ b/src/services/audio_source_adapters.py
@@ -22,6 +22,7 @@ class AudioResult:
     subtitle: str = ""
     series_label: str = ""
     authors: str = ""
+    language: str = ""
     cover_url: str = ""
     duration: Optional[float] = None
     display_name: str = ""
@@ -219,6 +220,7 @@ class ABSAudioSourceAdapter(AudioSourceAdapter):
                     subtitle=subtitle,
                     series_label=series_label,
                     authors=authors,
+                    language=str(metadata.get("language") or "").strip(),
                     cover_url=cover_url,
                     duration=float(duration) if duration is not None else None,
                     display_name=title,
@@ -398,6 +400,7 @@ class BookLoreAudioSourceAdapter(AudioSourceAdapter):
                     subtitle=subtitle,
                     series_label=series_label,
                     authors=self._format_authors(book),
+                    language=str(book.get("language") or "").strip(),
                     cover_url=self.get_cover_url(str(book_id)) or "",
                     duration=duration,
                     display_name=title,
@@ -730,6 +733,7 @@ class BookOrbitAudioSourceAdapter(AudioSourceAdapter):
                     subtitle=subtitle,
                     series_label=series_label,
                     authors=book.get("authors") or "",
+                    language=str(book.get("language") or "").strip(),
                     cover_url=self.get_cover_url(str(book_id)) or "",
                     duration=float(duration) if duration else None,
                     display_name=title,

--- a/src/services/suggestions_service.py
+++ b/src/services/suggestions_service.py
@@ -72,6 +72,7 @@ class SuggestionsService:
                 continue
 
             candidate_author = self._candidate_author(candidate)
+            candidate_language = str(getattr(candidate, 'language', None) or '').strip()
             candidate_source = (getattr(candidate, 'source', None) or '').strip()
             source_id = getattr(candidate, 'source_id', None) or getattr(candidate, 'booklore_id', None)
             raw_path = getattr(candidate, 'path', None)
@@ -87,6 +88,7 @@ class SuggestionsService:
             prepared.append({
                 "title": candidate_title,
                 "author": candidate_author,
+                "language": candidate_language,
                 "source": candidate_source,
                 "source_id": source_id,
                 "search_text": f"{candidate_title} {candidate_author}".strip(),
@@ -161,6 +163,16 @@ class SuggestionsService:
             return (self.get_abs_author(ab) or "").strip()
         except Exception:
             return ""
+
+    @staticmethod
+    def _audio_language(ab: dict) -> str:
+        value = ab.get("audio_language") or ab.get("language")
+        if not value:
+            media = ab.get("media") or {}
+            metadata = media.get("metadata") or {} if isinstance(media, dict) else {}
+            if isinstance(metadata, dict):
+                value = metadata.get("language")
+        return str(value or "").strip()
 
     def _audio_duration(self, ab: dict):
         raw_duration = ab.get("audio_duration")
@@ -261,6 +273,7 @@ class SuggestionsService:
                     "ebook_filename": candidate_info["name"],
                     "display_name": candidate_info["display_name"],
                     "author": candidate_info.get("author", ""),
+                    "language": candidate_info.get("language", ""),
                     "source": candidate_info.get("source", ""),
                     "source_id": candidate_info.get("source_id"),
                     "source_path": candidate_info.get("path") or "",
@@ -313,6 +326,7 @@ class SuggestionsService:
             "ebook_filename": candidate_info.get("name", ""),
             "display_name": candidate_info.get("display_name") or candidate_info.get("name", ""),
             "author": candidate_info.get("author", ""),
+            "language": candidate_info.get("language", ""),
             "source": candidate_info.get("source", ""),
             "source_id": candidate_info.get("source_id"),
             "source_path": candidate_info.get("path") or "",
@@ -409,6 +423,7 @@ class SuggestionsService:
         bridge_key = self._audio_bridge_key(ab)
         audio_title = self._audio_title(ab)
         audio_author = self._audio_author(ab)
+        audio_language = self._audio_language(ab)
         audio_cover_url = self._audio_cover_url(ab, audio_source, audio_source_id)
         audio_duration = self._audio_duration(ab)
         return {
@@ -417,6 +432,7 @@ class SuggestionsService:
             "audio_source_id": audio_source_id,
             "audio_title": audio_title,
             "audio_author": audio_author,
+            "audio_language": audio_language,
             "audio_duration": audio_duration,
             "audio_cover_url": audio_cover_url,
             "audio_path": self._audio_path(ab),
@@ -1001,6 +1017,7 @@ class SuggestionsService:
                 chosen["source_id"] = best["source_id"]
             if best.get("source"):
                 chosen["source"] = best["source"]
+            chosen["language"] = best.get("language", "")
             self.logger.info(
                 f"🔎 Resolved real file for '{audio_title}' -> {best['name']} (match {best_score:.0f})"
             )
@@ -1049,6 +1066,7 @@ class SuggestionsService:
                 "bridge_key": bridge_key,
                 "audio_title": audio_title,
                 "audio_author": audio_author,
+                "audio_language": self._audio_language(ab),
                 "audio_duration": audio_duration,
                 "audio_cover_url": audio_cover_url,
                 "audio_path": self._audio_path(ab),
@@ -1143,6 +1161,7 @@ class SuggestionsService:
                     "bridge_key": cand.get("bridge_key", ""),
                     "audio_title": cand_title,
                     "audio_author": cand_author,
+                    "audio_language": cand.get("audio_language", ""),
                     "audio_duration": cand.get("audio_duration"),
                     "audio_cover_url": cand.get("audio_cover_url", ""),
                     "audio_provider_book_id": cand.get("audio_provider_book_id", ""),
@@ -1173,6 +1192,7 @@ class SuggestionsService:
                 "bridge_key": cand.get("bridge_key", ""),
                 "audio_title": cand_title,
                 "audio_author": cand_author,
+                "audio_language": cand.get("audio_language", ""),
                 "audio_duration": cand.get("audio_duration"),
                 "audio_cover_url": cand.get("audio_cover_url", ""),
                 "audio_provider_book_id": cand.get("audio_provider_book_id", ""),

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -2575,11 +2575,12 @@ def _upsert_storyteller_mapping(
 class EbookResult:
     """Wrapper to provide consistent interface for ebooks from Grimmory, CWA, ABS, or filesystem."""
 
-    def __init__(self, name, title=None, subtitle=None, authors=None, booklore_id=None, path=None, source=None, source_id=None, abs_identifier=None):
+    def __init__(self, name, title=None, subtitle=None, authors=None, booklore_id=None, path=None, source=None, source_id=None, abs_identifier=None, language=None):
         self.name = name
         self.title = title or Path(name).stem
         self.subtitle = subtitle or ''
         self.authors = authors or ''
+        self.language = str(language or '').strip()
         self.booklore_id = booklore_id
         self.path = path # Public path
         self.source = source  # 'booklore', 'cwa', 'abs', 'filesystem'
@@ -2837,6 +2838,7 @@ def get_suggestion_audiobooks():
                 "audio_source_id": source_id,
                 "audio_title": title,
                 "audio_author": author,
+                "audio_language": item.language or "",
                 "audio_duration": item.duration,
                 "audio_cover_url": cover_url,
                 "audio_path": item.path or "",
@@ -2909,6 +2911,7 @@ def get_searchable_ebooks(search_term):
                             title=b.get('title'),
                             subtitle=_ebook_edition_label(b),
                             authors=b.get('authors'),
+                            language=b.get('language'),
                             booklore_id=b.get('id'),
                             path=b.get('filePath') or b.get('filepath') or b.get('path'),
                             source='Grimmory'
@@ -2943,6 +2946,7 @@ def get_searchable_ebooks(search_term):
                     name=fname,
                     title=b.get('title'),
                     authors=b.get('authors'),
+                    language=b.get('language'),
                     path=b.get('filePath') or b.get('filepath') or b.get('path'),
                     source='BookOrbit',
                     source_id=b.get('id'),
@@ -2971,6 +2975,7 @@ def get_searchable_ebooks(search_term):
                     name=fname,
                     title=title,
                     authors=authors,
+                    language=b.get('language'),
                     path=None,
                     source='BookFusion',
                     source_id=bf_id,
@@ -3000,6 +3005,7 @@ def get_searchable_ebooks(search_term):
                     title=book.get('title'),
                     subtitle=_ebook_edition_label(book),
                     authors=book.get('authors') or book.get('author'),
+                    language=book.get('language'),
                     path=book.get('filePath') or book.get('path'),
                     source='Kavita',
                     source_id=book.get('id'),
@@ -3024,6 +3030,7 @@ def get_searchable_ebooks(search_term):
                                     name=fname,
                                     title=ab.get('title'),
                                     authors=ab.get('author'),
+                                    language=ab.get('language'),
                                     source='ABS',
                                     source_id=ab.get('id'),
                                     subtitle=_ebook_edition_label(ab)
@@ -3061,6 +3068,7 @@ def get_searchable_ebooks(search_term):
                                 name=fname,
                                 title=cr.get('title'),
                                 authors=cr.get('author'),
+                                language=cr.get('language'),
                                 path=cr.get('download_url'),
                                 source='CWA',
                                 source_id=cwa_id,

--- a/templates/add_book.html
+++ b/templates/add_book.html
@@ -363,6 +363,11 @@
         margin-top: 6px;
     }
 
+    .source-badge.language {
+        background: rgba(255, 255, 255, 0.1);
+        color: rgba(255, 255, 255, 0.82);
+    }
+
     .source-badge.grimmory {
         background: rgba(76, 175, 80, 0.2);
         color: #81c784;
@@ -1031,6 +1036,9 @@
                             {{ ab.title }}
                             {% set ab_src = 'Grimmory' if ab.source == 'BookLore' else ab.source %}
                             <span class="source-badge {{ ab_src.lower().replace(' ', '') }}">{{ ab_src }}</span>
+                            {% if ab.language %}
+                            <span class="source-badge language" title="Language">{{ ab.language }}</span>
+                            {% endif %}
                         </div>
                         {% set edition_label = ab.subtitle or ab.series_label %}
                         {% if edition_label %}
@@ -1096,11 +1104,14 @@
                         data-source-path="{{ eb.path if eb.path else '' }}"
                         data-abs-identifier="{{ eb.abs_identifier or '' }}"
                         onclick="selectEbookCard(this)">
-                        {% if eb.source or eb.abs_identifier %}
+                        {% if eb.source or eb.abs_identifier or eb.language %}
                         <div class="card-badges">
                             {% if eb.source %}
                             {% set badge_cls = eb.source.lower().replace(' ', '') %}
                             <span class="source-badge {{ badge_cls }}">{{ eb.source }}</span>
+                            {% endif %}
+                            {% if eb.language %}
+                            <span class="source-badge language" title="Language">{{ eb.language }}</span>
                             {% endif %}
                             {% if eb.abs_identifier %}
                             <span class="source-badge linked" title="Authoritative match via Calibre audiobookshelf_id">📌 Linked</span>

--- a/templates/suggestions.html
+++ b/templates/suggestions.html
@@ -55,6 +55,7 @@
     .best-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
     .best { flex: 1; min-width: 0; font-size: 12px; color: rgba(255,255,255,0.78); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .source-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; white-space: nowrap; }
+    .source-badge.language { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.82); }
     .source-badge.grimmory { background: rgba(76,175,80,0.2); color: #81c784; }
     .source-badge.bookorbit { background: rgba(0,188,212,0.2); color: #4dd0e1; }
     .source-badge.abs { background: rgba(102,126,234,0.2); color: #93a5f6; }
@@ -195,11 +196,17 @@
                         <div class="suggestion-main">
                             <img src="{{ s.audio_cover_url or s.cover_url }}" alt="Cover" class="cover" onerror="this.style.opacity='0.25';">
                             <div>
-                                <div class="title">{{ s.audio_title or s.abs_title }}</div>
+                                <div class="title">
+                                    {{ s.audio_title or s.abs_title }}
+                                    {% if s.audio_language %}<span class="source-badge language" title="Language">{{ s.audio_language }}</span>{% endif %}
+                                </div>
                                 {% if s.audio_author or s.abs_author %}<div class="author">{{ s.audio_author or s.abs_author }}</div>{% endif %}
                                 <div class="score">{% if s.matches and s.matches|length > 0 %}Match {{ s.matches[0].score|round|int }}%{% else %}Match --{% endif %}</div>
                                 {% if s.matches and s.matches|length > 0 %}
-                                <div class="best" title="{{ s.matches[0].display_name }}">Best: {{ s.matches[0].display_name }} ({{ s.matches[0].score|round|int }}%)</div>
+                                <div class="best" title="{{ s.matches[0].display_name }}">
+                                    Best: {{ s.matches[0].display_name }} ({{ s.matches[0].score|round|int }}%)
+                                    {% if s.matches[0].language %}<span class="source-badge language" title="Language">{{ s.matches[0].language }}</span>{% endif %}
+                                </div>
                                 {% endif %}
                             </div>
                         </div>
@@ -685,6 +692,7 @@
             const sourcePath = match.source_path || match.path || '';
             const matchReason = match.match_reason || '';
             const author = match.author || '';
+            const language = (match.language || '').toString().trim();
             const score = Math.round(match.score || 0);
 
             const card = document.createElement('div');
@@ -732,6 +740,14 @@
                 badge.className = `source-badge ${sourceBadgeClass(source)}`;
                 badge.textContent = source;
                 card.appendChild(badge);
+            }
+
+            if (language) {
+                const languageBadge = document.createElement('span');
+                languageBadge.className = 'source-badge language';
+                languageBadge.title = 'Language';
+                languageBadge.textContent = language;
+                card.appendChild(languageBadge);
             }
 
             if (matchReason === 'same_folder' || matchReason === 'same_folder_ambiguous') {

--- a/tests/test_book_language_metadata.py
+++ b/tests/test_book_language_metadata.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+from src.api.cwa_client import CWAClient
+from src.services.audio_source_adapters import ABSAudioSourceAdapter
+from src.services.suggestions_service import SuggestionsService
+
+
+def test_cwa_opds_parser_preserves_dcterms_language():
+    client = object.__new__(CWAClient)
+    client.base_url = "http://cwa.test"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:dcterms="http://purl.org/dc/terms/">
+      <entry>
+        <id>http://cwa.test/opds/book/42</id>
+        <title>Example Book</title>
+        <author><name>Example Author</name></author>
+        <dcterms:language>deu</dcterms:language>
+        <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/opds/download/42/epub/" />
+      </entry>
+    </feed>"""
+
+    result = client._parse_opds(xml)
+
+    assert len(result) == 1
+    assert result[0]["language"] == "deu"
+
+
+def test_cwa_opds_parser_uses_empty_language_when_missing():
+    client = object.__new__(CWAClient)
+    client.base_url = "http://cwa.test"
+    xml = """<feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <id>http://cwa.test/opds/book/7</id>
+        <title>Unknown Language</title>
+        <author><name>Example Author</name></author>
+        <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/opds/download/7/epub/" />
+      </entry>
+    </feed>"""
+
+    result = client._parse_opds(xml)
+
+    assert result[0]["language"] == ""
+
+
+class _FakeABSClient:
+    def search_audiobooks(self, query, library_id=None):
+        return [{
+            "id": "abs-1",
+            "media": {
+                "metadata": {
+                    "title": "Example Book",
+                    "authorName": "Example Author",
+                    "language": "eng",
+                },
+                "duration": 123.0,
+            },
+        }]
+
+    def is_configured(self):
+        return True
+
+
+def test_abs_audio_adapter_preserves_existing_language(monkeypatch):
+    monkeypatch.setattr(ABSAudioSourceAdapter, "_parse_library_scope", staticmethod(lambda: None))
+    result = ABSAudioSourceAdapter(_FakeABSClient()).search("Example")
+
+    assert len(result) == 1
+    assert result[0].language == "eng"
+
+
+def _suggestions_service():
+    return SuggestionsService(
+        database_service=SimpleNamespace(),
+        container=SimpleNamespace(),
+        manager=SimpleNamespace(),
+        get_audiobooks_conditionally=lambda: [],
+        get_searchable_ebooks=lambda _query: [],
+        audiobook_matches_search=lambda _ab, _text: False,
+        get_abs_author=lambda _ab: "",
+        logger=SimpleNamespace(warning=lambda *args, **kwargs: None, debug=lambda *args, **kwargs: None),
+    )
+
+
+def test_suggestion_candidate_language_is_not_part_of_search_text():
+    service = _suggestions_service()
+    candidate = SimpleNamespace(
+        title="Example Book",
+        authors="Example Author",
+        source="CWA",
+        source_id="42",
+        name="cwa_42.epub",
+        display_name="Example Book - Example Author",
+        language="deu",
+        path=None,
+        abs_identifier=None,
+        booklore_id=None,
+    )
+
+    prepared = service._prepare_candidate_pool([candidate])[0]
+    match = service._match_from_pool(prepared, 91.25)
+
+    assert prepared["language"] == "deu"
+    assert prepared["search_text"] == "Example Book Example Author"
+    assert match["language"] == "deu"
+
+
+def test_suggestion_audio_language_supports_normalized_and_raw_abs_records():
+    service = _suggestions_service()
+
+    assert service._audio_language({"audio_language": "deu"}) == "deu"
+    assert service._audio_language({"media": {"metadata": {"language": "fra"}}}) == "fra"
+
+
+def test_suggestion_shell_keeps_audio_language_without_affecting_title_author():
+    service = _suggestions_service()
+    suggestion = service._suggestion_shell({
+        "audio_source": "ABS",
+        "audio_source_id": "abs-1",
+        "audio_title": "Example Book",
+        "audio_author": "Example Author",
+        "audio_language": "eng",
+    }, [])
+
+    assert suggestion["audio_language"] == "eng"
+    assert suggestion["audio_title"] == "Example Book"
+    assert suggestion["audio_author"] == "Example Author"


### PR DESCRIPTION
## Summary

- expose optional language metadata for audiobook and ebook search results
- parse Calibre-Web OPDS `dcterms:language`
- preserve Audiobookshelf language metadata for both audiobook and ebook results
- pass existing language fields through Grimmory, BookOrbit, BookFusion, and Kavita results when already present
- display compact language badges in **Add Book** and **Suggestions**
- keep language strictly display-only: it is not added to search text, fuzzy scoring, authoritative matching, or other ranking logic

## Compatibility / scope

- no database migration
- no new setting
- no additional provider requests
- missing language metadata renders nothing
- existing suggestion-cache entries without a language field remain compatible

## Validation

- Python syntax check passed
- focused language regression tests: **6 passed**
- full test suite: **2980 passed, 2 skipped, 43 subtests passed**

The full suite was run on the identical feature source tree before the branch was squashed to one clean commit; the squash only removed temporary validation helpers/workflow files.

Closes #267